### PR TITLE
add additional arguments to resolveWhereClause to allow operators to …

### DIFF
--- a/src/PgConnectionArgFilterPlugin.js
+++ b/src/PgConnectionArgFilterPlugin.js
@@ -413,7 +413,7 @@ module.exports = function PgConnectionArgFilterPlugin(
                 const val = operator.options.resolveWithRawInput
                   ? input
                   : valFromInput(input, inputResolver, attr.type);
-                return operator.resolveWhereClause(identifier, val);
+                return operator.resolveWhereClause(identifier, val, fieldName, queryBuilder);
               }
 
               // Computed columns
@@ -429,7 +429,7 @@ module.exports = function PgConnectionArgFilterPlugin(
                 const val = operator.options.resolveWithRawInput
                   ? input
                   : valFromInput(input, inputResolver, procReturnType);
-                return operator.resolveWhereClause(identifier, val);
+                return operator.resolveWhereClause(identifier, val, fieldName, queryBuilder);
               }
 
               throw new Error(


### PR DESCRIPTION
…modify the query

This is needed for tsvector full text searching, because the filter needs to add an extra column to the select to be able to return (and order by) the rank.