### PR TITLE
Add support for network operators

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,11 @@ The following filter operators are exposed by default:
 | NOT SIMILAR TO '...' | notSimilarTo | String |
 | @> | contains | JSON |
 | <@ | containedBy | JSON |
+| &lt;&lt; | inetContainedBy | inet |
+| &lt;&lt;= | inetContainedByOrEquals | inet |
+| &gt;&gt; | inetContains | inet |
+| &gt;&gt;= | inetContainsOrEquals | inet |
+| &amp;&amp; | inetContainsOrIsContainedBy | inet |
 
 ### List Comparison Operators
 

--- a/__tests__/fixtures/queries/connections-filter.graphql
+++ b/__tests__/fixtures/queries/connections-filter.graphql
@@ -60,6 +60,11 @@ query {
   intArray_anyLessThanOrEqualTo_2: allFilterables(filter: { intArray: { anyLessThanOrEqualTo: 2 } }) { ...filterableIntArrayConnection }
   intArray_anyGreaterThan_2: allFilterables(filter: { intArray: { anyGreaterThan: 2 } }) { ...filterableIntArrayConnection }
   intArray_anyGreaterThanOrEqualTo_2: allFilterables(filter: { intArray: { anyGreaterThanOrEqualTo: 2 } }) { ...filterableIntArrayConnection }
+  inet_inetContainedBy: allFilterables(filter: { inet: { inetContainedBy: "192.168.0/24" } }) { ...filterableInetConnection }
+  inet_inetContainedByOrEquals: allFilterables(filter: { inet: { inetContainedByOrEquals: "192.168.0/24" } }) { ...filterableInetConnection }
+  inet_inetContains: allFilterables(filter: { inet: { inetContains: "192.168.0.1" } }) { ...filterableInetConnection }
+  inet_inetContainsOrEquals: allFilterables(filter: { inet: { inetContainsOrEquals: "192.168.0.1" } }) { ...filterableInetConnection }
+  inet_inetContainsOrIsContainedBy: allFilterables(filter: { inet: { inetContainsOrIsContainedBy: "192.168.1/24" } }) { ...filterableInetConnection }
 }
 
 fragment filterableConnection on FilterablesConnection {
@@ -94,5 +99,12 @@ fragment filterableIntArrayConnection on FilterablesConnection {
   nodes {
     id
     intArray
+  }
+}
+
+fragment filterableInetConnection on FilterablesConnection {
+  nodes {
+    id
+    inet
   }
 }

--- a/__tests__/integration/__snapshots__/queries.test.js.snap
+++ b/__tests__/integration/__snapshots__/queries.test.js.snap
@@ -288,6 +288,62 @@ Object {
       },
       "totalCount": 1,
     },
+    "inet_inetContainedBy": Object {
+      "nodes": Array [
+        Object {
+          "id": 1,
+          "inet": "192.168.0.1",
+        },
+        Object {
+          "id": 4,
+          "inet": "192.168.0.3",
+        },
+      ],
+    },
+    "inet_inetContainedByOrEquals": Object {
+      "nodes": Array [
+        Object {
+          "id": 1,
+          "inet": "192.168.0.1",
+        },
+        Object {
+          "id": 3,
+          "inet": "192.168.0.0/24",
+        },
+        Object {
+          "id": 4,
+          "inet": "192.168.0.3",
+        },
+      ],
+    },
+    "inet_inetContains": Object {
+      "nodes": Array [
+        Object {
+          "id": 3,
+          "inet": "192.168.0.0/24",
+        },
+      ],
+    },
+    "inet_inetContainsOrEquals": Object {
+      "nodes": Array [
+        Object {
+          "id": 1,
+          "inet": "192.168.0.1",
+        },
+        Object {
+          "id": 3,
+          "inet": "192.168.0.0/24",
+        },
+      ],
+    },
+    "inet_inetContainsOrIsContainedBy": Object {
+      "nodes": Array [
+        Object {
+          "id": 2,
+          "inet": "192.168.1.1",
+        },
+      ],
+    },
     "intArray_anyEqualTo_2": Object {
       "nodes": Array [
         Object {
@@ -1664,39 +1720,6 @@ Object {
         "hasNextPage": false,
         "hasPreviousPage": false,
         "startCursor": "WyJwcmltYXJ5X2tleV9hc2MiLFsxXV0=",
-      },
-      "totalCount": 2,
-    },
-    "string_similarTo_te_or_st": Object {
-      "edges": Array [
-        Object {
-          "cursor": "WyJwcmltYXJ5X2tleV9hc2MiLFsyXV0=",
-          "node": Object {
-            "boolean": true,
-            "id": 2,
-            "int": 2,
-            "numeric": "0.2",
-            "real": 0.2,
-            "string": "Test",
-          },
-        },
-        Object {
-          "cursor": "WyJwcmltYXJ5X2tleV9hc2MiLFs0XV0=",
-          "node": Object {
-            "boolean": false,
-            "id": 4,
-            "int": 4,
-            "numeric": "0.4",
-            "real": 0.4,
-            "string": "test",
-          },
-        },
-      ],
-      "pageInfo": Object {
-        "endCursor": "WyJwcmltYXJ5X2tleV9hc2MiLFs0XV0=",
-        "hasNextPage": false,
-        "hasPreviousPage": false,
-        "startCursor": "WyJwcmltYXJ5X2tleV9hc2MiLFsyXV0=",
       },
       "totalCount": 2,
     },

--- a/__tests__/integration/schema/__snapshots__/connectionFilter.test.js.snap
+++ b/__tests__/integration/schema/__snapshots__/connectionFilter.test.js.snap
@@ -173,6 +173,7 @@ type Filterable implements Node {
   computed: String
   computed2: String
   id: Int!
+  inet: Inet
   int: Int
   intArray: [Int]
   jsonb: JSON
@@ -196,6 +197,9 @@ input FilterableCondition {
 
   \\"\\"\\"Checks for equality with the object’s \`id\` field.\\"\\"\\"
   id: Int
+
+  \\"\\"\\"Checks for equality with the object’s \`inet\` field.\\"\\"\\"
+  inet: Inet
 
   \\"\\"\\"Checks for equality with the object’s \`int\` field.\\"\\"\\"
   int: Int
@@ -229,6 +233,9 @@ input FilterableFilter {
   \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
   id: IntFilter
 
+  \\"\\"\\"Filter by the object’s \`inet\` field.\\"\\"\\"
+  inet: InetFilter
+
   \\"\\"\\"Filter by the object’s \`int\` field.\\"\\"\\"
   int: IntFilter
 
@@ -255,6 +262,7 @@ input FilterableFilter {
 input FilterableInput {
   boolean: Boolean
   id: Int
+  inet: Inet
   int: Int
   intArray: [Int]
   jsonb: JSON
@@ -269,6 +277,7 @@ Represents an update to a \`Filterable\`. Fields that are set will be updated.
 input FilterablePatch {
   boolean: Boolean
   id: Int
+  inet: Inet
   int: Int
   intArray: [Int]
   jsonb: JSON
@@ -309,6 +318,8 @@ enum FilterablesOrderBy {
   BOOLEAN_DESC
   ID_ASC
   ID_DESC
+  INET_ASC
+  INET_DESC
   INT_ARRAY_ASC
   INT_ARRAY_DESC
   INT_ASC
@@ -324,6 +335,56 @@ enum FilterablesOrderBy {
   REAL_DESC
   STRING_ASC
   STRING_DESC
+}
+
+\\"\\"\\"An IPv4 or IPv6 host address, and optionally its subnet.\\"\\"\\"
+scalar Inet
+
+\\"\\"\\"
+A filter to be used against Inet fields. All fields are combined with a logical ‘and.’
+\\"\\"\\"
+input InetFilter {
+  \\"\\"\\"
+  Checks for values not equal to this value, treating null like an ordinary value.
+  \\"\\"\\"
+  distinctFrom: Inet
+
+  \\"\\"\\"Checks for values equal to this value.\\"\\"\\"
+  equalTo: Inet
+
+  \\"\\"\\"Checks for values in this list.\\"\\"\\"
+  in: [Inet!]
+
+  \\"\\"\\"Checks if an inet is contained by another inet\\"\\"\\"
+  inetContainedBy: Inet
+
+  \\"\\"\\"Checks if an inet is contained by or equals another inet\\"\\"\\"
+  inetContainedByOrEquals: Inet
+
+  \\"\\"\\"Checks if an inet contains another inet\\"\\"\\"
+  inetContains: Inet
+
+  \\"\\"\\"Checks if an inet contains or equals another inet\\"\\"\\"
+  inetContainsOrEquals: Inet
+
+  \\"\\"\\"Checks if an inet contains or is contained by another inet\\"\\"\\"
+  inetContainsOrIsContainedBy: Inet
+
+  \\"\\"\\"
+  If set to true, checks for null values.  If set to false, checks for non-null values.
+  \\"\\"\\"
+  isNull: Boolean
+
+  \\"\\"\\"
+  Checks for values equal to this value, treating null like an ordinary value.
+  \\"\\"\\"
+  notDistinctFrom: Inet
+
+  \\"\\"\\"Checks for values not equal to this value.\\"\\"\\"
+  notEqualTo: Inet
+
+  \\"\\"\\"Checks for values not in this list.\\"\\"\\"
+  notIn: [Inet!]
 }
 
 \\"\\"\\"

--- a/__tests__/integration/schema/__snapshots__/connectionFilterAllowedOperators.test.js.snap
+++ b/__tests__/integration/schema/__snapshots__/connectionFilterAllowedOperators.test.js.snap
@@ -119,6 +119,7 @@ type Filterable implements Node {
   computed: String
   computed2: String
   id: Int!
+  inet: Inet
   int: Int
   intArray: [Int]
   jsonb: JSON
@@ -142,6 +143,9 @@ input FilterableCondition {
 
   \\"\\"\\"Checks for equality with the object’s \`id\` field.\\"\\"\\"
   id: Int
+
+  \\"\\"\\"Checks for equality with the object’s \`inet\` field.\\"\\"\\"
+  inet: Inet
 
   \\"\\"\\"Checks for equality with the object’s \`int\` field.\\"\\"\\"
   int: Int
@@ -175,6 +179,9 @@ input FilterableFilter {
   \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
   id: IntFilter
 
+  \\"\\"\\"Filter by the object’s \`inet\` field.\\"\\"\\"
+  inet: InetFilter
+
   \\"\\"\\"Filter by the object’s \`int\` field.\\"\\"\\"
   int: IntFilter
 
@@ -201,6 +208,7 @@ input FilterableFilter {
 input FilterableInput {
   boolean: Boolean
   id: Int
+  inet: Inet
   int: Int
   intArray: [Int]
   jsonb: JSON
@@ -215,6 +223,7 @@ Represents an update to a \`Filterable\`. Fields that are set will be updated.
 input FilterablePatch {
   boolean: Boolean
   id: Int
+  inet: Inet
   int: Int
   intArray: [Int]
   jsonb: JSON
@@ -255,6 +264,8 @@ enum FilterablesOrderBy {
   BOOLEAN_DESC
   ID_ASC
   ID_DESC
+  INET_ASC
+  INET_DESC
   INT_ARRAY_ASC
   INT_ARRAY_DESC
   INT_ASC
@@ -270,6 +281,20 @@ enum FilterablesOrderBy {
   REAL_DESC
   STRING_ASC
   STRING_DESC
+}
+
+\\"\\"\\"An IPv4 or IPv6 host address, and optionally its subnet.\\"\\"\\"
+scalar Inet
+
+\\"\\"\\"
+A filter to be used against Inet fields. All fields are combined with a logical ‘and.’
+\\"\\"\\"
+input InetFilter {
+  \\"\\"\\"Checks for values equal to this value.\\"\\"\\"
+  equalTo: Inet
+
+  \\"\\"\\"Checks for values not equal to this value.\\"\\"\\"
+  notEqualTo: Inet
 }
 
 \\"\\"\\"

--- a/__tests__/integration/schema/__snapshots__/connectionFilterLists.test.js.snap
+++ b/__tests__/integration/schema/__snapshots__/connectionFilterLists.test.js.snap
@@ -173,6 +173,7 @@ type Filterable implements Node {
   computed: String
   computed2: String
   id: Int!
+  inet: Inet
   int: Int
   intArray: [Int]
   jsonb: JSON
@@ -196,6 +197,9 @@ input FilterableCondition {
 
   \\"\\"\\"Checks for equality with the object’s \`id\` field.\\"\\"\\"
   id: Int
+
+  \\"\\"\\"Checks for equality with the object’s \`inet\` field.\\"\\"\\"
+  inet: Inet
 
   \\"\\"\\"Checks for equality with the object’s \`int\` field.\\"\\"\\"
   int: Int
@@ -229,6 +233,9 @@ input FilterableFilter {
   \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
   id: IntFilter
 
+  \\"\\"\\"Filter by the object’s \`inet\` field.\\"\\"\\"
+  inet: InetFilter
+
   \\"\\"\\"Filter by the object’s \`int\` field.\\"\\"\\"
   int: IntFilter
 
@@ -252,6 +259,7 @@ input FilterableFilter {
 input FilterableInput {
   boolean: Boolean
   id: Int
+  inet: Inet
   int: Int
   intArray: [Int]
   jsonb: JSON
@@ -266,6 +274,7 @@ Represents an update to a \`Filterable\`. Fields that are set will be updated.
 input FilterablePatch {
   boolean: Boolean
   id: Int
+  inet: Inet
   int: Int
   intArray: [Int]
   jsonb: JSON
@@ -306,6 +315,8 @@ enum FilterablesOrderBy {
   BOOLEAN_DESC
   ID_ASC
   ID_DESC
+  INET_ASC
+  INET_DESC
   INT_ARRAY_ASC
   INT_ARRAY_DESC
   INT_ASC
@@ -321,6 +332,56 @@ enum FilterablesOrderBy {
   REAL_DESC
   STRING_ASC
   STRING_DESC
+}
+
+\\"\\"\\"An IPv4 or IPv6 host address, and optionally its subnet.\\"\\"\\"
+scalar Inet
+
+\\"\\"\\"
+A filter to be used against Inet fields. All fields are combined with a logical ‘and.’
+\\"\\"\\"
+input InetFilter {
+  \\"\\"\\"
+  Checks for values not equal to this value, treating null like an ordinary value.
+  \\"\\"\\"
+  distinctFrom: Inet
+
+  \\"\\"\\"Checks for values equal to this value.\\"\\"\\"
+  equalTo: Inet
+
+  \\"\\"\\"Checks for values in this list.\\"\\"\\"
+  in: [Inet!]
+
+  \\"\\"\\"Checks if an inet is contained by another inet\\"\\"\\"
+  inetContainedBy: Inet
+
+  \\"\\"\\"Checks if an inet is contained by or equals another inet\\"\\"\\"
+  inetContainedByOrEquals: Inet
+
+  \\"\\"\\"Checks if an inet contains another inet\\"\\"\\"
+  inetContains: Inet
+
+  \\"\\"\\"Checks if an inet contains or equals another inet\\"\\"\\"
+  inetContainsOrEquals: Inet
+
+  \\"\\"\\"Checks if an inet contains or is contained by another inet\\"\\"\\"
+  inetContainsOrIsContainedBy: Inet
+
+  \\"\\"\\"
+  If set to true, checks for null values.  If set to false, checks for non-null values.
+  \\"\\"\\"
+  isNull: Boolean
+
+  \\"\\"\\"
+  Checks for values equal to this value, treating null like an ordinary value.
+  \\"\\"\\"
+  notDistinctFrom: Inet
+
+  \\"\\"\\"Checks for values not equal to this value.\\"\\"\\"
+  notEqualTo: Inet
+
+  \\"\\"\\"Checks for values not in this list.\\"\\"\\"
+  notIn: [Inet!]
 }
 
 \\"\\"\\"

--- a/__tests__/integration/schema/__snapshots__/connectionFilterOperatorNames.test.js.snap
+++ b/__tests__/integration/schema/__snapshots__/connectionFilterOperatorNames.test.js.snap
@@ -173,6 +173,7 @@ type Filterable implements Node {
   computed: String
   computed2: String
   id: Int!
+  inet: Inet
   int: Int
   intArray: [Int]
   jsonb: JSON
@@ -196,6 +197,9 @@ input FilterableCondition {
 
   \\"\\"\\"Checks for equality with the object’s \`id\` field.\\"\\"\\"
   id: Int
+
+  \\"\\"\\"Checks for equality with the object’s \`inet\` field.\\"\\"\\"
+  inet: Inet
 
   \\"\\"\\"Checks for equality with the object’s \`int\` field.\\"\\"\\"
   int: Int
@@ -229,6 +233,9 @@ input FilterableFilter {
   \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
   id: IntFilter
 
+  \\"\\"\\"Filter by the object’s \`inet\` field.\\"\\"\\"
+  inet: InetFilter
+
   \\"\\"\\"Filter by the object’s \`int\` field.\\"\\"\\"
   int: IntFilter
 
@@ -255,6 +262,7 @@ input FilterableFilter {
 input FilterableInput {
   boolean: Boolean
   id: Int
+  inet: Inet
   int: Int
   intArray: [Int]
   jsonb: JSON
@@ -269,6 +277,7 @@ Represents an update to a \`Filterable\`. Fields that are set will be updated.
 input FilterablePatch {
   boolean: Boolean
   id: Int
+  inet: Inet
   int: Int
   intArray: [Int]
   jsonb: JSON
@@ -309,6 +318,8 @@ enum FilterablesOrderBy {
   BOOLEAN_DESC
   ID_ASC
   ID_DESC
+  INET_ASC
+  INET_DESC
   INT_ARRAY_ASC
   INT_ARRAY_DESC
   INT_ASC
@@ -324,6 +335,56 @@ enum FilterablesOrderBy {
   REAL_DESC
   STRING_ASC
   STRING_DESC
+}
+
+\\"\\"\\"An IPv4 or IPv6 host address, and optionally its subnet.\\"\\"\\"
+scalar Inet
+
+\\"\\"\\"
+A filter to be used against Inet fields. All fields are combined with a logical ‘and.’
+\\"\\"\\"
+input InetFilter {
+  \\"\\"\\"
+  Checks for values not equal to this value, treating null like an ordinary value.
+  \\"\\"\\"
+  distinctFrom: Inet
+
+  \\"\\"\\"Checks for values equal to this value.\\"\\"\\"
+  eq: Inet
+
+  \\"\\"\\"Checks for values in this list.\\"\\"\\"
+  in: [Inet!]
+
+  \\"\\"\\"Checks if an inet is contained by another inet\\"\\"\\"
+  inetContainedBy: Inet
+
+  \\"\\"\\"Checks if an inet is contained by or equals another inet\\"\\"\\"
+  inetContainedByOrEquals: Inet
+
+  \\"\\"\\"Checks if an inet contains another inet\\"\\"\\"
+  inetContains: Inet
+
+  \\"\\"\\"Checks if an inet contains or equals another inet\\"\\"\\"
+  inetContainsOrEquals: Inet
+
+  \\"\\"\\"Checks if an inet contains or is contained by another inet\\"\\"\\"
+  inetContainsOrIsContainedBy: Inet
+
+  \\"\\"\\"
+  If set to true, checks for null values.  If set to false, checks for non-null values.
+  \\"\\"\\"
+  isNull: Boolean
+
+  \\"\\"\\"Checks for values not equal to this value.\\"\\"\\"
+  ne: Inet
+
+  \\"\\"\\"
+  Checks for values equal to this value, treating null like an ordinary value.
+  \\"\\"\\"
+  notDistinctFrom: Inet
+
+  \\"\\"\\"Checks for values not in this list.\\"\\"\\"
+  notIn: [Inet!]
 }
 
 \\"\\"\\"

--- a/__tests__/p-data.sql
+++ b/__tests__/p-data.sql
@@ -1,6 +1,6 @@
-insert into p.filterable (id, string, int, real, numeric, boolean, jsonb, int_array) values
-  (1, 'TEST', 1, 0.1, 0.1, true, '{"string":"TEST","int":1,"boolean":true}', '{1, 10}'),
-  (2, 'Test', 2, 0.2, 0.2, true, '{"string":"Test","int":2,"boolean":true}', '{2, 20}'),
-  (3, 'tEST', 3, 0.3, 0.3, false, '{"string":"tEST","int":3,"boolean":false}', '{3, 30}'),
-  (4, 'test', 4, 0.4, 0.4, false, '{"string":"test","int":4,"boolean":false}', '{4, 40}'),
-  (5, null, null, null, null, null, null, null);
+insert into p.filterable (id, string, int, real, numeric, boolean, jsonb, int_array, inet) values
+  (1, 'TEST', 1, 0.1, 0.1, true, '{"string":"TEST","int":1,"boolean":true}', '{1, 10}', '192.168.0.1'),
+  (2, 'Test', 2, 0.2, 0.2, true, '{"string":"Test","int":2,"boolean":true}', '{2, 20}', '192.168.1.1'),
+  (3, 'tEST', 3, 0.3, 0.3, false, '{"string":"tEST","int":3,"boolean":false}', '{3, 30}', '192.168.0/24'),
+  (4, 'test', 4, 0.4, 0.4, false, '{"string":"test","int":4,"boolean":false}', '{4, 40}', '192.168.0.3'),
+  (5, null, null, null, null, null, null, null, null);

--- a/__tests__/p-schema.sql
+++ b/__tests__/p-schema.sql
@@ -10,7 +10,8 @@ create table p.filterable (
   "numeric" numeric,
   "boolean" boolean,
   "jsonb" jsonb,
-  "int_array" int[]
+  "int_array" int[],
+  "inet" inet
 );
 
 comment on column p.filterable.real is E'@omit filter';

--- a/src/PgConnectionArgFilterOperatorsPlugin.js
+++ b/src/PgConnectionArgFilterOperatorsPlugin.js
@@ -501,6 +501,61 @@ module.exports = function PgConnectionArgFilterOperatorsPlugin(builder) {
         allowedListTypes: ["List"],
       }
     );
+    addConnectionFilterOperator(
+      "inetContainedBy",
+      "Checks if an inet is contained by another inet",
+      fieldType => fieldType,
+      (identifier, val) => {
+        return sql.query`${identifier} << ${val}`;
+      },
+      {
+        allowedFieldTypes: ["Inet"],
+      }
+    );
+    addConnectionFilterOperator(
+      "inetContainedByOrEquals",
+      "Checks if an inet is contained by or equals another inet",
+      fieldType => fieldType,
+      (identifier, val) => {
+        return sql.query`${identifier} <<= ${val}`;
+      },
+      {
+        allowedFieldTypes: ["Inet"],
+      }
+    );
+    addConnectionFilterOperator(
+      "inetContains",
+      "Checks if an inet contains another inet",
+      fieldType => fieldType,
+      (identifier, val) => {
+        return sql.query`${identifier} >> ${val}`;
+      },
+      {
+        allowedFieldTypes: ["Inet"],
+      }
+    );
+    addConnectionFilterOperator(
+      "inetContainsOrEquals",
+      "Checks if an inet contains or equals another inet",
+      fieldType => fieldType,
+      (identifier, val) => {
+        return sql.query`${identifier} >>= ${val}`;
+      },
+      {
+        allowedFieldTypes: ["Inet"],
+      }
+    );
+    addConnectionFilterOperator(
+      "inetContainsOrIsContainedBy",
+      "Checks if an inet contains or is contained by another inet",
+      fieldType => fieldType,
+      (identifier, val) => {
+        return sql.query`${identifier} && ${val}`;
+      },
+      {
+        allowedFieldTypes: ["Inet"],
+      }
+    );
     return _;
   });
 };

--- a/src/PgConnectionArgFilterPlugin.js
+++ b/src/PgConnectionArgFilterPlugin.js
@@ -380,14 +380,16 @@ module.exports = function PgConnectionArgFilterPlugin(
                 ? pgType.isPgArray
                   ? sql.query`${gql2pg(
                       (inputResolver && inputResolver(input)) || input,
-                      pgType
+                      pgType,
+                      null
                     )}`
                   : sql.query`(${sql.join(
                       input.map(
                         i =>
                           sql.query`${gql2pg(
                             (inputResolver && inputResolver(i)) || i,
-                            pgType
+                            pgType,
+                            null
                           )}`
                       ),
                       ","
@@ -395,11 +397,13 @@ module.exports = function PgConnectionArgFilterPlugin(
                 : pgType.isPgArray
                   ? sql.query`${gql2pg(
                       (inputResolver && inputResolver(input)) || input,
-                      pgType.arrayItemType
+                      pgType.arrayItemType,
+                      null
                     )}`
                   : sql.query`${gql2pg(
                       (inputResolver && inputResolver(input)) || input,
-                      pgType
+                      pgType,
+                      null
                     )}`;
 
             function resolveWhereComparison(fieldName, operatorName, input) {


### PR DESCRIPTION
This PR depends on graphile/graphile-build#255 being merged, but I wanted to submit it now for discussion.

I added the following comparison operators:

- inetContainedBy
- inetContainedByOrEquals
- inetContains
- inetContainsOrEquals
- inetContainsOrIsContainedBy

which work on the postgres inet type.

This PR also addresses #44 which I had to do to make it work with the latest graphile-build.

