### PR TITLE
fix: allow filtering setof functions when source table is commented as `@omit all`

### DIFF
--- a/__tests__/integration/schema/__snapshots__/additionalInsensitiveOperatorsTrue.test.js.snap
+++ b/__tests__/integration/schema/__snapshots__/additionalInsensitiveOperatorsTrue.test.js.snap
@@ -3877,6 +3877,43 @@ enum ParentsOrderBy {
   PRIMARY_KEY_DESC
 }
 
+type Protected implements Node {
+  id: Int!
+  name: String
+
+  \\"\\"\\"
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  \\"\\"\\"
+  nodeId: ID!
+  otherId: Int
+}
+
+\\"\\"\\"A connection to a list of \`Protected\` values.\\"\\"\\"
+type ProtectedsConnection {
+  \\"\\"\\"
+  A list of edges which contains the \`Protected\` and cursor to aid in pagination.
+  \\"\\"\\"
+  edges: [ProtectedsEdge!]!
+
+  \\"\\"\\"A list of \`Protected\` objects.\\"\\"\\"
+  nodes: [Protected]!
+
+  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  pageInfo: PageInfo!
+
+  \\"\\"\\"The count of *all* \`Protected\` you could get from the connection.\\"\\"\\"
+  totalCount: Int
+}
+
+\\"\\"\\"A \`Protected\` edge in the connection.\\"\\"\\"
+type ProtectedsEdge {
+  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  cursor: Cursor
+
+  \\"\\"\\"The \`Protected\` at the end of the edge.\\"\\"\\"
+  node: Protected
+}
+
 \\"\\"\\"The root query type which gives access points into the data universe.\\"\\"\\"
 type Query implements Node {
   \\"\\"\\"Reads and enables pagination through a set of \`ArrayType\`.\\"\\"\\"
@@ -4648,6 +4685,37 @@ type Query implements Node {
     nodeId: ID!
   ): Parent
   parentById(id: Int!): Parent
+
+  \\"\\"\\"Reads a single \`Protected\` using its globally unique \`ID\`.\\"\\"\\"
+  protected(
+    \\"\\"\\"
+    The globally unique \`ID\` to be used in selecting a single \`Protected\`.
+    \\"\\"\\"
+    nodeId: ID!
+  ): Protected
+  protectedById(id: Int!): Protected
+
+  \\"\\"\\"Reads and enables pagination through a set of \`Protected\`.\\"\\"\\"
+  protectedsByOtherId(
+    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    after: Cursor
+
+    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    before: Cursor
+
+    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    first: Int
+
+    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    last: Int
+
+    \\"\\"\\"
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    \\"\\"\\"
+    offset: Int
+    otherId: Int
+  ): ProtectedsConnection!
 
   \\"\\"\\"
   Exposes the root query type nested one level down. This is helpful for Relay 1

--- a/__tests__/integration/schema/__snapshots__/additionalInsensitiveOperatorsTrue.test.js.snap
+++ b/__tests__/integration/schema/__snapshots__/additionalInsensitiveOperatorsTrue.test.js.snap
@@ -3888,6 +3888,29 @@ type Protected implements Node {
   otherId: Int
 }
 
+\\"\\"\\"
+A filter to be used against \`Protected\` object types. All fields are combined with a logical ‘and.’
+\\"\\"\\"
+input ProtectedFilter {
+  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  and: [ProtectedFilter!]
+
+  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  id: IntFilter
+
+  \\"\\"\\"Filter by the object’s \`name\` field.\\"\\"\\"
+  name: StringFilter
+
+  \\"\\"\\"Negates the expression.\\"\\"\\"
+  not: ProtectedFilter
+
+  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  or: [ProtectedFilter!]
+
+  \\"\\"\\"Filter by the object’s \`otherId\` field.\\"\\"\\"
+  otherId: IntFilter
+}
+
 \\"\\"\\"A connection to a list of \`Protected\` values.\\"\\"\\"
 type ProtectedsConnection {
   \\"\\"\\"
@@ -4702,6 +4725,11 @@ type Query implements Node {
 
     \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
     before: Cursor
+
+    \\"\\"\\"
+    A filter to be used in determining which values should be returned by the collection.
+    \\"\\"\\"
+    filter: ProtectedFilter
 
     \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
     first: Int

--- a/__tests__/integration/schema/__snapshots__/allowedFieldTypes.test.js.snap
+++ b/__tests__/integration/schema/__snapshots__/allowedFieldTypes.test.js.snap
@@ -1817,6 +1817,43 @@ enum ParentsOrderBy {
   PRIMARY_KEY_DESC
 }
 
+type Protected implements Node {
+  id: Int!
+  name: String
+
+  \\"\\"\\"
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  \\"\\"\\"
+  nodeId: ID!
+  otherId: Int
+}
+
+\\"\\"\\"A connection to a list of \`Protected\` values.\\"\\"\\"
+type ProtectedsConnection {
+  \\"\\"\\"
+  A list of edges which contains the \`Protected\` and cursor to aid in pagination.
+  \\"\\"\\"
+  edges: [ProtectedsEdge!]!
+
+  \\"\\"\\"A list of \`Protected\` objects.\\"\\"\\"
+  nodes: [Protected]!
+
+  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  pageInfo: PageInfo!
+
+  \\"\\"\\"The count of *all* \`Protected\` you could get from the connection.\\"\\"\\"
+  totalCount: Int
+}
+
+\\"\\"\\"A \`Protected\` edge in the connection.\\"\\"\\"
+type ProtectedsEdge {
+  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  cursor: Cursor
+
+  \\"\\"\\"The \`Protected\` at the end of the edge.\\"\\"\\"
+  node: Protected
+}
+
 \\"\\"\\"The root query type which gives access points into the data universe.\\"\\"\\"
 type Query implements Node {
   \\"\\"\\"Reads and enables pagination through a set of \`ArrayType\`.\\"\\"\\"
@@ -2588,6 +2625,37 @@ type Query implements Node {
     nodeId: ID!
   ): Parent
   parentById(id: Int!): Parent
+
+  \\"\\"\\"Reads a single \`Protected\` using its globally unique \`ID\`.\\"\\"\\"
+  protected(
+    \\"\\"\\"
+    The globally unique \`ID\` to be used in selecting a single \`Protected\`.
+    \\"\\"\\"
+    nodeId: ID!
+  ): Protected
+  protectedById(id: Int!): Protected
+
+  \\"\\"\\"Reads and enables pagination through a set of \`Protected\`.\\"\\"\\"
+  protectedsByOtherId(
+    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    after: Cursor
+
+    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    before: Cursor
+
+    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    first: Int
+
+    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    last: Int
+
+    \\"\\"\\"
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    \\"\\"\\"
+    offset: Int
+    otherId: Int
+  ): ProtectedsConnection!
 
   \\"\\"\\"
   Exposes the root query type nested one level down. This is helpful for Relay 1

--- a/__tests__/integration/schema/__snapshots__/allowedFieldTypes.test.js.snap
+++ b/__tests__/integration/schema/__snapshots__/allowedFieldTypes.test.js.snap
@@ -1828,6 +1828,29 @@ type Protected implements Node {
   otherId: Int
 }
 
+\\"\\"\\"
+A filter to be used against \`Protected\` object types. All fields are combined with a logical ‘and.’
+\\"\\"\\"
+input ProtectedFilter {
+  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  and: [ProtectedFilter!]
+
+  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  id: IntFilter
+
+  \\"\\"\\"Filter by the object’s \`name\` field.\\"\\"\\"
+  name: StringFilter
+
+  \\"\\"\\"Negates the expression.\\"\\"\\"
+  not: ProtectedFilter
+
+  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  or: [ProtectedFilter!]
+
+  \\"\\"\\"Filter by the object’s \`otherId\` field.\\"\\"\\"
+  otherId: IntFilter
+}
+
 \\"\\"\\"A connection to a list of \`Protected\` values.\\"\\"\\"
 type ProtectedsConnection {
   \\"\\"\\"
@@ -2642,6 +2665,11 @@ type Query implements Node {
 
     \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
     before: Cursor
+
+    \\"\\"\\"
+    A filter to be used in determining which values should be returned by the collection.
+    \\"\\"\\"
+    filter: ProtectedFilter
 
     \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
     first: Int

--- a/__tests__/integration/schema/__snapshots__/allowedOperators.test.js.snap
+++ b/__tests__/integration/schema/__snapshots__/allowedOperators.test.js.snap
@@ -2328,6 +2328,43 @@ enum ParentsOrderBy {
   PRIMARY_KEY_DESC
 }
 
+type Protected implements Node {
+  id: Int!
+  name: String
+
+  \\"\\"\\"
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  \\"\\"\\"
+  nodeId: ID!
+  otherId: Int
+}
+
+\\"\\"\\"A connection to a list of \`Protected\` values.\\"\\"\\"
+type ProtectedsConnection {
+  \\"\\"\\"
+  A list of edges which contains the \`Protected\` and cursor to aid in pagination.
+  \\"\\"\\"
+  edges: [ProtectedsEdge!]!
+
+  \\"\\"\\"A list of \`Protected\` objects.\\"\\"\\"
+  nodes: [Protected]!
+
+  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  pageInfo: PageInfo!
+
+  \\"\\"\\"The count of *all* \`Protected\` you could get from the connection.\\"\\"\\"
+  totalCount: Int
+}
+
+\\"\\"\\"A \`Protected\` edge in the connection.\\"\\"\\"
+type ProtectedsEdge {
+  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  cursor: Cursor
+
+  \\"\\"\\"The \`Protected\` at the end of the edge.\\"\\"\\"
+  node: Protected
+}
+
 \\"\\"\\"The root query type which gives access points into the data universe.\\"\\"\\"
 type Query implements Node {
   \\"\\"\\"Reads and enables pagination through a set of \`ArrayType\`.\\"\\"\\"
@@ -3099,6 +3136,37 @@ type Query implements Node {
     nodeId: ID!
   ): Parent
   parentById(id: Int!): Parent
+
+  \\"\\"\\"Reads a single \`Protected\` using its globally unique \`ID\`.\\"\\"\\"
+  protected(
+    \\"\\"\\"
+    The globally unique \`ID\` to be used in selecting a single \`Protected\`.
+    \\"\\"\\"
+    nodeId: ID!
+  ): Protected
+  protectedById(id: Int!): Protected
+
+  \\"\\"\\"Reads and enables pagination through a set of \`Protected\`.\\"\\"\\"
+  protectedsByOtherId(
+    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    after: Cursor
+
+    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    before: Cursor
+
+    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    first: Int
+
+    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    last: Int
+
+    \\"\\"\\"
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    \\"\\"\\"
+    offset: Int
+    otherId: Int
+  ): ProtectedsConnection!
 
   \\"\\"\\"
   Exposes the root query type nested one level down. This is helpful for Relay 1

--- a/__tests__/integration/schema/__snapshots__/allowedOperators.test.js.snap
+++ b/__tests__/integration/schema/__snapshots__/allowedOperators.test.js.snap
@@ -2339,6 +2339,29 @@ type Protected implements Node {
   otherId: Int
 }
 
+\\"\\"\\"
+A filter to be used against \`Protected\` object types. All fields are combined with a logical ‘and.’
+\\"\\"\\"
+input ProtectedFilter {
+  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  and: [ProtectedFilter!]
+
+  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  id: IntFilter
+
+  \\"\\"\\"Filter by the object’s \`name\` field.\\"\\"\\"
+  name: StringFilter
+
+  \\"\\"\\"Negates the expression.\\"\\"\\"
+  not: ProtectedFilter
+
+  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  or: [ProtectedFilter!]
+
+  \\"\\"\\"Filter by the object’s \`otherId\` field.\\"\\"\\"
+  otherId: IntFilter
+}
+
 \\"\\"\\"A connection to a list of \`Protected\` values.\\"\\"\\"
 type ProtectedsConnection {
   \\"\\"\\"
@@ -3153,6 +3176,11 @@ type Query implements Node {
 
     \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
     before: Cursor
+
+    \\"\\"\\"
+    A filter to be used in determining which values should be returned by the collection.
+    \\"\\"\\"
+    filter: ProtectedFilter
 
     \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
     first: Int

--- a/__tests__/integration/schema/__snapshots__/computedColumnsFalse.test.js.snap
+++ b/__tests__/integration/schema/__snapshots__/computedColumnsFalse.test.js.snap
@@ -3837,6 +3837,43 @@ enum ParentsOrderBy {
   PRIMARY_KEY_DESC
 }
 
+type Protected implements Node {
+  id: Int!
+  name: String
+
+  \\"\\"\\"
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  \\"\\"\\"
+  nodeId: ID!
+  otherId: Int
+}
+
+\\"\\"\\"A connection to a list of \`Protected\` values.\\"\\"\\"
+type ProtectedsConnection {
+  \\"\\"\\"
+  A list of edges which contains the \`Protected\` and cursor to aid in pagination.
+  \\"\\"\\"
+  edges: [ProtectedsEdge!]!
+
+  \\"\\"\\"A list of \`Protected\` objects.\\"\\"\\"
+  nodes: [Protected]!
+
+  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  pageInfo: PageInfo!
+
+  \\"\\"\\"The count of *all* \`Protected\` you could get from the connection.\\"\\"\\"
+  totalCount: Int
+}
+
+\\"\\"\\"A \`Protected\` edge in the connection.\\"\\"\\"
+type ProtectedsEdge {
+  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  cursor: Cursor
+
+  \\"\\"\\"The \`Protected\` at the end of the edge.\\"\\"\\"
+  node: Protected
+}
+
 \\"\\"\\"The root query type which gives access points into the data universe.\\"\\"\\"
 type Query implements Node {
   \\"\\"\\"Reads and enables pagination through a set of \`ArrayType\`.\\"\\"\\"
@@ -4608,6 +4645,37 @@ type Query implements Node {
     nodeId: ID!
   ): Parent
   parentById(id: Int!): Parent
+
+  \\"\\"\\"Reads a single \`Protected\` using its globally unique \`ID\`.\\"\\"\\"
+  protected(
+    \\"\\"\\"
+    The globally unique \`ID\` to be used in selecting a single \`Protected\`.
+    \\"\\"\\"
+    nodeId: ID!
+  ): Protected
+  protectedById(id: Int!): Protected
+
+  \\"\\"\\"Reads and enables pagination through a set of \`Protected\`.\\"\\"\\"
+  protectedsByOtherId(
+    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    after: Cursor
+
+    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    before: Cursor
+
+    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    first: Int
+
+    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    last: Int
+
+    \\"\\"\\"
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    \\"\\"\\"
+    offset: Int
+    otherId: Int
+  ): ProtectedsConnection!
 
   \\"\\"\\"
   Exposes the root query type nested one level down. This is helpful for Relay 1

--- a/__tests__/integration/schema/__snapshots__/computedColumnsFalse.test.js.snap
+++ b/__tests__/integration/schema/__snapshots__/computedColumnsFalse.test.js.snap
@@ -3848,6 +3848,29 @@ type Protected implements Node {
   otherId: Int
 }
 
+\\"\\"\\"
+A filter to be used against \`Protected\` object types. All fields are combined with a logical ‘and.’
+\\"\\"\\"
+input ProtectedFilter {
+  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  and: [ProtectedFilter!]
+
+  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  id: IntFilter
+
+  \\"\\"\\"Filter by the object’s \`name\` field.\\"\\"\\"
+  name: StringFilter
+
+  \\"\\"\\"Negates the expression.\\"\\"\\"
+  not: ProtectedFilter
+
+  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  or: [ProtectedFilter!]
+
+  \\"\\"\\"Filter by the object’s \`otherId\` field.\\"\\"\\"
+  otherId: IntFilter
+}
+
 \\"\\"\\"A connection to a list of \`Protected\` values.\\"\\"\\"
 type ProtectedsConnection {
   \\"\\"\\"
@@ -4662,6 +4685,11 @@ type Query implements Node {
 
     \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
     before: Cursor
+
+    \\"\\"\\"
+    A filter to be used in determining which values should be returned by the collection.
+    \\"\\"\\"
+    filter: ProtectedFilter
 
     \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
     first: Int

--- a/__tests__/integration/schema/__snapshots__/defaultOptions.test.js.snap
+++ b/__tests__/integration/schema/__snapshots__/defaultOptions.test.js.snap
@@ -3843,6 +3843,43 @@ enum ParentsOrderBy {
   PRIMARY_KEY_DESC
 }
 
+type Protected implements Node {
+  id: Int!
+  name: String
+
+  \\"\\"\\"
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  \\"\\"\\"
+  nodeId: ID!
+  otherId: Int
+}
+
+\\"\\"\\"A connection to a list of \`Protected\` values.\\"\\"\\"
+type ProtectedsConnection {
+  \\"\\"\\"
+  A list of edges which contains the \`Protected\` and cursor to aid in pagination.
+  \\"\\"\\"
+  edges: [ProtectedsEdge!]!
+
+  \\"\\"\\"A list of \`Protected\` objects.\\"\\"\\"
+  nodes: [Protected]!
+
+  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  pageInfo: PageInfo!
+
+  \\"\\"\\"The count of *all* \`Protected\` you could get from the connection.\\"\\"\\"
+  totalCount: Int
+}
+
+\\"\\"\\"A \`Protected\` edge in the connection.\\"\\"\\"
+type ProtectedsEdge {
+  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  cursor: Cursor
+
+  \\"\\"\\"The \`Protected\` at the end of the edge.\\"\\"\\"
+  node: Protected
+}
+
 \\"\\"\\"The root query type which gives access points into the data universe.\\"\\"\\"
 type Query implements Node {
   \\"\\"\\"Reads and enables pagination through a set of \`ArrayType\`.\\"\\"\\"
@@ -4614,6 +4651,37 @@ type Query implements Node {
     nodeId: ID!
   ): Parent
   parentById(id: Int!): Parent
+
+  \\"\\"\\"Reads a single \`Protected\` using its globally unique \`ID\`.\\"\\"\\"
+  protected(
+    \\"\\"\\"
+    The globally unique \`ID\` to be used in selecting a single \`Protected\`.
+    \\"\\"\\"
+    nodeId: ID!
+  ): Protected
+  protectedById(id: Int!): Protected
+
+  \\"\\"\\"Reads and enables pagination through a set of \`Protected\`.\\"\\"\\"
+  protectedsByOtherId(
+    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    after: Cursor
+
+    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    before: Cursor
+
+    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    first: Int
+
+    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    last: Int
+
+    \\"\\"\\"
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    \\"\\"\\"
+    offset: Int
+    otherId: Int
+  ): ProtectedsConnection!
 
   \\"\\"\\"
   Exposes the root query type nested one level down. This is helpful for Relay 1

--- a/__tests__/integration/schema/__snapshots__/defaultOptions.test.js.snap
+++ b/__tests__/integration/schema/__snapshots__/defaultOptions.test.js.snap
@@ -3854,6 +3854,29 @@ type Protected implements Node {
   otherId: Int
 }
 
+\\"\\"\\"
+A filter to be used against \`Protected\` object types. All fields are combined with a logical ‘and.’
+\\"\\"\\"
+input ProtectedFilter {
+  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  and: [ProtectedFilter!]
+
+  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  id: IntFilter
+
+  \\"\\"\\"Filter by the object’s \`name\` field.\\"\\"\\"
+  name: StringFilter
+
+  \\"\\"\\"Negates the expression.\\"\\"\\"
+  not: ProtectedFilter
+
+  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  or: [ProtectedFilter!]
+
+  \\"\\"\\"Filter by the object’s \`otherId\` field.\\"\\"\\"
+  otherId: IntFilter
+}
+
 \\"\\"\\"A connection to a list of \`Protected\` values.\\"\\"\\"
 type ProtectedsConnection {
   \\"\\"\\"
@@ -4668,6 +4691,11 @@ type Query implements Node {
 
     \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
     before: Cursor
+
+    \\"\\"\\"
+    A filter to be used in determining which values should be returned by the collection.
+    \\"\\"\\"
+    filter: ProtectedFilter
 
     \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
     first: Int

--- a/__tests__/integration/schema/__snapshots__/ignoreIndexesFalse.test.js.snap
+++ b/__tests__/integration/schema/__snapshots__/ignoreIndexesFalse.test.js.snap
@@ -1399,6 +1399,43 @@ enum ParentsOrderBy {
   PRIMARY_KEY_DESC
 }
 
+type Protected implements Node {
+  id: Int!
+  name: String
+
+  \\"\\"\\"
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  \\"\\"\\"
+  nodeId: ID!
+  otherId: Int
+}
+
+\\"\\"\\"A connection to a list of \`Protected\` values.\\"\\"\\"
+type ProtectedsConnection {
+  \\"\\"\\"
+  A list of edges which contains the \`Protected\` and cursor to aid in pagination.
+  \\"\\"\\"
+  edges: [ProtectedsEdge!]!
+
+  \\"\\"\\"A list of \`Protected\` objects.\\"\\"\\"
+  nodes: [Protected]!
+
+  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  pageInfo: PageInfo!
+
+  \\"\\"\\"The count of *all* \`Protected\` you could get from the connection.\\"\\"\\"
+  totalCount: Int
+}
+
+\\"\\"\\"A \`Protected\` edge in the connection.\\"\\"\\"
+type ProtectedsEdge {
+  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  cursor: Cursor
+
+  \\"\\"\\"The \`Protected\` at the end of the edge.\\"\\"\\"
+  node: Protected
+}
+
 \\"\\"\\"The root query type which gives access points into the data universe.\\"\\"\\"
 type Query implements Node {
   \\"\\"\\"Reads and enables pagination through a set of \`ArrayType\`.\\"\\"\\"
@@ -2160,6 +2197,37 @@ type Query implements Node {
     nodeId: ID!
   ): Parent
   parentById(id: Int!): Parent
+
+  \\"\\"\\"Reads a single \`Protected\` using its globally unique \`ID\`.\\"\\"\\"
+  protected(
+    \\"\\"\\"
+    The globally unique \`ID\` to be used in selecting a single \`Protected\`.
+    \\"\\"\\"
+    nodeId: ID!
+  ): Protected
+  protectedById(id: Int!): Protected
+
+  \\"\\"\\"Reads and enables pagination through a set of \`Protected\`.\\"\\"\\"
+  protectedsByOtherId(
+    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    after: Cursor
+
+    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    before: Cursor
+
+    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    first: Int
+
+    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    last: Int
+
+    \\"\\"\\"
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    \\"\\"\\"
+    offset: Int
+    otherId: Int
+  ): ProtectedsConnection!
 
   \\"\\"\\"
   Exposes the root query type nested one level down. This is helpful for Relay 1

--- a/__tests__/integration/schema/__snapshots__/listsFalse.test.js.snap
+++ b/__tests__/integration/schema/__snapshots__/listsFalse.test.js.snap
@@ -3009,6 +3009,43 @@ enum ParentsOrderBy {
   PRIMARY_KEY_DESC
 }
 
+type Protected implements Node {
+  id: Int!
+  name: String
+
+  \\"\\"\\"
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  \\"\\"\\"
+  nodeId: ID!
+  otherId: Int
+}
+
+\\"\\"\\"A connection to a list of \`Protected\` values.\\"\\"\\"
+type ProtectedsConnection {
+  \\"\\"\\"
+  A list of edges which contains the \`Protected\` and cursor to aid in pagination.
+  \\"\\"\\"
+  edges: [ProtectedsEdge!]!
+
+  \\"\\"\\"A list of \`Protected\` objects.\\"\\"\\"
+  nodes: [Protected]!
+
+  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  pageInfo: PageInfo!
+
+  \\"\\"\\"The count of *all* \`Protected\` you could get from the connection.\\"\\"\\"
+  totalCount: Int
+}
+
+\\"\\"\\"A \`Protected\` edge in the connection.\\"\\"\\"
+type ProtectedsEdge {
+  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  cursor: Cursor
+
+  \\"\\"\\"The \`Protected\` at the end of the edge.\\"\\"\\"
+  node: Protected
+}
+
 \\"\\"\\"The root query type which gives access points into the data universe.\\"\\"\\"
 type Query implements Node {
   \\"\\"\\"Reads and enables pagination through a set of \`ArrayType\`.\\"\\"\\"
@@ -3780,6 +3817,37 @@ type Query implements Node {
     nodeId: ID!
   ): Parent
   parentById(id: Int!): Parent
+
+  \\"\\"\\"Reads a single \`Protected\` using its globally unique \`ID\`.\\"\\"\\"
+  protected(
+    \\"\\"\\"
+    The globally unique \`ID\` to be used in selecting a single \`Protected\`.
+    \\"\\"\\"
+    nodeId: ID!
+  ): Protected
+  protectedById(id: Int!): Protected
+
+  \\"\\"\\"Reads and enables pagination through a set of \`Protected\`.\\"\\"\\"
+  protectedsByOtherId(
+    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    after: Cursor
+
+    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    before: Cursor
+
+    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    first: Int
+
+    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    last: Int
+
+    \\"\\"\\"
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    \\"\\"\\"
+    offset: Int
+    otherId: Int
+  ): ProtectedsConnection!
 
   \\"\\"\\"
   Exposes the root query type nested one level down. This is helpful for Relay 1

--- a/__tests__/integration/schema/__snapshots__/listsFalse.test.js.snap
+++ b/__tests__/integration/schema/__snapshots__/listsFalse.test.js.snap
@@ -3020,6 +3020,29 @@ type Protected implements Node {
   otherId: Int
 }
 
+\\"\\"\\"
+A filter to be used against \`Protected\` object types. All fields are combined with a logical ‘and.’
+\\"\\"\\"
+input ProtectedFilter {
+  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  and: [ProtectedFilter!]
+
+  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  id: IntFilter
+
+  \\"\\"\\"Filter by the object’s \`name\` field.\\"\\"\\"
+  name: StringFilter
+
+  \\"\\"\\"Negates the expression.\\"\\"\\"
+  not: ProtectedFilter
+
+  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  or: [ProtectedFilter!]
+
+  \\"\\"\\"Filter by the object’s \`otherId\` field.\\"\\"\\"
+  otherId: IntFilter
+}
+
 \\"\\"\\"A connection to a list of \`Protected\` values.\\"\\"\\"
 type ProtectedsConnection {
   \\"\\"\\"
@@ -3834,6 +3857,11 @@ type Query implements Node {
 
     \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
     before: Cursor
+
+    \\"\\"\\"
+    A filter to be used in determining which values should be returned by the collection.
+    \\"\\"\\"
+    filter: ProtectedFilter
 
     \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
     first: Int

--- a/__tests__/integration/schema/__snapshots__/logicalOperatorsFalse.test.js.snap
+++ b/__tests__/integration/schema/__snapshots__/logicalOperatorsFalse.test.js.snap
@@ -3708,6 +3708,43 @@ enum ParentsOrderBy {
   PRIMARY_KEY_DESC
 }
 
+type Protected implements Node {
+  id: Int!
+  name: String
+
+  \\"\\"\\"
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  \\"\\"\\"
+  nodeId: ID!
+  otherId: Int
+}
+
+\\"\\"\\"A connection to a list of \`Protected\` values.\\"\\"\\"
+type ProtectedsConnection {
+  \\"\\"\\"
+  A list of edges which contains the \`Protected\` and cursor to aid in pagination.
+  \\"\\"\\"
+  edges: [ProtectedsEdge!]!
+
+  \\"\\"\\"A list of \`Protected\` objects.\\"\\"\\"
+  nodes: [Protected]!
+
+  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  pageInfo: PageInfo!
+
+  \\"\\"\\"The count of *all* \`Protected\` you could get from the connection.\\"\\"\\"
+  totalCount: Int
+}
+
+\\"\\"\\"A \`Protected\` edge in the connection.\\"\\"\\"
+type ProtectedsEdge {
+  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  cursor: Cursor
+
+  \\"\\"\\"The \`Protected\` at the end of the edge.\\"\\"\\"
+  node: Protected
+}
+
 \\"\\"\\"The root query type which gives access points into the data universe.\\"\\"\\"
 type Query implements Node {
   \\"\\"\\"Reads and enables pagination through a set of \`ArrayType\`.\\"\\"\\"
@@ -4479,6 +4516,37 @@ type Query implements Node {
     nodeId: ID!
   ): Parent
   parentById(id: Int!): Parent
+
+  \\"\\"\\"Reads a single \`Protected\` using its globally unique \`ID\`.\\"\\"\\"
+  protected(
+    \\"\\"\\"
+    The globally unique \`ID\` to be used in selecting a single \`Protected\`.
+    \\"\\"\\"
+    nodeId: ID!
+  ): Protected
+  protectedById(id: Int!): Protected
+
+  \\"\\"\\"Reads and enables pagination through a set of \`Protected\`.\\"\\"\\"
+  protectedsByOtherId(
+    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    after: Cursor
+
+    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    before: Cursor
+
+    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    first: Int
+
+    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    last: Int
+
+    \\"\\"\\"
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    \\"\\"\\"
+    offset: Int
+    otherId: Int
+  ): ProtectedsConnection!
 
   \\"\\"\\"
   Exposes the root query type nested one level down. This is helpful for Relay 1

--- a/__tests__/integration/schema/__snapshots__/logicalOperatorsFalse.test.js.snap
+++ b/__tests__/integration/schema/__snapshots__/logicalOperatorsFalse.test.js.snap
@@ -3719,6 +3719,20 @@ type Protected implements Node {
   otherId: Int
 }
 
+\\"\\"\\"
+A filter to be used against \`Protected\` object types. All fields are combined with a logical ‘and.’
+\\"\\"\\"
+input ProtectedFilter {
+  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  id: IntFilter
+
+  \\"\\"\\"Filter by the object’s \`name\` field.\\"\\"\\"
+  name: StringFilter
+
+  \\"\\"\\"Filter by the object’s \`otherId\` field.\\"\\"\\"
+  otherId: IntFilter
+}
+
 \\"\\"\\"A connection to a list of \`Protected\` values.\\"\\"\\"
 type ProtectedsConnection {
   \\"\\"\\"
@@ -4533,6 +4547,11 @@ type Query implements Node {
 
     \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
     before: Cursor
+
+    \\"\\"\\"
+    A filter to be used in determining which values should be returned by the collection.
+    \\"\\"\\"
+    filter: ProtectedFilter
 
     \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
     first: Int

--- a/__tests__/integration/schema/__snapshots__/operatorNames.test.js.snap
+++ b/__tests__/integration/schema/__snapshots__/operatorNames.test.js.snap
@@ -3843,6 +3843,43 @@ enum ParentsOrderBy {
   PRIMARY_KEY_DESC
 }
 
+type Protected implements Node {
+  id: Int!
+  name: String
+
+  \\"\\"\\"
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  \\"\\"\\"
+  nodeId: ID!
+  otherId: Int
+}
+
+\\"\\"\\"A connection to a list of \`Protected\` values.\\"\\"\\"
+type ProtectedsConnection {
+  \\"\\"\\"
+  A list of edges which contains the \`Protected\` and cursor to aid in pagination.
+  \\"\\"\\"
+  edges: [ProtectedsEdge!]!
+
+  \\"\\"\\"A list of \`Protected\` objects.\\"\\"\\"
+  nodes: [Protected]!
+
+  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  pageInfo: PageInfo!
+
+  \\"\\"\\"The count of *all* \`Protected\` you could get from the connection.\\"\\"\\"
+  totalCount: Int
+}
+
+\\"\\"\\"A \`Protected\` edge in the connection.\\"\\"\\"
+type ProtectedsEdge {
+  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  cursor: Cursor
+
+  \\"\\"\\"The \`Protected\` at the end of the edge.\\"\\"\\"
+  node: Protected
+}
+
 \\"\\"\\"The root query type which gives access points into the data universe.\\"\\"\\"
 type Query implements Node {
   \\"\\"\\"Reads and enables pagination through a set of \`ArrayType\`.\\"\\"\\"
@@ -4614,6 +4651,37 @@ type Query implements Node {
     nodeId: ID!
   ): Parent
   parentById(id: Int!): Parent
+
+  \\"\\"\\"Reads a single \`Protected\` using its globally unique \`ID\`.\\"\\"\\"
+  protected(
+    \\"\\"\\"
+    The globally unique \`ID\` to be used in selecting a single \`Protected\`.
+    \\"\\"\\"
+    nodeId: ID!
+  ): Protected
+  protectedById(id: Int!): Protected
+
+  \\"\\"\\"Reads and enables pagination through a set of \`Protected\`.\\"\\"\\"
+  protectedsByOtherId(
+    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    after: Cursor
+
+    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    before: Cursor
+
+    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    first: Int
+
+    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    last: Int
+
+    \\"\\"\\"
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    \\"\\"\\"
+    offset: Int
+    otherId: Int
+  ): ProtectedsConnection!
 
   \\"\\"\\"
   Exposes the root query type nested one level down. This is helpful for Relay 1

--- a/__tests__/integration/schema/__snapshots__/operatorNames.test.js.snap
+++ b/__tests__/integration/schema/__snapshots__/operatorNames.test.js.snap
@@ -3854,6 +3854,29 @@ type Protected implements Node {
   otherId: Int
 }
 
+\\"\\"\\"
+A filter to be used against \`Protected\` object types. All fields are combined with a logical ‘and.’
+\\"\\"\\"
+input ProtectedFilter {
+  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  and: [ProtectedFilter!]
+
+  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  id: IntFilter
+
+  \\"\\"\\"Filter by the object’s \`name\` field.\\"\\"\\"
+  name: StringFilter
+
+  \\"\\"\\"Negates the expression.\\"\\"\\"
+  not: ProtectedFilter
+
+  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  or: [ProtectedFilter!]
+
+  \\"\\"\\"Filter by the object’s \`otherId\` field.\\"\\"\\"
+  otherId: IntFilter
+}
+
 \\"\\"\\"A connection to a list of \`Protected\` values.\\"\\"\\"
 type ProtectedsConnection {
   \\"\\"\\"
@@ -4668,6 +4691,11 @@ type Query implements Node {
 
     \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
     before: Cursor
+
+    \\"\\"\\"
+    A filter to be used in determining which values should be returned by the collection.
+    \\"\\"\\"
+    filter: ProtectedFilter
 
     \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
     first: Int

--- a/__tests__/integration/schema/__snapshots__/relationsTrue.test.js.snap
+++ b/__tests__/integration/schema/__snapshots__/relationsTrue.test.js.snap
@@ -3981,6 +3981,29 @@ type Protected implements Node {
   otherId: Int
 }
 
+\\"\\"\\"
+A filter to be used against \`Protected\` object types. All fields are combined with a logical ‘and.’
+\\"\\"\\"
+input ProtectedFilter {
+  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  and: [ProtectedFilter!]
+
+  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  id: IntFilter
+
+  \\"\\"\\"Filter by the object’s \`name\` field.\\"\\"\\"
+  name: StringFilter
+
+  \\"\\"\\"Negates the expression.\\"\\"\\"
+  not: ProtectedFilter
+
+  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  or: [ProtectedFilter!]
+
+  \\"\\"\\"Filter by the object’s \`otherId\` field.\\"\\"\\"
+  otherId: IntFilter
+}
+
 \\"\\"\\"A connection to a list of \`Protected\` values.\\"\\"\\"
 type ProtectedsConnection {
   \\"\\"\\"
@@ -4795,6 +4818,11 @@ type Query implements Node {
 
     \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
     before: Cursor
+
+    \\"\\"\\"
+    A filter to be used in determining which values should be returned by the collection.
+    \\"\\"\\"
+    filter: ProtectedFilter
 
     \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
     first: Int

--- a/__tests__/integration/schema/__snapshots__/relationsTrue.test.js.snap
+++ b/__tests__/integration/schema/__snapshots__/relationsTrue.test.js.snap
@@ -3970,6 +3970,43 @@ input ParentToManyFilterableFilter {
   some: FilterableFilter
 }
 
+type Protected implements Node {
+  id: Int!
+  name: String
+
+  \\"\\"\\"
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  \\"\\"\\"
+  nodeId: ID!
+  otherId: Int
+}
+
+\\"\\"\\"A connection to a list of \`Protected\` values.\\"\\"\\"
+type ProtectedsConnection {
+  \\"\\"\\"
+  A list of edges which contains the \`Protected\` and cursor to aid in pagination.
+  \\"\\"\\"
+  edges: [ProtectedsEdge!]!
+
+  \\"\\"\\"A list of \`Protected\` objects.\\"\\"\\"
+  nodes: [Protected]!
+
+  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  pageInfo: PageInfo!
+
+  \\"\\"\\"The count of *all* \`Protected\` you could get from the connection.\\"\\"\\"
+  totalCount: Int
+}
+
+\\"\\"\\"A \`Protected\` edge in the connection.\\"\\"\\"
+type ProtectedsEdge {
+  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  cursor: Cursor
+
+  \\"\\"\\"The \`Protected\` at the end of the edge.\\"\\"\\"
+  node: Protected
+}
+
 \\"\\"\\"The root query type which gives access points into the data universe.\\"\\"\\"
 type Query implements Node {
   \\"\\"\\"Reads and enables pagination through a set of \`ArrayType\`.\\"\\"\\"
@@ -4741,6 +4778,37 @@ type Query implements Node {
     nodeId: ID!
   ): Parent
   parentById(id: Int!): Parent
+
+  \\"\\"\\"Reads a single \`Protected\` using its globally unique \`ID\`.\\"\\"\\"
+  protected(
+    \\"\\"\\"
+    The globally unique \`ID\` to be used in selecting a single \`Protected\`.
+    \\"\\"\\"
+    nodeId: ID!
+  ): Protected
+  protectedById(id: Int!): Protected
+
+  \\"\\"\\"Reads and enables pagination through a set of \`Protected\`.\\"\\"\\"
+  protectedsByOtherId(
+    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    after: Cursor
+
+    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    before: Cursor
+
+    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    first: Int
+
+    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    last: Int
+
+    \\"\\"\\"
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    \\"\\"\\"
+    offset: Int
+    otherId: Int
+  ): ProtectedsConnection!
 
   \\"\\"\\"
   Exposes the root query type nested one level down. This is helpful for Relay 1

--- a/__tests__/integration/schema/__snapshots__/setofFunctionsFalse.test.js.snap
+++ b/__tests__/integration/schema/__snapshots__/setofFunctionsFalse.test.js.snap
@@ -3813,6 +3813,43 @@ enum ParentsOrderBy {
   PRIMARY_KEY_DESC
 }
 
+type Protected implements Node {
+  id: Int!
+  name: String
+
+  \\"\\"\\"
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  \\"\\"\\"
+  nodeId: ID!
+  otherId: Int
+}
+
+\\"\\"\\"A connection to a list of \`Protected\` values.\\"\\"\\"
+type ProtectedsConnection {
+  \\"\\"\\"
+  A list of edges which contains the \`Protected\` and cursor to aid in pagination.
+  \\"\\"\\"
+  edges: [ProtectedsEdge!]!
+
+  \\"\\"\\"A list of \`Protected\` objects.\\"\\"\\"
+  nodes: [Protected]!
+
+  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  pageInfo: PageInfo!
+
+  \\"\\"\\"The count of *all* \`Protected\` you could get from the connection.\\"\\"\\"
+  totalCount: Int
+}
+
+\\"\\"\\"A \`Protected\` edge in the connection.\\"\\"\\"
+type ProtectedsEdge {
+  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  cursor: Cursor
+
+  \\"\\"\\"The \`Protected\` at the end of the edge.\\"\\"\\"
+  node: Protected
+}
+
 \\"\\"\\"The root query type which gives access points into the data universe.\\"\\"\\"
 type Query implements Node {
   \\"\\"\\"Reads and enables pagination through a set of \`ArrayType\`.\\"\\"\\"
@@ -4574,6 +4611,37 @@ type Query implements Node {
     nodeId: ID!
   ): Parent
   parentById(id: Int!): Parent
+
+  \\"\\"\\"Reads a single \`Protected\` using its globally unique \`ID\`.\\"\\"\\"
+  protected(
+    \\"\\"\\"
+    The globally unique \`ID\` to be used in selecting a single \`Protected\`.
+    \\"\\"\\"
+    nodeId: ID!
+  ): Protected
+  protectedById(id: Int!): Protected
+
+  \\"\\"\\"Reads and enables pagination through a set of \`Protected\`.\\"\\"\\"
+  protectedsByOtherId(
+    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    after: Cursor
+
+    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    before: Cursor
+
+    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    first: Int
+
+    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    last: Int
+
+    \\"\\"\\"
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    \\"\\"\\"
+    offset: Int
+    otherId: Int
+  ): ProtectedsConnection!
 
   \\"\\"\\"
   Exposes the root query type nested one level down. This is helpful for Relay 1

--- a/__tests__/p-schema.sql
+++ b/__tests__/p-schema.sql
@@ -280,3 +280,15 @@ create function p.func_tagged_filterable_returns_table_multi_col() returns table
 $$ language sql stable;
 
 comment on function p.func_tagged_filterable_returns_table_multi_col() is E'@filterable';
+
+create table p.protected (
+  id int primary key,
+  other_id int,
+  name text
+);
+
+comment on table p.protected is E'@omit all';
+
+create function p.protecteds_by_other_id (other_id int) returns setof p.protected as $$
+  select * from p.protected where other_id = other_id;
+$$ language sql stable;

--- a/src/PgConnectionArgFilterPlugin.js
+++ b/src/PgConnectionArgFilterPlugin.js
@@ -65,11 +65,15 @@ module.exports = function PgConnectionArgFilterPlugin(
       if (!nodeType) {
         return args;
       }
+      const nodeSource =
+        source.kind === "procedure" && returnType.class
+          ? returnType.class
+          : source;
 
       const FilterType = connectionFilterType(
         newWithHooks,
         filterTypeName,
-        source,
+        nodeSource,
         nodeTypeName
       );
       if (!FilterType) {


### PR DESCRIPTION
Fixes #99 