### PR TITLE
refactor: allow CommonJS require() without .default

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -79,4 +79,7 @@ const PostGraphileConnectionFilterPlugin: Plugin = (builder, configOptions) => {
   PgConnectionArgFilterOperatorsPlugin(builder, options);
 };
 
-export default PostGraphileConnectionFilterPlugin;
+// This is a temporary hack to avoid a breaking change for CommonJS users.
+// In the next major version, `export =` should be changed to `export default`.
+(PostGraphileConnectionFilterPlugin as any).default = PostGraphileConnectionFilterPlugin;
+export = PostGraphileConnectionFilterPlugin;

--- a/src/index.ts
+++ b/src/index.ts
@@ -79,7 +79,6 @@ const PostGraphileConnectionFilterPlugin: Plugin = (builder, configOptions) => {
   PgConnectionArgFilterOperatorsPlugin(builder, options);
 };
 
-// This is a temporary hack to avoid a breaking change for CommonJS users.
-// In the next major version, `export =` should be changed to `export default`.
-(PostGraphileConnectionFilterPlugin as any).default = PostGraphileConnectionFilterPlugin;
+// TODO: In the next major version, change `export =` to `export default`.
+// This will be a breaking change for CommonJS users.
 export = PostGraphileConnectionFilterPlugin;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,6 +19,7 @@
     "noUnusedParameters": true,
     "noUnusedLocals": true,
     "preserveWatchOutput": true,
+    "esModuleInterop": true,
     "lib": ["es2018", "esnext.asynciterable"]
   },
   "include": ["src/**/*"]


### PR DESCRIPTION
This allows CommonJS users to continue using `require("postgraphile-plugin-connection-filter")` without the `.default`, postponing the breaking change until 3.0.0.