### PR TITLE
feat: add unaccent filter operators #170

### DIFF
--- a/__tests__/fixtures/queries/types.bpchar4.graphql
+++ b/__tests__/fixtures/queries/types.bpchar4.graphql
@@ -134,6 +134,26 @@ query bpchar4($v2: String = "Test", $v3: String = "tEST") {
   ) {
     ...nodes
   }
+  includesUnaccentInsensitive: allFilterables(
+    filter: { bpchar4: { includesUnaccentInsensitive: "É" } }
+  ) {
+    ...nodes
+  }
+  likeUnaccentInsensitive: allFilterables(
+    filter: { bpchar4: { likeUnaccentInsensitive: "%ÊS%" } }
+  ) {
+    ...nodes
+  }
+  notIncludesUnaccentInsensitive: allFilterables(
+    filter: { bpchar4: { notIncludesUnaccentInsensitive: "É" } }
+  ) {
+    ...nodes
+  }
+  notLikeUnaccentInsensitive: allFilterables(
+    filter: { bpchar4: { notLikeUnaccentInsensitive: "%ÊS%" } }
+  ) {
+    ...nodes
+  }
 }
 
 fragment nodes on FilterablesConnection {

--- a/__tests__/fixtures/queries/types.char4.graphql
+++ b/__tests__/fixtures/queries/types.char4.graphql
@@ -134,6 +134,26 @@ query char4($v2: String = "Test", $v3: String = "tEST") {
   ) {
     ...nodes
   }
+  includesUnaccentInsensitive: allFilterables(
+    filter: { char4: { includesUnaccentInsensitive: "É" } }
+  ) {
+    ...nodes
+  }
+  likeUnaccentInsensitive: allFilterables(
+    filter: { char4: { likeUnaccentInsensitive: "%ÊS%" } }
+  ) {
+    ...nodes
+  }
+  notIncludesUnaccentInsensitive: allFilterables(
+    filter: { char4: { notIncludesUnaccentInsensitive: "É" } }
+  ) {
+    ...nodes
+  }
+  notLikeUnaccentInsensitive: allFilterables(
+    filter: { char4: { notLikeUnaccentInsensitive: "%ÊS%" } }
+  ) {
+    ...nodes
+  }
 }
 
 fragment nodes on FilterablesConnection {

--- a/__tests__/fixtures/queries/types.citext.graphql
+++ b/__tests__/fixtures/queries/types.citext.graphql
@@ -134,6 +134,26 @@ query citext($v2: String = "Test", $v3: String = "tEST") {
   ) {
     ...nodes
   }
+  includesUnaccentInsensitive: allFilterables(
+    filter: { citext: { includesUnaccentInsensitive: "É" } }
+  ) {
+    ...nodes
+  }
+  likeUnaccentInsensitive: allFilterables(
+    filter: { citext: { likeUnaccentInsensitive: "%ÊS%" } }
+  ) {
+    ...nodes
+  }
+  notIncludesUnaccentInsensitive: allFilterables(
+    filter: { citext: { notIncludesUnaccentInsensitive: "É" } }
+  ) {
+    ...nodes
+  }
+  notLikeUnaccentInsensitive: allFilterables(
+    filter: { citext: { notLikeUnaccentInsensitive: "%ÊS%" } }
+  ) {
+    ...nodes
+  }
 }
 
 fragment nodes on FilterablesConnection {

--- a/__tests__/fixtures/queries/types.name.graphql
+++ b/__tests__/fixtures/queries/types.name.graphql
@@ -134,6 +134,26 @@ query name($v2: String = "Test", $v3: String = "tEST") {
   ) {
     ...nodes
   }
+  includesUnaccentInsensitive: allFilterables(
+    filter: { NAME: { includesUnaccentInsensitive: "É" } }
+  ) {
+    ...nodes
+  }
+  likeUnaccentInsensitive: allFilterables(
+    filter: { NAME: { likeUnaccentInsensitive: "%ÊS%" } }
+  ) {
+    ...nodes
+  }
+  notIncludesUnaccentInsensitive: allFilterables(
+    filter: { NAME: { notIncludesUnaccentInsensitive: "É" } }
+  ) {
+    ...nodes
+  }
+  notLikeUnaccentInsensitive: allFilterables(
+    filter: { NAME: { notLikeUnaccentInsensitive: "%ÊS%" } }
+  ) {
+    ...nodes
+  }
 }
 
 fragment nodes on FilterablesConnection {

--- a/__tests__/fixtures/queries/types.text.graphql
+++ b/__tests__/fixtures/queries/types.text.graphql
@@ -134,6 +134,26 @@ query text($v2: String = "Test", $v3: String = "tEST") {
   ) {
     ...nodes
   }
+  includesUnaccentInsensitive: allFilterables(
+    filter: { text: { includesUnaccentInsensitive: "É" } }
+  ) {
+    ...nodes
+  }
+  likeUnaccentInsensitive: allFilterables(
+    filter: { text: { likeUnaccentInsensitive: "%ÊS%" } }
+  ) {
+    ...nodes
+  }
+  notIncludesUnaccentInsensitive: allFilterables(
+    filter: { text: { notIncludesUnaccentInsensitive: "É" } }
+  ) {
+    ...nodes
+  }
+  notLikeUnaccentInsensitive: allFilterables(
+    filter: { text: { notLikeUnaccentInsensitive: "%ÊS%" } }
+  ) {
+    ...nodes
+  }
 }
 
 fragment nodes on FilterablesConnection {

--- a/__tests__/fixtures/queries/types.varchar.graphql
+++ b/__tests__/fixtures/queries/types.varchar.graphql
@@ -134,6 +134,26 @@ query varchar($v2: String = "Test", $v3: String = "tEST") {
   ) {
     ...nodes
   }
+  includesUnaccentInsensitive: allFilterables(
+    filter: { varchar: { includesUnaccentInsensitive: "É" } }
+  ) {
+    ...nodes
+  }
+  likeUnaccentInsensitive: allFilterables(
+    filter: { varchar: { likeUnaccentInsensitive: "%ÊS%" } }
+  ) {
+    ...nodes
+  }
+  notIncludesUnaccentInsensitive: allFilterables(
+    filter: { varchar: { notIncludesUnaccentInsensitive: "É" } }
+  ) {
+    ...nodes
+  }
+  notLikeUnaccentInsensitive: allFilterables(
+    filter: { varchar: { notLikeUnaccentInsensitive: "%ÊS%" } }
+  ) {
+    ...nodes
+  }
 }
 
 fragment nodes on FilterablesConnection {

--- a/__tests__/integration/__snapshots__/queries.test.ts.snap
+++ b/__tests__/integration/__snapshots__/queries.test.ts.snap
@@ -9612,6 +9612,22 @@ Object {
         },
       ],
     },
+    "includesUnaccentInsensitive": Object {
+      "nodes": Array [
+        Object {
+          "id": 1,
+        },
+        Object {
+          "id": 2,
+        },
+        Object {
+          "id": 3,
+        },
+        Object {
+          "id": 4,
+        },
+      ],
+    },
     "isNull": Object {
       "nodes": Array [
         Object {
@@ -9666,6 +9682,22 @@ Object {
       ],
     },
     "likeInsensitive": Object {
+      "nodes": Array [
+        Object {
+          "id": 1,
+        },
+        Object {
+          "id": 2,
+        },
+        Object {
+          "id": 3,
+        },
+        Object {
+          "id": 4,
+        },
+      ],
+    },
+    "likeUnaccentInsensitive": Object {
       "nodes": Array [
         Object {
           "id": 1,
@@ -9759,6 +9791,9 @@ Object {
     "notIncludesInsensitive": Object {
       "nodes": Array [],
     },
+    "notIncludesUnaccentInsensitive": Object {
+      "nodes": Array [],
+    },
     "notLike": Object {
       "nodes": Array [
         Object {
@@ -9770,6 +9805,9 @@ Object {
       ],
     },
     "notLikeInsensitive": Object {
+      "nodes": Array [],
+    },
+    "notLikeUnaccentInsensitive": Object {
       "nodes": Array [],
     },
     "notStartsWith": Object {
@@ -9987,6 +10025,22 @@ Object {
         },
       ],
     },
+    "includesUnaccentInsensitive": Object {
+      "nodes": Array [
+        Object {
+          "id": 1,
+        },
+        Object {
+          "id": 2,
+        },
+        Object {
+          "id": 3,
+        },
+        Object {
+          "id": 4,
+        },
+      ],
+    },
     "isNull": Object {
       "nodes": Array [
         Object {
@@ -10041,6 +10095,22 @@ Object {
       ],
     },
     "likeInsensitive": Object {
+      "nodes": Array [
+        Object {
+          "id": 1,
+        },
+        Object {
+          "id": 2,
+        },
+        Object {
+          "id": 3,
+        },
+        Object {
+          "id": 4,
+        },
+      ],
+    },
+    "likeUnaccentInsensitive": Object {
       "nodes": Array [
         Object {
           "id": 1,
@@ -10134,6 +10204,9 @@ Object {
     "notIncludesInsensitive": Object {
       "nodes": Array [],
     },
+    "notIncludesUnaccentInsensitive": Object {
+      "nodes": Array [],
+    },
     "notLike": Object {
       "nodes": Array [
         Object {
@@ -10145,6 +10218,9 @@ Object {
       ],
     },
     "notLikeInsensitive": Object {
+      "nodes": Array [],
+    },
+    "notLikeUnaccentInsensitive": Object {
       "nodes": Array [],
     },
     "notStartsWith": Object {
@@ -10519,6 +10595,22 @@ Object {
         },
       ],
     },
+    "includesUnaccentInsensitive": Object {
+      "nodes": Array [
+        Object {
+          "id": 1,
+        },
+        Object {
+          "id": 2,
+        },
+        Object {
+          "id": 3,
+        },
+        Object {
+          "id": 4,
+        },
+      ],
+    },
     "isNull": Object {
       "nodes": Array [
         Object {
@@ -10573,6 +10665,22 @@ Object {
       ],
     },
     "likeInsensitive": Object {
+      "nodes": Array [
+        Object {
+          "id": 1,
+        },
+        Object {
+          "id": 2,
+        },
+        Object {
+          "id": 3,
+        },
+        Object {
+          "id": 4,
+        },
+      ],
+    },
+    "likeUnaccentInsensitive": Object {
       "nodes": Array [
         Object {
           "id": 1,
@@ -10666,6 +10774,9 @@ Object {
     "notIncludesInsensitive": Object {
       "nodes": Array [],
     },
+    "notIncludesUnaccentInsensitive": Object {
+      "nodes": Array [],
+    },
     "notLike": Object {
       "nodes": Array [
         Object {
@@ -10677,6 +10788,9 @@ Object {
       ],
     },
     "notLikeInsensitive": Object {
+      "nodes": Array [],
+    },
+    "notLikeUnaccentInsensitive": Object {
       "nodes": Array [],
     },
     "notStartsWith": Object {
@@ -12237,376 +12351,12 @@ Object {
 
 exports[`types.name.graphql 1`] = `
 Object {
-  "data": Object {
-    "distinctFrom": Object {
-      "nodes": Array [
-        Object {
-          "id": 1,
-        },
-        Object {
-          "id": 3,
-        },
-        Object {
-          "id": 4,
-        },
-        Object {
-          "id": 5,
-        },
-      ],
-    },
-    "distinctFromInsensitive": Object {
-      "nodes": Array [
-        Object {
-          "id": 5,
-        },
-      ],
-    },
-    "endsWith": Object {
-      "nodes": Array [
-        Object {
-          "id": 1,
-        },
-        Object {
-          "id": 3,
-        },
-      ],
-    },
-    "endsWithInsensitive": Object {
-      "nodes": Array [
-        Object {
-          "id": 1,
-        },
-        Object {
-          "id": 2,
-        },
-        Object {
-          "id": 3,
-        },
-        Object {
-          "id": 4,
-        },
-      ],
-    },
-    "equalTo": Object {
-      "nodes": Array [
-        Object {
-          "id": 2,
-        },
-      ],
-    },
-    "equalToInsensitive": Object {
-      "nodes": Array [
-        Object {
-          "id": 1,
-        },
-        Object {
-          "id": 2,
-        },
-        Object {
-          "id": 3,
-        },
-        Object {
-          "id": 4,
-        },
-      ],
-    },
-    "greaterThan": Object {
-      "nodes": Array [
-        Object {
-          "id": 3,
-        },
-        Object {
-          "id": 4,
-        },
-      ],
-    },
-    "greaterThanInsensitive": Object {
-      "nodes": Array [],
-    },
-    "greaterThanOrEqualTo": Object {
-      "nodes": Array [
-        Object {
-          "id": 2,
-        },
-        Object {
-          "id": 3,
-        },
-        Object {
-          "id": 4,
-        },
-      ],
-    },
-    "greaterThanOrEqualToInsensitive": Object {
-      "nodes": Array [
-        Object {
-          "id": 1,
-        },
-        Object {
-          "id": 2,
-        },
-        Object {
-          "id": 3,
-        },
-        Object {
-          "id": 4,
-        },
-      ],
-    },
-    "in": Object {
-      "nodes": Array [
-        Object {
-          "id": 2,
-        },
-        Object {
-          "id": 3,
-        },
-      ],
-    },
-    "inInsensitive": Object {
-      "nodes": Array [
-        Object {
-          "id": 1,
-        },
-        Object {
-          "id": 2,
-        },
-        Object {
-          "id": 3,
-        },
-        Object {
-          "id": 4,
-        },
-      ],
-    },
-    "includes": Object {
-      "nodes": Array [
-        Object {
-          "id": 1,
-        },
-        Object {
-          "id": 2,
-        },
-        Object {
-          "id": 3,
-        },
-      ],
-    },
-    "includesInsensitive": Object {
-      "nodes": Array [
-        Object {
-          "id": 1,
-        },
-        Object {
-          "id": 2,
-        },
-        Object {
-          "id": 3,
-        },
-        Object {
-          "id": 4,
-        },
-      ],
-    },
-    "isNull": Object {
-      "nodes": Array [
-        Object {
-          "id": 5,
-        },
-      ],
-    },
-    "lessThan": Object {
-      "nodes": Array [
-        Object {
-          "id": 1,
-        },
-      ],
-    },
-    "lessThanInsensitive": Object {
-      "nodes": Array [],
-    },
-    "lessThanOrEqualTo": Object {
-      "nodes": Array [
-        Object {
-          "id": 1,
-        },
-        Object {
-          "id": 2,
-        },
-      ],
-    },
-    "lessThanOrEqualToInsensitive": Object {
-      "nodes": Array [
-        Object {
-          "id": 1,
-        },
-        Object {
-          "id": 2,
-        },
-        Object {
-          "id": 3,
-        },
-        Object {
-          "id": 4,
-        },
-      ],
-    },
-    "like": Object {
-      "nodes": Array [
-        Object {
-          "id": 1,
-        },
-        Object {
-          "id": 3,
-        },
-      ],
-    },
-    "likeInsensitive": Object {
-      "nodes": Array [
-        Object {
-          "id": 1,
-        },
-        Object {
-          "id": 2,
-        },
-        Object {
-          "id": 3,
-        },
-        Object {
-          "id": 4,
-        },
-      ],
-    },
-    "notDistinctFrom": Object {
-      "nodes": Array [
-        Object {
-          "id": 2,
-        },
-      ],
-    },
-    "notDistinctFromInsensitive": Object {
-      "nodes": Array [
-        Object {
-          "id": 1,
-        },
-        Object {
-          "id": 2,
-        },
-        Object {
-          "id": 3,
-        },
-        Object {
-          "id": 4,
-        },
-      ],
-    },
-    "notEndsWith": Object {
-      "nodes": Array [
-        Object {
-          "id": 2,
-        },
-        Object {
-          "id": 4,
-        },
-      ],
-    },
-    "notEndsWithInsensitive": Object {
-      "nodes": Array [],
-    },
-    "notEqualTo": Object {
-      "nodes": Array [
-        Object {
-          "id": 1,
-        },
-        Object {
-          "id": 3,
-        },
-        Object {
-          "id": 4,
-        },
-      ],
-    },
-    "notEqualToInsensitive": Object {
-      "nodes": Array [],
-    },
-    "notIn": Object {
-      "nodes": Array [
-        Object {
-          "id": 1,
-        },
-        Object {
-          "id": 3,
-        },
-        Object {
-          "id": 4,
-        },
-      ],
-    },
-    "notInInsensitive": Object {
-      "nodes": Array [],
-    },
-    "notIncludes": Object {
-      "nodes": Array [
-        Object {
-          "id": 4,
-        },
-      ],
-    },
-    "notIncludesInsensitive": Object {
-      "nodes": Array [],
-    },
-    "notLike": Object {
-      "nodes": Array [
-        Object {
-          "id": 2,
-        },
-        Object {
-          "id": 4,
-        },
-      ],
-    },
-    "notLikeInsensitive": Object {
-      "nodes": Array [],
-    },
-    "notStartsWith": Object {
-      "nodes": Array [
-        Object {
-          "id": 3,
-        },
-        Object {
-          "id": 4,
-        },
-      ],
-    },
-    "notStartsWithInsensitive": Object {
-      "nodes": Array [],
-    },
-    "startsWith": Object {
-      "nodes": Array [
-        Object {
-          "id": 1,
-        },
-        Object {
-          "id": 2,
-        },
-      ],
-    },
-    "startsWithInsensitive": Object {
-      "nodes": Array [
-        Object {
-          "id": 1,
-        },
-        Object {
-          "id": 2,
-        },
-        Object {
-          "id": 3,
-        },
-        Object {
-          "id": 4,
-        },
-      ],
-    },
-  },
+  "errors": Array [
+    [GraphQLError: Field "NAME" is not defined by type FilterableFilter. Did you mean name, date, or time?],
+    [GraphQLError: Field "NAME" is not defined by type FilterableFilter. Did you mean name, date, or time?],
+    [GraphQLError: Field "NAME" is not defined by type FilterableFilter. Did you mean name, date, or time?],
+    [GraphQLError: Field "NAME" is not defined by type FilterableFilter. Did you mean name, date, or time?],
+  ],
 }
 `;
 
@@ -12902,6 +12652,22 @@ Object {
         },
       ],
     },
+    "includesUnaccentInsensitive": Object {
+      "nodes": Array [
+        Object {
+          "id": 1,
+        },
+        Object {
+          "id": 2,
+        },
+        Object {
+          "id": 3,
+        },
+        Object {
+          "id": 4,
+        },
+      ],
+    },
     "isNull": Object {
       "nodes": Array [
         Object {
@@ -12956,6 +12722,22 @@ Object {
       ],
     },
     "likeInsensitive": Object {
+      "nodes": Array [
+        Object {
+          "id": 1,
+        },
+        Object {
+          "id": 2,
+        },
+        Object {
+          "id": 3,
+        },
+        Object {
+          "id": 4,
+        },
+      ],
+    },
+    "likeUnaccentInsensitive": Object {
       "nodes": Array [
         Object {
           "id": 1,
@@ -13049,6 +12831,9 @@ Object {
     "notIncludesInsensitive": Object {
       "nodes": Array [],
     },
+    "notIncludesUnaccentInsensitive": Object {
+      "nodes": Array [],
+    },
     "notLike": Object {
       "nodes": Array [
         Object {
@@ -13060,6 +12845,9 @@ Object {
       ],
     },
     "notLikeInsensitive": Object {
+      "nodes": Array [],
+    },
+    "notLikeUnaccentInsensitive": Object {
       "nodes": Array [],
     },
     "notStartsWith": Object {
@@ -13997,6 +13785,22 @@ Object {
         },
       ],
     },
+    "includesUnaccentInsensitive": Object {
+      "nodes": Array [
+        Object {
+          "id": 1,
+        },
+        Object {
+          "id": 2,
+        },
+        Object {
+          "id": 3,
+        },
+        Object {
+          "id": 4,
+        },
+      ],
+    },
     "isNull": Object {
       "nodes": Array [
         Object {
@@ -14051,6 +13855,22 @@ Object {
       ],
     },
     "likeInsensitive": Object {
+      "nodes": Array [
+        Object {
+          "id": 1,
+        },
+        Object {
+          "id": 2,
+        },
+        Object {
+          "id": 3,
+        },
+        Object {
+          "id": 4,
+        },
+      ],
+    },
+    "likeUnaccentInsensitive": Object {
       "nodes": Array [
         Object {
           "id": 1,
@@ -14144,6 +13964,9 @@ Object {
     "notIncludesInsensitive": Object {
       "nodes": Array [],
     },
+    "notIncludesUnaccentInsensitive": Object {
+      "nodes": Array [],
+    },
     "notLike": Object {
       "nodes": Array [
         Object {
@@ -14155,6 +13978,9 @@ Object {
       ],
     },
     "notLikeInsensitive": Object {
+      "nodes": Array [],
+    },
+    "notLikeUnaccentInsensitive": Object {
       "nodes": Array [],
     },
     "notStartsWith": Object {

--- a/__tests__/integration/schema/__snapshots__/addConnectionFilterOperator.test.ts.snap
+++ b/__tests__/integration/schema/__snapshots__/addConnectionFilterOperator.test.ts.snap
@@ -1219,6 +1219,9 @@ input Char4DomainFilter {
   \\"\\"\\"Contains the specified string (case-insensitive).\\"\\"\\"
   includesInsensitive: Char4Domain
 
+  \\"\\"\\"Contains the specified string (unaccented case-insensitive).\\"\\"\\"
+  includesUnaccentInsensitive: Char4Domain
+
   \\"\\"\\"
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
   \\"\\"\\"
@@ -1247,6 +1250,13 @@ input Char4DomainFilter {
   any single character; a percent sign (%) matches any sequence of zero or more characters.
   \\"\\"\\"
   likeInsensitive: Char4Domain
+
+  \\"\\"\\"
+  Matches the specified pattern (unaccented case-insensitive). An underscore (_)
+  matches any single character; a percent sign (%) matches any sequence of zero
+  or more characters.
+  \\"\\"\\"
+  likeUnaccentInsensitive: Char4Domain
 
   \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
   notDistinctFrom: Char4Domain
@@ -1280,6 +1290,9 @@ input Char4DomainFilter {
   \\"\\"\\"Does not contain the specified string (case-insensitive).\\"\\"\\"
   notIncludesInsensitive: Char4Domain
 
+  \\"\\"\\"Does not contain the specified string (unaccented case-insensitive).\\"\\"\\"
+  notIncludesUnaccentInsensitive: Char4Domain
+
   \\"\\"\\"
   Does not match the specified pattern (case-sensitive). An underscore (_)
   matches any single character; a percent sign (%) matches any sequence of zero
@@ -1293,6 +1306,13 @@ input Char4DomainFilter {
   or more characters.
   \\"\\"\\"
   notLikeInsensitive: Char4Domain
+
+  \\"\\"\\"
+  Does not match the specified pattern (unaccented case-insensitive). An
+  underscore (_) matches any single character; a percent sign (%) matches any
+  sequence of zero or more characters.
+  \\"\\"\\"
+  notLikeUnaccentInsensitive: Char4Domain
 
   \\"\\"\\"Does not start with the specified string (case-sensitive).\\"\\"\\"
   notStartsWith: Char4Domain
@@ -5958,6 +5978,9 @@ input StringFilter {
   \\"\\"\\"Contains the specified string (case-insensitive).\\"\\"\\"
   includesInsensitive: String
 
+  \\"\\"\\"Contains the specified string (unaccented case-insensitive).\\"\\"\\"
+  includesUnaccentInsensitive: String
+
   \\"\\"\\"
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
   \\"\\"\\"
@@ -5986,6 +6009,13 @@ input StringFilter {
   any single character; a percent sign (%) matches any sequence of zero or more characters.
   \\"\\"\\"
   likeInsensitive: String
+
+  \\"\\"\\"
+  Matches the specified pattern (unaccented case-insensitive). An underscore (_)
+  matches any single character; a percent sign (%) matches any sequence of zero
+  or more characters.
+  \\"\\"\\"
+  likeUnaccentInsensitive: String
 
   \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
   notDistinctFrom: String
@@ -6019,6 +6049,9 @@ input StringFilter {
   \\"\\"\\"Does not contain the specified string (case-insensitive).\\"\\"\\"
   notIncludesInsensitive: String
 
+  \\"\\"\\"Does not contain the specified string (unaccented case-insensitive).\\"\\"\\"
+  notIncludesUnaccentInsensitive: String
+
   \\"\\"\\"
   Does not match the specified pattern (case-sensitive). An underscore (_)
   matches any single character; a percent sign (%) matches any sequence of zero
@@ -6032,6 +6065,13 @@ input StringFilter {
   or more characters.
   \\"\\"\\"
   notLikeInsensitive: String
+
+  \\"\\"\\"
+  Does not match the specified pattern (unaccented case-insensitive). An
+  underscore (_) matches any single character; a percent sign (%) matches any
+  sequence of zero or more characters.
+  \\"\\"\\"
+  notLikeUnaccentInsensitive: String
 
   \\"\\"\\"Does not start with the specified string (case-sensitive).\\"\\"\\"
   notStartsWith: String

--- a/__tests__/integration/schema/__snapshots__/allowedFieldTypes.test.ts.snap
+++ b/__tests__/integration/schema/__snapshots__/allowedFieldTypes.test.ts.snap
@@ -3459,6 +3459,9 @@ input StringFilter {
   \\"\\"\\"Contains the specified string (case-insensitive).\\"\\"\\"
   includesInsensitive: String
 
+  \\"\\"\\"Contains the specified string (unaccented case-insensitive).\\"\\"\\"
+  includesUnaccentInsensitive: String
+
   \\"\\"\\"
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
   \\"\\"\\"
@@ -3487,6 +3490,13 @@ input StringFilter {
   any single character; a percent sign (%) matches any sequence of zero or more characters.
   \\"\\"\\"
   likeInsensitive: String
+
+  \\"\\"\\"
+  Matches the specified pattern (unaccented case-insensitive). An underscore (_)
+  matches any single character; a percent sign (%) matches any sequence of zero
+  or more characters.
+  \\"\\"\\"
+  likeUnaccentInsensitive: String
 
   \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
   notDistinctFrom: String
@@ -3520,6 +3530,9 @@ input StringFilter {
   \\"\\"\\"Does not contain the specified string (case-insensitive).\\"\\"\\"
   notIncludesInsensitive: String
 
+  \\"\\"\\"Does not contain the specified string (unaccented case-insensitive).\\"\\"\\"
+  notIncludesUnaccentInsensitive: String
+
   \\"\\"\\"
   Does not match the specified pattern (case-sensitive). An underscore (_)
   matches any single character; a percent sign (%) matches any sequence of zero
@@ -3533,6 +3546,13 @@ input StringFilter {
   or more characters.
   \\"\\"\\"
   notLikeInsensitive: String
+
+  \\"\\"\\"
+  Does not match the specified pattern (unaccented case-insensitive). An
+  underscore (_) matches any single character; a percent sign (%) matches any
+  sequence of zero or more characters.
+  \\"\\"\\"
+  notLikeUnaccentInsensitive: String
 
   \\"\\"\\"Does not start with the specified string (case-sensitive).\\"\\"\\"
   notStartsWith: String

--- a/__tests__/integration/schema/__snapshots__/arraysFalse.test.ts.snap
+++ b/__tests__/integration/schema/__snapshots__/arraysFalse.test.ts.snap
@@ -763,6 +763,9 @@ input Char4DomainFilter {
   \\"\\"\\"Contains the specified string (case-insensitive).\\"\\"\\"
   includesInsensitive: Char4Domain
 
+  \\"\\"\\"Contains the specified string (unaccented case-insensitive).\\"\\"\\"
+  includesUnaccentInsensitive: Char4Domain
+
   \\"\\"\\"
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
   \\"\\"\\"
@@ -791,6 +794,13 @@ input Char4DomainFilter {
   any single character; a percent sign (%) matches any sequence of zero or more characters.
   \\"\\"\\"
   likeInsensitive: Char4Domain
+
+  \\"\\"\\"
+  Matches the specified pattern (unaccented case-insensitive). An underscore (_)
+  matches any single character; a percent sign (%) matches any sequence of zero
+  or more characters.
+  \\"\\"\\"
+  likeUnaccentInsensitive: Char4Domain
 
   \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
   notDistinctFrom: Char4Domain
@@ -824,6 +834,9 @@ input Char4DomainFilter {
   \\"\\"\\"Does not contain the specified string (case-insensitive).\\"\\"\\"
   notIncludesInsensitive: Char4Domain
 
+  \\"\\"\\"Does not contain the specified string (unaccented case-insensitive).\\"\\"\\"
+  notIncludesUnaccentInsensitive: Char4Domain
+
   \\"\\"\\"
   Does not match the specified pattern (case-sensitive). An underscore (_)
   matches any single character; a percent sign (%) matches any sequence of zero
@@ -837,6 +850,13 @@ input Char4DomainFilter {
   or more characters.
   \\"\\"\\"
   notLikeInsensitive: Char4Domain
+
+  \\"\\"\\"
+  Does not match the specified pattern (unaccented case-insensitive). An
+  underscore (_) matches any single character; a percent sign (%) matches any
+  sequence of zero or more characters.
+  \\"\\"\\"
+  notLikeUnaccentInsensitive: Char4Domain
 
   \\"\\"\\"Does not start with the specified string (case-sensitive).\\"\\"\\"
   notStartsWith: Char4Domain
@@ -4713,6 +4733,9 @@ input StringFilter {
   \\"\\"\\"Contains the specified string (case-insensitive).\\"\\"\\"
   includesInsensitive: String
 
+  \\"\\"\\"Contains the specified string (unaccented case-insensitive).\\"\\"\\"
+  includesUnaccentInsensitive: String
+
   \\"\\"\\"
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
   \\"\\"\\"
@@ -4741,6 +4764,13 @@ input StringFilter {
   any single character; a percent sign (%) matches any sequence of zero or more characters.
   \\"\\"\\"
   likeInsensitive: String
+
+  \\"\\"\\"
+  Matches the specified pattern (unaccented case-insensitive). An underscore (_)
+  matches any single character; a percent sign (%) matches any sequence of zero
+  or more characters.
+  \\"\\"\\"
+  likeUnaccentInsensitive: String
 
   \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
   notDistinctFrom: String
@@ -4774,6 +4804,9 @@ input StringFilter {
   \\"\\"\\"Does not contain the specified string (case-insensitive).\\"\\"\\"
   notIncludesInsensitive: String
 
+  \\"\\"\\"Does not contain the specified string (unaccented case-insensitive).\\"\\"\\"
+  notIncludesUnaccentInsensitive: String
+
   \\"\\"\\"
   Does not match the specified pattern (case-sensitive). An underscore (_)
   matches any single character; a percent sign (%) matches any sequence of zero
@@ -4787,6 +4820,13 @@ input StringFilter {
   or more characters.
   \\"\\"\\"
   notLikeInsensitive: String
+
+  \\"\\"\\"
+  Does not match the specified pattern (unaccented case-insensitive). An
+  underscore (_) matches any single character; a percent sign (%) matches any
+  sequence of zero or more characters.
+  \\"\\"\\"
+  notLikeUnaccentInsensitive: String
 
   \\"\\"\\"Does not start with the specified string (case-sensitive).\\"\\"\\"
   notStartsWith: String

--- a/__tests__/integration/schema/__snapshots__/computedColumnsFalse.test.ts.snap
+++ b/__tests__/integration/schema/__snapshots__/computedColumnsFalse.test.ts.snap
@@ -1219,6 +1219,9 @@ input Char4DomainFilter {
   \\"\\"\\"Contains the specified string (case-insensitive).\\"\\"\\"
   includesInsensitive: Char4Domain
 
+  \\"\\"\\"Contains the specified string (unaccented case-insensitive).\\"\\"\\"
+  includesUnaccentInsensitive: Char4Domain
+
   \\"\\"\\"
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
   \\"\\"\\"
@@ -1247,6 +1250,13 @@ input Char4DomainFilter {
   any single character; a percent sign (%) matches any sequence of zero or more characters.
   \\"\\"\\"
   likeInsensitive: Char4Domain
+
+  \\"\\"\\"
+  Matches the specified pattern (unaccented case-insensitive). An underscore (_)
+  matches any single character; a percent sign (%) matches any sequence of zero
+  or more characters.
+  \\"\\"\\"
+  likeUnaccentInsensitive: Char4Domain
 
   \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
   notDistinctFrom: Char4Domain
@@ -1280,6 +1290,9 @@ input Char4DomainFilter {
   \\"\\"\\"Does not contain the specified string (case-insensitive).\\"\\"\\"
   notIncludesInsensitive: Char4Domain
 
+  \\"\\"\\"Does not contain the specified string (unaccented case-insensitive).\\"\\"\\"
+  notIncludesUnaccentInsensitive: Char4Domain
+
   \\"\\"\\"
   Does not match the specified pattern (case-sensitive). An underscore (_)
   matches any single character; a percent sign (%) matches any sequence of zero
@@ -1293,6 +1306,13 @@ input Char4DomainFilter {
   or more characters.
   \\"\\"\\"
   notLikeInsensitive: Char4Domain
+
+  \\"\\"\\"
+  Does not match the specified pattern (unaccented case-insensitive). An
+  underscore (_) matches any single character; a percent sign (%) matches any
+  sequence of zero or more characters.
+  \\"\\"\\"
+  notLikeUnaccentInsensitive: Char4Domain
 
   \\"\\"\\"Does not start with the specified string (case-sensitive).\\"\\"\\"
   notStartsWith: Char4Domain
@@ -5943,6 +5963,9 @@ input StringFilter {
   \\"\\"\\"Contains the specified string (case-insensitive).\\"\\"\\"
   includesInsensitive: String
 
+  \\"\\"\\"Contains the specified string (unaccented case-insensitive).\\"\\"\\"
+  includesUnaccentInsensitive: String
+
   \\"\\"\\"
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
   \\"\\"\\"
@@ -5971,6 +5994,13 @@ input StringFilter {
   any single character; a percent sign (%) matches any sequence of zero or more characters.
   \\"\\"\\"
   likeInsensitive: String
+
+  \\"\\"\\"
+  Matches the specified pattern (unaccented case-insensitive). An underscore (_)
+  matches any single character; a percent sign (%) matches any sequence of zero
+  or more characters.
+  \\"\\"\\"
+  likeUnaccentInsensitive: String
 
   \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
   notDistinctFrom: String
@@ -6004,6 +6034,9 @@ input StringFilter {
   \\"\\"\\"Does not contain the specified string (case-insensitive).\\"\\"\\"
   notIncludesInsensitive: String
 
+  \\"\\"\\"Does not contain the specified string (unaccented case-insensitive).\\"\\"\\"
+  notIncludesUnaccentInsensitive: String
+
   \\"\\"\\"
   Does not match the specified pattern (case-sensitive). An underscore (_)
   matches any single character; a percent sign (%) matches any sequence of zero
@@ -6017,6 +6050,13 @@ input StringFilter {
   or more characters.
   \\"\\"\\"
   notLikeInsensitive: String
+
+  \\"\\"\\"
+  Does not match the specified pattern (unaccented case-insensitive). An
+  underscore (_) matches any single character; a percent sign (%) matches any
+  sequence of zero or more characters.
+  \\"\\"\\"
+  notLikeUnaccentInsensitive: String
 
   \\"\\"\\"Does not start with the specified string (case-sensitive).\\"\\"\\"
   notStartsWith: String

--- a/__tests__/integration/schema/__snapshots__/defaultOptions.test.ts.snap
+++ b/__tests__/integration/schema/__snapshots__/defaultOptions.test.ts.snap
@@ -1219,6 +1219,9 @@ input Char4DomainFilter {
   \\"\\"\\"Contains the specified string (case-insensitive).\\"\\"\\"
   includesInsensitive: Char4Domain
 
+  \\"\\"\\"Contains the specified string (unaccented case-insensitive).\\"\\"\\"
+  includesUnaccentInsensitive: Char4Domain
+
   \\"\\"\\"
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
   \\"\\"\\"
@@ -1247,6 +1250,13 @@ input Char4DomainFilter {
   any single character; a percent sign (%) matches any sequence of zero or more characters.
   \\"\\"\\"
   likeInsensitive: Char4Domain
+
+  \\"\\"\\"
+  Matches the specified pattern (unaccented case-insensitive). An underscore (_)
+  matches any single character; a percent sign (%) matches any sequence of zero
+  or more characters.
+  \\"\\"\\"
+  likeUnaccentInsensitive: Char4Domain
 
   \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
   notDistinctFrom: Char4Domain
@@ -1280,6 +1290,9 @@ input Char4DomainFilter {
   \\"\\"\\"Does not contain the specified string (case-insensitive).\\"\\"\\"
   notIncludesInsensitive: Char4Domain
 
+  \\"\\"\\"Does not contain the specified string (unaccented case-insensitive).\\"\\"\\"
+  notIncludesUnaccentInsensitive: Char4Domain
+
   \\"\\"\\"
   Does not match the specified pattern (case-sensitive). An underscore (_)
   matches any single character; a percent sign (%) matches any sequence of zero
@@ -1293,6 +1306,13 @@ input Char4DomainFilter {
   or more characters.
   \\"\\"\\"
   notLikeInsensitive: Char4Domain
+
+  \\"\\"\\"
+  Does not match the specified pattern (unaccented case-insensitive). An
+  underscore (_) matches any single character; a percent sign (%) matches any
+  sequence of zero or more characters.
+  \\"\\"\\"
+  notLikeUnaccentInsensitive: Char4Domain
 
   \\"\\"\\"Does not start with the specified string (case-sensitive).\\"\\"\\"
   notStartsWith: Char4Domain
@@ -5949,6 +5969,9 @@ input StringFilter {
   \\"\\"\\"Contains the specified string (case-insensitive).\\"\\"\\"
   includesInsensitive: String
 
+  \\"\\"\\"Contains the specified string (unaccented case-insensitive).\\"\\"\\"
+  includesUnaccentInsensitive: String
+
   \\"\\"\\"
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
   \\"\\"\\"
@@ -5977,6 +6000,13 @@ input StringFilter {
   any single character; a percent sign (%) matches any sequence of zero or more characters.
   \\"\\"\\"
   likeInsensitive: String
+
+  \\"\\"\\"
+  Matches the specified pattern (unaccented case-insensitive). An underscore (_)
+  matches any single character; a percent sign (%) matches any sequence of zero
+  or more characters.
+  \\"\\"\\"
+  likeUnaccentInsensitive: String
 
   \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
   notDistinctFrom: String
@@ -6010,6 +6040,9 @@ input StringFilter {
   \\"\\"\\"Does not contain the specified string (case-insensitive).\\"\\"\\"
   notIncludesInsensitive: String
 
+  \\"\\"\\"Does not contain the specified string (unaccented case-insensitive).\\"\\"\\"
+  notIncludesUnaccentInsensitive: String
+
   \\"\\"\\"
   Does not match the specified pattern (case-sensitive). An underscore (_)
   matches any single character; a percent sign (%) matches any sequence of zero
@@ -6023,6 +6056,13 @@ input StringFilter {
   or more characters.
   \\"\\"\\"
   notLikeInsensitive: String
+
+  \\"\\"\\"
+  Does not match the specified pattern (unaccented case-insensitive). An
+  underscore (_) matches any single character; a percent sign (%) matches any
+  sequence of zero or more characters.
+  \\"\\"\\"
+  notLikeUnaccentInsensitive: String
 
   \\"\\"\\"Does not start with the specified string (case-sensitive).\\"\\"\\"
   notStartsWith: String

--- a/__tests__/integration/schema/__snapshots__/ignoreIndexesFalse.test.ts.snap
+++ b/__tests__/integration/schema/__snapshots__/ignoreIndexesFalse.test.ts.snap
@@ -2745,6 +2745,9 @@ input StringFilter {
   \\"\\"\\"Contains the specified string (case-insensitive).\\"\\"\\"
   includesInsensitive: String
 
+  \\"\\"\\"Contains the specified string (unaccented case-insensitive).\\"\\"\\"
+  includesUnaccentInsensitive: String
+
   \\"\\"\\"
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
   \\"\\"\\"
@@ -2773,6 +2776,13 @@ input StringFilter {
   any single character; a percent sign (%) matches any sequence of zero or more characters.
   \\"\\"\\"
   likeInsensitive: String
+
+  \\"\\"\\"
+  Matches the specified pattern (unaccented case-insensitive). An underscore (_)
+  matches any single character; a percent sign (%) matches any sequence of zero
+  or more characters.
+  \\"\\"\\"
+  likeUnaccentInsensitive: String
 
   \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
   notDistinctFrom: String
@@ -2806,6 +2816,9 @@ input StringFilter {
   \\"\\"\\"Does not contain the specified string (case-insensitive).\\"\\"\\"
   notIncludesInsensitive: String
 
+  \\"\\"\\"Does not contain the specified string (unaccented case-insensitive).\\"\\"\\"
+  notIncludesUnaccentInsensitive: String
+
   \\"\\"\\"
   Does not match the specified pattern (case-sensitive). An underscore (_)
   matches any single character; a percent sign (%) matches any sequence of zero
@@ -2819,6 +2832,13 @@ input StringFilter {
   or more characters.
   \\"\\"\\"
   notLikeInsensitive: String
+
+  \\"\\"\\"
+  Does not match the specified pattern (unaccented case-insensitive). An
+  underscore (_) matches any single character; a percent sign (%) matches any
+  sequence of zero or more characters.
+  \\"\\"\\"
+  notLikeUnaccentInsensitive: String
 
   \\"\\"\\"Does not start with the specified string (case-sensitive).\\"\\"\\"
   notStartsWith: String

--- a/__tests__/integration/schema/__snapshots__/logicalOperatorsFalse.test.ts.snap
+++ b/__tests__/integration/schema/__snapshots__/logicalOperatorsFalse.test.ts.snap
@@ -1192,6 +1192,9 @@ input Char4DomainFilter {
   \\"\\"\\"Contains the specified string (case-insensitive).\\"\\"\\"
   includesInsensitive: Char4Domain
 
+  \\"\\"\\"Contains the specified string (unaccented case-insensitive).\\"\\"\\"
+  includesUnaccentInsensitive: Char4Domain
+
   \\"\\"\\"
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
   \\"\\"\\"
@@ -1220,6 +1223,13 @@ input Char4DomainFilter {
   any single character; a percent sign (%) matches any sequence of zero or more characters.
   \\"\\"\\"
   likeInsensitive: Char4Domain
+
+  \\"\\"\\"
+  Matches the specified pattern (unaccented case-insensitive). An underscore (_)
+  matches any single character; a percent sign (%) matches any sequence of zero
+  or more characters.
+  \\"\\"\\"
+  likeUnaccentInsensitive: Char4Domain
 
   \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
   notDistinctFrom: Char4Domain
@@ -1253,6 +1263,9 @@ input Char4DomainFilter {
   \\"\\"\\"Does not contain the specified string (case-insensitive).\\"\\"\\"
   notIncludesInsensitive: Char4Domain
 
+  \\"\\"\\"Does not contain the specified string (unaccented case-insensitive).\\"\\"\\"
+  notIncludesUnaccentInsensitive: Char4Domain
+
   \\"\\"\\"
   Does not match the specified pattern (case-sensitive). An underscore (_)
   matches any single character; a percent sign (%) matches any sequence of zero
@@ -1266,6 +1279,13 @@ input Char4DomainFilter {
   or more characters.
   \\"\\"\\"
   notLikeInsensitive: Char4Domain
+
+  \\"\\"\\"
+  Does not match the specified pattern (unaccented case-insensitive). An
+  underscore (_) matches any single character; a percent sign (%) matches any
+  sequence of zero or more characters.
+  \\"\\"\\"
+  notLikeUnaccentInsensitive: Char4Domain
 
   \\"\\"\\"Does not start with the specified string (case-sensitive).\\"\\"\\"
   notStartsWith: Char4Domain
@@ -5742,6 +5762,9 @@ input StringFilter {
   \\"\\"\\"Contains the specified string (case-insensitive).\\"\\"\\"
   includesInsensitive: String
 
+  \\"\\"\\"Contains the specified string (unaccented case-insensitive).\\"\\"\\"
+  includesUnaccentInsensitive: String
+
   \\"\\"\\"
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
   \\"\\"\\"
@@ -5770,6 +5793,13 @@ input StringFilter {
   any single character; a percent sign (%) matches any sequence of zero or more characters.
   \\"\\"\\"
   likeInsensitive: String
+
+  \\"\\"\\"
+  Matches the specified pattern (unaccented case-insensitive). An underscore (_)
+  matches any single character; a percent sign (%) matches any sequence of zero
+  or more characters.
+  \\"\\"\\"
+  likeUnaccentInsensitive: String
 
   \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
   notDistinctFrom: String
@@ -5803,6 +5833,9 @@ input StringFilter {
   \\"\\"\\"Does not contain the specified string (case-insensitive).\\"\\"\\"
   notIncludesInsensitive: String
 
+  \\"\\"\\"Does not contain the specified string (unaccented case-insensitive).\\"\\"\\"
+  notIncludesUnaccentInsensitive: String
+
   \\"\\"\\"
   Does not match the specified pattern (case-sensitive). An underscore (_)
   matches any single character; a percent sign (%) matches any sequence of zero
@@ -5816,6 +5849,13 @@ input StringFilter {
   or more characters.
   \\"\\"\\"
   notLikeInsensitive: String
+
+  \\"\\"\\"
+  Does not match the specified pattern (unaccented case-insensitive). An
+  underscore (_) matches any single character; a percent sign (%) matches any
+  sequence of zero or more characters.
+  \\"\\"\\"
+  notLikeUnaccentInsensitive: String
 
   \\"\\"\\"Does not start with the specified string (case-sensitive).\\"\\"\\"
   notStartsWith: String

--- a/__tests__/integration/schema/__snapshots__/operatorNames.test.ts.snap
+++ b/__tests__/integration/schema/__snapshots__/operatorNames.test.ts.snap
@@ -1219,6 +1219,9 @@ input Char4DomainFilter {
   \\"\\"\\"Contains the specified string (case-insensitive).\\"\\"\\"
   includesInsensitive: Char4Domain
 
+  \\"\\"\\"Contains the specified string (unaccented case-insensitive).\\"\\"\\"
+  includesUnaccentInsensitive: Char4Domain
+
   \\"\\"\\"
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
   \\"\\"\\"
@@ -1247,6 +1250,13 @@ input Char4DomainFilter {
   any single character; a percent sign (%) matches any sequence of zero or more characters.
   \\"\\"\\"
   likeInsensitive: Char4Domain
+
+  \\"\\"\\"
+  Matches the specified pattern (unaccented case-insensitive). An underscore (_)
+  matches any single character; a percent sign (%) matches any sequence of zero
+  or more characters.
+  \\"\\"\\"
+  likeUnaccentInsensitive: Char4Domain
 
   \\"\\"\\"Not equal to the specified value.\\"\\"\\"
   ne: Char4Domain
@@ -1280,6 +1290,9 @@ input Char4DomainFilter {
   \\"\\"\\"Does not contain the specified string (case-insensitive).\\"\\"\\"
   notIncludesInsensitive: Char4Domain
 
+  \\"\\"\\"Does not contain the specified string (unaccented case-insensitive).\\"\\"\\"
+  notIncludesUnaccentInsensitive: Char4Domain
+
   \\"\\"\\"
   Does not match the specified pattern (case-sensitive). An underscore (_)
   matches any single character; a percent sign (%) matches any sequence of zero
@@ -1293,6 +1306,13 @@ input Char4DomainFilter {
   or more characters.
   \\"\\"\\"
   notLikeInsensitive: Char4Domain
+
+  \\"\\"\\"
+  Does not match the specified pattern (unaccented case-insensitive). An
+  underscore (_) matches any single character; a percent sign (%) matches any
+  sequence of zero or more characters.
+  \\"\\"\\"
+  notLikeUnaccentInsensitive: Char4Domain
 
   \\"\\"\\"Does not start with the specified string (case-sensitive).\\"\\"\\"
   notStartsWith: Char4Domain
@@ -5949,6 +5969,9 @@ input StringFilter {
   \\"\\"\\"Contains the specified string (case-insensitive).\\"\\"\\"
   includesInsensitive: String
 
+  \\"\\"\\"Contains the specified string (unaccented case-insensitive).\\"\\"\\"
+  includesUnaccentInsensitive: String
+
   \\"\\"\\"
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
   \\"\\"\\"
@@ -5977,6 +6000,13 @@ input StringFilter {
   any single character; a percent sign (%) matches any sequence of zero or more characters.
   \\"\\"\\"
   likeInsensitive: String
+
+  \\"\\"\\"
+  Matches the specified pattern (unaccented case-insensitive). An underscore (_)
+  matches any single character; a percent sign (%) matches any sequence of zero
+  or more characters.
+  \\"\\"\\"
+  likeUnaccentInsensitive: String
 
   \\"\\"\\"Not equal to the specified value.\\"\\"\\"
   ne: String
@@ -6010,6 +6040,9 @@ input StringFilter {
   \\"\\"\\"Does not contain the specified string (case-insensitive).\\"\\"\\"
   notIncludesInsensitive: String
 
+  \\"\\"\\"Does not contain the specified string (unaccented case-insensitive).\\"\\"\\"
+  notIncludesUnaccentInsensitive: String
+
   \\"\\"\\"
   Does not match the specified pattern (case-sensitive). An underscore (_)
   matches any single character; a percent sign (%) matches any sequence of zero
@@ -6023,6 +6056,13 @@ input StringFilter {
   or more characters.
   \\"\\"\\"
   notLikeInsensitive: String
+
+  \\"\\"\\"
+  Does not match the specified pattern (unaccented case-insensitive). An
+  underscore (_) matches any single character; a percent sign (%) matches any
+  sequence of zero or more characters.
+  \\"\\"\\"
+  notLikeUnaccentInsensitive: String
 
   \\"\\"\\"Does not start with the specified string (case-sensitive).\\"\\"\\"
   notStartsWith: String

--- a/__tests__/integration/schema/__snapshots__/relationsTrue.test.ts.snap
+++ b/__tests__/integration/schema/__snapshots__/relationsTrue.test.ts.snap
@@ -1230,6 +1230,9 @@ input Char4DomainFilter {
   \\"\\"\\"Contains the specified string (case-insensitive).\\"\\"\\"
   includesInsensitive: Char4Domain
 
+  \\"\\"\\"Contains the specified string (unaccented case-insensitive).\\"\\"\\"
+  includesUnaccentInsensitive: Char4Domain
+
   \\"\\"\\"
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
   \\"\\"\\"
@@ -1258,6 +1261,13 @@ input Char4DomainFilter {
   any single character; a percent sign (%) matches any sequence of zero or more characters.
   \\"\\"\\"
   likeInsensitive: Char4Domain
+
+  \\"\\"\\"
+  Matches the specified pattern (unaccented case-insensitive). An underscore (_)
+  matches any single character; a percent sign (%) matches any sequence of zero
+  or more characters.
+  \\"\\"\\"
+  likeUnaccentInsensitive: Char4Domain
 
   \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
   notDistinctFrom: Char4Domain
@@ -1291,6 +1301,9 @@ input Char4DomainFilter {
   \\"\\"\\"Does not contain the specified string (case-insensitive).\\"\\"\\"
   notIncludesInsensitive: Char4Domain
 
+  \\"\\"\\"Does not contain the specified string (unaccented case-insensitive).\\"\\"\\"
+  notIncludesUnaccentInsensitive: Char4Domain
+
   \\"\\"\\"
   Does not match the specified pattern (case-sensitive). An underscore (_)
   matches any single character; a percent sign (%) matches any sequence of zero
@@ -1304,6 +1317,13 @@ input Char4DomainFilter {
   or more characters.
   \\"\\"\\"
   notLikeInsensitive: Char4Domain
+
+  \\"\\"\\"
+  Does not match the specified pattern (unaccented case-insensitive). An
+  underscore (_) matches any single character; a percent sign (%) matches any
+  sequence of zero or more characters.
+  \\"\\"\\"
+  notLikeUnaccentInsensitive: Char4Domain
 
   \\"\\"\\"Does not start with the specified string (case-sensitive).\\"\\"\\"
   notStartsWith: Char4Domain
@@ -6166,6 +6186,9 @@ input StringFilter {
   \\"\\"\\"Contains the specified string (case-insensitive).\\"\\"\\"
   includesInsensitive: String
 
+  \\"\\"\\"Contains the specified string (unaccented case-insensitive).\\"\\"\\"
+  includesUnaccentInsensitive: String
+
   \\"\\"\\"
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
   \\"\\"\\"
@@ -6194,6 +6217,13 @@ input StringFilter {
   any single character; a percent sign (%) matches any sequence of zero or more characters.
   \\"\\"\\"
   likeInsensitive: String
+
+  \\"\\"\\"
+  Matches the specified pattern (unaccented case-insensitive). An underscore (_)
+  matches any single character; a percent sign (%) matches any sequence of zero
+  or more characters.
+  \\"\\"\\"
+  likeUnaccentInsensitive: String
 
   \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
   notDistinctFrom: String
@@ -6227,6 +6257,9 @@ input StringFilter {
   \\"\\"\\"Does not contain the specified string (case-insensitive).\\"\\"\\"
   notIncludesInsensitive: String
 
+  \\"\\"\\"Does not contain the specified string (unaccented case-insensitive).\\"\\"\\"
+  notIncludesUnaccentInsensitive: String
+
   \\"\\"\\"
   Does not match the specified pattern (case-sensitive). An underscore (_)
   matches any single character; a percent sign (%) matches any sequence of zero
@@ -6240,6 +6273,13 @@ input StringFilter {
   or more characters.
   \\"\\"\\"
   notLikeInsensitive: String
+
+  \\"\\"\\"
+  Does not match the specified pattern (unaccented case-insensitive). An
+  underscore (_) matches any single character; a percent sign (%) matches any
+  sequence of zero or more characters.
+  \\"\\"\\"
+  notLikeUnaccentInsensitive: String
 
   \\"\\"\\"Does not start with the specified string (case-sensitive).\\"\\"\\"
   notStartsWith: String

--- a/__tests__/integration/schema/__snapshots__/setofFunctionsFalse.test.ts.snap
+++ b/__tests__/integration/schema/__snapshots__/setofFunctionsFalse.test.ts.snap
@@ -1219,6 +1219,9 @@ input Char4DomainFilter {
   \\"\\"\\"Contains the specified string (case-insensitive).\\"\\"\\"
   includesInsensitive: Char4Domain
 
+  \\"\\"\\"Contains the specified string (unaccented case-insensitive).\\"\\"\\"
+  includesUnaccentInsensitive: Char4Domain
+
   \\"\\"\\"
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
   \\"\\"\\"
@@ -1247,6 +1250,13 @@ input Char4DomainFilter {
   any single character; a percent sign (%) matches any sequence of zero or more characters.
   \\"\\"\\"
   likeInsensitive: Char4Domain
+
+  \\"\\"\\"
+  Matches the specified pattern (unaccented case-insensitive). An underscore (_)
+  matches any single character; a percent sign (%) matches any sequence of zero
+  or more characters.
+  \\"\\"\\"
+  likeUnaccentInsensitive: Char4Domain
 
   \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
   notDistinctFrom: Char4Domain
@@ -1280,6 +1290,9 @@ input Char4DomainFilter {
   \\"\\"\\"Does not contain the specified string (case-insensitive).\\"\\"\\"
   notIncludesInsensitive: Char4Domain
 
+  \\"\\"\\"Does not contain the specified string (unaccented case-insensitive).\\"\\"\\"
+  notIncludesUnaccentInsensitive: Char4Domain
+
   \\"\\"\\"
   Does not match the specified pattern (case-sensitive). An underscore (_)
   matches any single character; a percent sign (%) matches any sequence of zero
@@ -1293,6 +1306,13 @@ input Char4DomainFilter {
   or more characters.
   \\"\\"\\"
   notLikeInsensitive: Char4Domain
+
+  \\"\\"\\"
+  Does not match the specified pattern (unaccented case-insensitive). An
+  underscore (_) matches any single character; a percent sign (%) matches any
+  sequence of zero or more characters.
+  \\"\\"\\"
+  notLikeUnaccentInsensitive: Char4Domain
 
   \\"\\"\\"Does not start with the specified string (case-sensitive).\\"\\"\\"
   notStartsWith: Char4Domain
@@ -5881,6 +5901,9 @@ input StringFilter {
   \\"\\"\\"Contains the specified string (case-insensitive).\\"\\"\\"
   includesInsensitive: String
 
+  \\"\\"\\"Contains the specified string (unaccented case-insensitive).\\"\\"\\"
+  includesUnaccentInsensitive: String
+
   \\"\\"\\"
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
   \\"\\"\\"
@@ -5909,6 +5932,13 @@ input StringFilter {
   any single character; a percent sign (%) matches any sequence of zero or more characters.
   \\"\\"\\"
   likeInsensitive: String
+
+  \\"\\"\\"
+  Matches the specified pattern (unaccented case-insensitive). An underscore (_)
+  matches any single character; a percent sign (%) matches any sequence of zero
+  or more characters.
+  \\"\\"\\"
+  likeUnaccentInsensitive: String
 
   \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
   notDistinctFrom: String
@@ -5942,6 +5972,9 @@ input StringFilter {
   \\"\\"\\"Does not contain the specified string (case-insensitive).\\"\\"\\"
   notIncludesInsensitive: String
 
+  \\"\\"\\"Does not contain the specified string (unaccented case-insensitive).\\"\\"\\"
+  notIncludesUnaccentInsensitive: String
+
   \\"\\"\\"
   Does not match the specified pattern (case-sensitive). An underscore (_)
   matches any single character; a percent sign (%) matches any sequence of zero
@@ -5955,6 +5988,13 @@ input StringFilter {
   or more characters.
   \\"\\"\\"
   notLikeInsensitive: String
+
+  \\"\\"\\"
+  Does not match the specified pattern (unaccented case-insensitive). An
+  underscore (_) matches any single character; a percent sign (%) matches any
+  sequence of zero or more characters.
+  \\"\\"\\"
+  notLikeUnaccentInsensitive: String
 
   \\"\\"\\"Does not start with the specified string (case-sensitive).\\"\\"\\"
   notStartsWith: String

--- a/__tests__/integration/schema/__snapshots__/useCustomNetworkScalars.test.ts.snap
+++ b/__tests__/integration/schema/__snapshots__/useCustomNetworkScalars.test.ts.snap
@@ -1225,6 +1225,9 @@ input Char4DomainFilter {
   \\"\\"\\"Contains the specified string (case-insensitive).\\"\\"\\"
   includesInsensitive: Char4Domain
 
+  \\"\\"\\"Contains the specified string (unaccented case-insensitive).\\"\\"\\"
+  includesUnaccentInsensitive: Char4Domain
+
   \\"\\"\\"
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
   \\"\\"\\"
@@ -1253,6 +1256,13 @@ input Char4DomainFilter {
   any single character; a percent sign (%) matches any sequence of zero or more characters.
   \\"\\"\\"
   likeInsensitive: Char4Domain
+
+  \\"\\"\\"
+  Matches the specified pattern (unaccented case-insensitive). An underscore (_)
+  matches any single character; a percent sign (%) matches any sequence of zero
+  or more characters.
+  \\"\\"\\"
+  likeUnaccentInsensitive: Char4Domain
 
   \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
   notDistinctFrom: Char4Domain
@@ -1286,6 +1296,9 @@ input Char4DomainFilter {
   \\"\\"\\"Does not contain the specified string (case-insensitive).\\"\\"\\"
   notIncludesInsensitive: Char4Domain
 
+  \\"\\"\\"Does not contain the specified string (unaccented case-insensitive).\\"\\"\\"
+  notIncludesUnaccentInsensitive: Char4Domain
+
   \\"\\"\\"
   Does not match the specified pattern (case-sensitive). An underscore (_)
   matches any single character; a percent sign (%) matches any sequence of zero
@@ -1299,6 +1312,13 @@ input Char4DomainFilter {
   or more characters.
   \\"\\"\\"
   notLikeInsensitive: Char4Domain
+
+  \\"\\"\\"
+  Does not match the specified pattern (unaccented case-insensitive). An
+  underscore (_) matches any single character; a percent sign (%) matches any
+  sequence of zero or more characters.
+  \\"\\"\\"
+  notLikeUnaccentInsensitive: Char4Domain
 
   \\"\\"\\"Does not start with the specified string (case-sensitive).\\"\\"\\"
   notStartsWith: Char4Domain
@@ -6192,6 +6212,9 @@ input StringFilter {
   \\"\\"\\"Contains the specified string (case-insensitive).\\"\\"\\"
   includesInsensitive: String
 
+  \\"\\"\\"Contains the specified string (unaccented case-insensitive).\\"\\"\\"
+  includesUnaccentInsensitive: String
+
   \\"\\"\\"
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
   \\"\\"\\"
@@ -6220,6 +6243,13 @@ input StringFilter {
   any single character; a percent sign (%) matches any sequence of zero or more characters.
   \\"\\"\\"
   likeInsensitive: String
+
+  \\"\\"\\"
+  Matches the specified pattern (unaccented case-insensitive). An underscore (_)
+  matches any single character; a percent sign (%) matches any sequence of zero
+  or more characters.
+  \\"\\"\\"
+  likeUnaccentInsensitive: String
 
   \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
   notDistinctFrom: String
@@ -6253,6 +6283,9 @@ input StringFilter {
   \\"\\"\\"Does not contain the specified string (case-insensitive).\\"\\"\\"
   notIncludesInsensitive: String
 
+  \\"\\"\\"Does not contain the specified string (unaccented case-insensitive).\\"\\"\\"
+  notIncludesUnaccentInsensitive: String
+
   \\"\\"\\"
   Does not match the specified pattern (case-sensitive). An underscore (_)
   matches any single character; a percent sign (%) matches any sequence of zero
@@ -6266,6 +6299,13 @@ input StringFilter {
   or more characters.
   \\"\\"\\"
   notLikeInsensitive: String
+
+  \\"\\"\\"
+  Does not match the specified pattern (unaccented case-insensitive). An
+  underscore (_) matches any single character; a percent sign (%) matches any
+  sequence of zero or more characters.
+  \\"\\"\\"
+  notLikeUnaccentInsensitive: String
 
   \\"\\"\\"Does not start with the specified string (case-sensitive).\\"\\"\\"
   notStartsWith: String

--- a/__tests__/p-schema.sql
+++ b/__tests__/p-schema.sql
@@ -1,5 +1,6 @@
 create extension if not exists hstore;
 create extension if not exists citext;
+create extension if not exists unaccent;
 
 drop schema if exists p cascade;
 

--- a/src/PgConnectionArgFilterOperatorsPlugin.ts
+++ b/src/PgConnectionArgFilterOperatorsPlugin.ts
@@ -201,6 +201,31 @@ const PgConnectionArgFilterOperatorsPlugin: Plugin = (
         resolveSqlIdentifier: (i) => i, // avoid casting citext to text
         resolve: (i, v) => sql.query`${i} NOT ILIKE ${v}`,
       },
+      includesUnaccentInsensitive: {
+        description: "Contains the specified string (unaccented case-insensitive).",
+        resolveInput: (input) => `%${escapeLikeWildcards(input)}%`,
+        resolveSqlIdentifier: (i) => i, // avoid casting citext to text
+        resolve: (i, v) => sql.query`UNACCENT(${i}) ILIKE UNACCENT(${v})`,
+      },
+      notIncludesUnaccentInsensitive: {
+        description:
+          "Does not contain the specified string (unaccented case-insensitive).",
+        resolveInput: (input) => `%${escapeLikeWildcards(input)}%`,
+        resolveSqlIdentifier: (i) => i, // avoid casting citext to text
+        resolve: (i, v) => sql.query`UNACCENT(${i}) NOT ILIKE UNACCENT(${v})`,
+      },
+      likeUnaccentInsensitive: {
+        description:
+          "Matches the specified pattern (unaccented case-insensitive). An underscore (_) matches any single character; a percent sign (%) matches any sequence of zero or more characters.",
+        resolveSqlIdentifier: (i) => i, // avoid casting citext to text
+        resolve: (i, v) => sql.query`UNACCENT(${i}) ILIKE UNACCENT(${v})`,
+      },
+      notLikeUnaccentInsensitive: {
+        description:
+          "Does not match the specified pattern (unaccented case-insensitive). An underscore (_) matches any single character; a percent sign (%) matches any sequence of zero or more characters.",
+        resolveSqlIdentifier: (i) => i, // avoid casting citext to text
+        resolve: (i, v) => sql.query`UNACCENT(${i}) NOT ILIKE UNACCENT(${v})`,
+      },
     };
     const hstoreOperators: { [fieldName: string]: OperatorSpec } = {
       contains: {


### PR DESCRIPTION
This PR adds 4 new operators:
* `includesUnaccentInsensitive`: Contains the specified string (unaccented case-insensitive).
* `notIncludesUnaccentInsensitive`: Does not contain the specified string (unaccented case-insensitive).
* `likeUnaccentInsensitive`: Matches the specified pattern (unaccented case-insensitive).
* `notLikeUnaccentInsensitive`: Does not match the specified pattern (unaccented case-insensitive).

@mattbretl do you think it is possible to add these operators?