### PR TITLE
chore: use jest-serializer-graphql-schema for schema snapshots

### DIFF
--- a/__tests__/integration/schema/__snapshots__/addConnectionFilterOperator.test.ts.snap
+++ b/__tests__/integration/schema/__snapshots__/addConnectionFilterOperator.test.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`prints a schema with the filter plugin and a custom operators plugin using addConnectionFilterOperator 1`] = `
-"type ArrayType implements Node {
+type ArrayType implements Node {
   bit4Array: [BitString]
   boolArray: [Boolean]
   bpchar4Array: [String]
@@ -25,9 +25,9 @@ exports[`prints a schema with the filter plugin and a custom operators plugin us
   moneyArray: [Float]
   nameArray: [String]
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
   numericArray: [BigFloat]
   textArray: [String]
@@ -41,128 +41,128 @@ exports[`prints a schema with the filter plugin and a custom operators plugin us
   xmlArray: [String]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`ArrayType\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input ArrayTypeFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [ArrayTypeFilter!]
 
-  \\"\\"\\"Filter by the object’s \`bit4Array\` field.\\"\\"\\"
+  """Filter by the object’s \`bit4Array\` field."""
   bit4Array: BitStringListFilter
 
-  \\"\\"\\"Filter by the object’s \`boolArray\` field.\\"\\"\\"
+  """Filter by the object’s \`boolArray\` field."""
   boolArray: BooleanListFilter
 
-  \\"\\"\\"Filter by the object’s \`bpchar4Array\` field.\\"\\"\\"
+  """Filter by the object’s \`bpchar4Array\` field."""
   bpchar4Array: StringListFilter
 
-  \\"\\"\\"Filter by the object’s \`char4Array\` field.\\"\\"\\"
+  """Filter by the object’s \`char4Array\` field."""
   char4Array: StringListFilter
 
-  \\"\\"\\"Filter by the object’s \`citextArray\` field.\\"\\"\\"
+  """Filter by the object’s \`citextArray\` field."""
   citextArray: StringListFilter
 
-  \\"\\"\\"Filter by the object’s \`dateArray\` field.\\"\\"\\"
+  """Filter by the object’s \`dateArray\` field."""
   dateArray: DateListFilter
 
-  \\"\\"\\"Filter by the object’s \`float4Array\` field.\\"\\"\\"
+  """Filter by the object’s \`float4Array\` field."""
   float4Array: FloatListFilter
 
-  \\"\\"\\"Filter by the object’s \`float8Array\` field.\\"\\"\\"
+  """Filter by the object’s \`float8Array\` field."""
   float8Array: FloatListFilter
 
-  \\"\\"\\"Filter by the object’s \`hstoreArray\` field.\\"\\"\\"
+  """Filter by the object’s \`hstoreArray\` field."""
   hstoreArray: KeyValueHashListFilter
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`inetArray\` field.\\"\\"\\"
+  """Filter by the object’s \`inetArray\` field."""
   inetArray: InternetAddressListFilter
 
-  \\"\\"\\"Filter by the object’s \`int2Array\` field.\\"\\"\\"
+  """Filter by the object’s \`int2Array\` field."""
   int2Array: IntListFilter
 
-  \\"\\"\\"Filter by the object’s \`int4Array\` field.\\"\\"\\"
+  """Filter by the object’s \`int4Array\` field."""
   int4Array: IntListFilter
 
-  \\"\\"\\"Filter by the object’s \`int8Array\` field.\\"\\"\\"
+  """Filter by the object’s \`int8Array\` field."""
   int8Array: BigIntListFilter
 
-  \\"\\"\\"Filter by the object’s \`intervalArray\` field.\\"\\"\\"
+  """Filter by the object’s \`intervalArray\` field."""
   intervalArray: IntervalListFilter
 
-  \\"\\"\\"Filter by the object’s \`jsonbArray\` field.\\"\\"\\"
+  """Filter by the object’s \`jsonbArray\` field."""
   jsonbArray: JSONListFilter
 
-  \\"\\"\\"Filter by the object’s \`moneyArray\` field.\\"\\"\\"
+  """Filter by the object’s \`moneyArray\` field."""
   moneyArray: FloatListFilter
 
-  \\"\\"\\"Filter by the object’s \`nameArray\` field.\\"\\"\\"
+  """Filter by the object’s \`nameArray\` field."""
   nameArray: StringListFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: ArrayTypeFilter
 
-  \\"\\"\\"Filter by the object’s \`numericArray\` field.\\"\\"\\"
+  """Filter by the object’s \`numericArray\` field."""
   numericArray: BigFloatListFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [ArrayTypeFilter!]
 
-  \\"\\"\\"Filter by the object’s \`textArray\` field.\\"\\"\\"
+  """Filter by the object’s \`textArray\` field."""
   textArray: StringListFilter
 
-  \\"\\"\\"Filter by the object’s \`timeArray\` field.\\"\\"\\"
+  """Filter by the object’s \`timeArray\` field."""
   timeArray: TimeListFilter
 
-  \\"\\"\\"Filter by the object’s \`timestampArray\` field.\\"\\"\\"
+  """Filter by the object’s \`timestampArray\` field."""
   timestampArray: DatetimeListFilter
 
-  \\"\\"\\"Filter by the object’s \`timestamptzArray\` field.\\"\\"\\"
+  """Filter by the object’s \`timestamptzArray\` field."""
   timestamptzArray: DatetimeListFilter
 
-  \\"\\"\\"Filter by the object’s \`timetzArray\` field.\\"\\"\\"
+  """Filter by the object’s \`timetzArray\` field."""
   timetzArray: TimeListFilter
 
-  \\"\\"\\"Filter by the object’s \`uuidArray\` field.\\"\\"\\"
+  """Filter by the object’s \`uuidArray\` field."""
   uuidArray: UUIDListFilter
 
-  \\"\\"\\"Filter by the object’s \`varbitArray\` field.\\"\\"\\"
+  """Filter by the object’s \`varbitArray\` field."""
   varbitArray: BitStringListFilter
 
-  \\"\\"\\"Filter by the object’s \`varcharArray\` field.\\"\\"\\"
+  """Filter by the object’s \`varcharArray\` field."""
   varcharArray: StringListFilter
 }
 
-\\"\\"\\"A connection to a list of \`ArrayType\` values.\\"\\"\\"
+"""A connection to a list of \`ArrayType\` values."""
 type ArrayTypesConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`ArrayType\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [ArrayTypesEdge!]!
 
-  \\"\\"\\"A list of \`ArrayType\` objects.\\"\\"\\"
+  """A list of \`ArrayType\` objects."""
   nodes: [ArrayType]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`ArrayType\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`ArrayType\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`ArrayType\` edge in the connection.\\"\\"\\"
+"""A \`ArrayType\` edge in the connection."""
 type ArrayTypesEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`ArrayType\` at the end of the edge.\\"\\"\\"
+  """The \`ArrayType\` at the end of the edge."""
   node: ArrayType
 }
 
-\\"\\"\\"Methods to use when ordering \`ArrayType\`.\\"\\"\\"
+"""Methods to use when ordering \`ArrayType\`."""
 enum ArrayTypesOrderBy {
   BIT4_ARRAY_ASC
   BIT4_ARRAY_DESC
@@ -234,15 +234,15 @@ enum ArrayTypesOrderBy {
 }
 
 type Backward implements Node {
-  \\"\\"\\"Reads a single \`Filterable\` that is related to this \`Backward\`.\\"\\"\\"
+  """Reads a single \`Filterable\` that is related to this \`Backward\`."""
   filterableByFilterableId: Filterable
   filterableId: Int
   id: Int!
   name: String!
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
@@ -250,70 +250,70 @@ type BackwardCompound implements Node {
   backwardCompound1: Int!
   backwardCompound2: Int!
 
-  \\"\\"\\"
+  """
   Reads a single \`Filterable\` that is related to this \`BackwardCompound\`.
-  \\"\\"\\"
+  """
   filterableByBackwardCompound1AndBackwardCompound2: Filterable
   name: String
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`BackwardCompound\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input BackwardCompoundFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [BackwardCompoundFilter!]
 
-  \\"\\"\\"Filter by the object’s \`backwardCompound1\` field.\\"\\"\\"
+  """Filter by the object’s \`backwardCompound1\` field."""
   backwardCompound1: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`backwardCompound2\` field.\\"\\"\\"
+  """Filter by the object’s \`backwardCompound2\` field."""
   backwardCompound2: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`name\` field.\\"\\"\\"
+  """Filter by the object’s \`name\` field."""
   name: StringFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: BackwardCompoundFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [BackwardCompoundFilter!]
 }
 
-\\"\\"\\"A connection to a list of \`BackwardCompound\` values.\\"\\"\\"
+"""A connection to a list of \`BackwardCompound\` values."""
 type BackwardCompoundsConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`BackwardCompound\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [BackwardCompoundsEdge!]!
 
-  \\"\\"\\"A list of \`BackwardCompound\` objects.\\"\\"\\"
+  """A list of \`BackwardCompound\` objects."""
   nodes: [BackwardCompound]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"
+  """
   The count of *all* \`BackwardCompound\` you could get from the connection.
-  \\"\\"\\"
+  """
   totalCount: Int!
 }
 
-\\"\\"\\"A \`BackwardCompound\` edge in the connection.\\"\\"\\"
+"""A \`BackwardCompound\` edge in the connection."""
 type BackwardCompoundsEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`BackwardCompound\` at the end of the edge.\\"\\"\\"
+  """The \`BackwardCompound\` at the end of the edge."""
   node: BackwardCompound
 }
 
-\\"\\"\\"Methods to use when ordering \`BackwardCompound\`.\\"\\"\\"
+"""Methods to use when ordering \`BackwardCompound\`."""
 enum BackwardCompoundsOrderBy {
   BACKWARD_COMPOUND_1_ASC
   BACKWARD_COMPOUND_1_DESC
@@ -326,56 +326,56 @@ enum BackwardCompoundsOrderBy {
   PRIMARY_KEY_DESC
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`Backward\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input BackwardFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [BackwardFilter!]
 
-  \\"\\"\\"Filter by the object’s \`filterableId\` field.\\"\\"\\"
+  """Filter by the object’s \`filterableId\` field."""
   filterableId: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`name\` field.\\"\\"\\"
+  """Filter by the object’s \`name\` field."""
   name: StringFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: BackwardFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [BackwardFilter!]
 }
 
-\\"\\"\\"A connection to a list of \`Backward\` values.\\"\\"\\"
+"""A connection to a list of \`Backward\` values."""
 type BackwardsConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`Backward\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [BackwardsEdge!]!
 
-  \\"\\"\\"A list of \`Backward\` objects.\\"\\"\\"
+  """A list of \`Backward\` objects."""
   nodes: [Backward]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`Backward\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`Backward\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`Backward\` edge in the connection.\\"\\"\\"
+"""A \`Backward\` edge in the connection."""
 type BackwardsEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`Backward\` at the end of the edge.\\"\\"\\"
+  """The \`Backward\` at the end of the edge."""
   node: Backward
 }
 
-\\"\\"\\"Methods to use when ordering \`Backward\`.\\"\\"\\"
+"""Methods to use when ordering \`Backward\`."""
 enum BackwardsOrderBy {
   FILTERABLE_ID_ASC
   FILTERABLE_ID_DESC
@@ -388,1037 +388,1037 @@ enum BackwardsOrderBy {
   PRIMARY_KEY_DESC
 }
 
-\\"\\"\\"
+"""
 A floating point number that requires more precision than IEEE 754 binary 64
-\\"\\"\\"
+"""
 scalar BigFloat
 
-\\"\\"\\"
+"""
 A filter to be used against BigFloat fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input BigFloatFilter {
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: BigFloat
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: BigFloat
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: BigFloat
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: BigFloat
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [BigFloat!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: BigFloat
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: BigFloat
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: BigFloat
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: BigFloat
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [BigFloat!]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against BigFloat List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input BigFloatListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: BigFloat
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: BigFloat
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: BigFloat
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: BigFloat
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: BigFloat
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: BigFloat
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [BigFloat]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [BigFloat]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [BigFloat]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [BigFloat]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [BigFloat]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [BigFloat]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [BigFloat]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [BigFloat]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [BigFloat]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [BigFloat]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [BigFloat]
 }
 
-\\"\\"\\"A range of \`BigFloat\`.\\"\\"\\"
+"""A range of \`BigFloat\`."""
 type BigFloatRange {
-  \\"\\"\\"The ending bound of our range.\\"\\"\\"
+  """The ending bound of our range."""
   end: BigFloatRangeBound
 
-  \\"\\"\\"The starting bound of our range.\\"\\"\\"
+  """The starting bound of our range."""
   start: BigFloatRangeBound
 }
 
-\\"\\"\\"
+"""
 The value at one end of a range. A range can either include this value, or not.
-\\"\\"\\"
+"""
 type BigFloatRangeBound {
-  \\"\\"\\"Whether or not the value of this bound is included in the range.\\"\\"\\"
+  """Whether or not the value of this bound is included in the range."""
   inclusive: Boolean!
 
-  \\"\\"\\"The value at one end of our range.\\"\\"\\"
+  """The value at one end of our range."""
   value: BigFloat!
 }
 
-\\"\\"\\"
+"""
 The value at one end of a range. A range can either include this value, or not.
-\\"\\"\\"
+"""
 input BigFloatRangeBoundInput {
-  \\"\\"\\"Whether or not the value of this bound is included in the range.\\"\\"\\"
+  """Whether or not the value of this bound is included in the range."""
   inclusive: Boolean!
 
-  \\"\\"\\"The value at one end of our range.\\"\\"\\"
+  """The value at one end of our range."""
   value: BigFloat!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against BigFloatRange fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input BigFloatRangeFilter {
-  \\"\\"\\"Adjacent to the specified range.\\"\\"\\"
+  """Adjacent to the specified range."""
   adjacentTo: BigFloatRangeInput
 
-  \\"\\"\\"Contained by the specified range.\\"\\"\\"
+  """Contained by the specified range."""
   containedBy: BigFloatRangeInput
 
-  \\"\\"\\"Contains the specified range.\\"\\"\\"
+  """Contains the specified range."""
   contains: BigFloatRangeInput
 
-  \\"\\"\\"Contains the specified value.\\"\\"\\"
+  """Contains the specified value."""
   containsElement: BigFloat
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: BigFloatRangeInput
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: BigFloatRangeInput
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: BigFloatRangeInput
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: BigFloatRangeInput
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [BigFloatRangeInput!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: BigFloatRangeInput
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: BigFloatRangeInput
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: BigFloatRangeInput
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: BigFloatRangeInput
 
-  \\"\\"\\"Does not extend left of the specified range.\\"\\"\\"
+  """Does not extend left of the specified range."""
   notExtendsLeftOf: BigFloatRangeInput
 
-  \\"\\"\\"Does not extend right of the specified range.\\"\\"\\"
+  """Does not extend right of the specified range."""
   notExtendsRightOf: BigFloatRangeInput
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [BigFloatRangeInput!]
 
-  \\"\\"\\"Overlaps the specified range.\\"\\"\\"
+  """Overlaps the specified range."""
   overlaps: BigFloatRangeInput
 
-  \\"\\"\\"Strictly left of the specified range.\\"\\"\\"
+  """Strictly left of the specified range."""
   strictlyLeftOf: BigFloatRangeInput
 
-  \\"\\"\\"Strictly right of the specified range.\\"\\"\\"
+  """Strictly right of the specified range."""
   strictlyRightOf: BigFloatRangeInput
 }
 
-\\"\\"\\"A range of \`BigFloat\`.\\"\\"\\"
+"""A range of \`BigFloat\`."""
 input BigFloatRangeInput {
-  \\"\\"\\"The ending bound of our range.\\"\\"\\"
+  """The ending bound of our range."""
   end: BigFloatRangeBoundInput
 
-  \\"\\"\\"The starting bound of our range.\\"\\"\\"
+  """The starting bound of our range."""
   start: BigFloatRangeBoundInput
 }
 
-\\"\\"\\"
+"""
 A filter to be used against BigFloatRange List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input BigFloatRangeListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: BigFloatRangeInput
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: BigFloatRangeInput
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: BigFloatRangeInput
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: BigFloatRangeInput
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: BigFloatRangeInput
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: BigFloatRangeInput
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [BigFloatRangeInput]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [BigFloatRangeInput]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [BigFloatRangeInput]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [BigFloatRangeInput]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [BigFloatRangeInput]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [BigFloatRangeInput]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [BigFloatRangeInput]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [BigFloatRangeInput]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [BigFloatRangeInput]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [BigFloatRangeInput]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [BigFloatRangeInput]
 }
 
-\\"\\"\\"
+"""
 A signed eight-byte integer. The upper big integer values are greater than the
 max value for a JavaScript number. Therefore all big integers will be output as
 strings and not numbers.
-\\"\\"\\"
+"""
 scalar BigInt
 
-\\"\\"\\"
+"""
 A filter to be used against BigInt fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input BigIntFilter {
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: BigInt
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: BigInt
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: BigInt
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: BigInt
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [BigInt!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: BigInt
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: BigInt
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: BigInt
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: BigInt
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [BigInt!]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against BigInt List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input BigIntListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: BigInt
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: BigInt
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: BigInt
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: BigInt
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: BigInt
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: BigInt
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [BigInt]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [BigInt]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [BigInt]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [BigInt]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [BigInt]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [BigInt]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [BigInt]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [BigInt]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [BigInt]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [BigInt]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [BigInt]
 }
 
-\\"\\"\\"A range of \`BigInt\`.\\"\\"\\"
+"""A range of \`BigInt\`."""
 type BigIntRange {
-  \\"\\"\\"The ending bound of our range.\\"\\"\\"
+  """The ending bound of our range."""
   end: BigIntRangeBound
 
-  \\"\\"\\"The starting bound of our range.\\"\\"\\"
+  """The starting bound of our range."""
   start: BigIntRangeBound
 }
 
-\\"\\"\\"
+"""
 The value at one end of a range. A range can either include this value, or not.
-\\"\\"\\"
+"""
 type BigIntRangeBound {
-  \\"\\"\\"Whether or not the value of this bound is included in the range.\\"\\"\\"
+  """Whether or not the value of this bound is included in the range."""
   inclusive: Boolean!
 
-  \\"\\"\\"The value at one end of our range.\\"\\"\\"
+  """The value at one end of our range."""
   value: BigInt!
 }
 
-\\"\\"\\"
+"""
 The value at one end of a range. A range can either include this value, or not.
-\\"\\"\\"
+"""
 input BigIntRangeBoundInput {
-  \\"\\"\\"Whether or not the value of this bound is included in the range.\\"\\"\\"
+  """Whether or not the value of this bound is included in the range."""
   inclusive: Boolean!
 
-  \\"\\"\\"The value at one end of our range.\\"\\"\\"
+  """The value at one end of our range."""
   value: BigInt!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against BigIntRange fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input BigIntRangeFilter {
-  \\"\\"\\"Adjacent to the specified range.\\"\\"\\"
+  """Adjacent to the specified range."""
   adjacentTo: BigIntRangeInput
 
-  \\"\\"\\"Contained by the specified range.\\"\\"\\"
+  """Contained by the specified range."""
   containedBy: BigIntRangeInput
 
-  \\"\\"\\"Contains the specified range.\\"\\"\\"
+  """Contains the specified range."""
   contains: BigIntRangeInput
 
-  \\"\\"\\"Contains the specified value.\\"\\"\\"
+  """Contains the specified value."""
   containsElement: BigInt
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: BigIntRangeInput
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: BigIntRangeInput
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: BigIntRangeInput
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: BigIntRangeInput
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [BigIntRangeInput!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: BigIntRangeInput
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: BigIntRangeInput
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: BigIntRangeInput
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: BigIntRangeInput
 
-  \\"\\"\\"Does not extend left of the specified range.\\"\\"\\"
+  """Does not extend left of the specified range."""
   notExtendsLeftOf: BigIntRangeInput
 
-  \\"\\"\\"Does not extend right of the specified range.\\"\\"\\"
+  """Does not extend right of the specified range."""
   notExtendsRightOf: BigIntRangeInput
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [BigIntRangeInput!]
 
-  \\"\\"\\"Overlaps the specified range.\\"\\"\\"
+  """Overlaps the specified range."""
   overlaps: BigIntRangeInput
 
-  \\"\\"\\"Strictly left of the specified range.\\"\\"\\"
+  """Strictly left of the specified range."""
   strictlyLeftOf: BigIntRangeInput
 
-  \\"\\"\\"Strictly right of the specified range.\\"\\"\\"
+  """Strictly right of the specified range."""
   strictlyRightOf: BigIntRangeInput
 }
 
-\\"\\"\\"A range of \`BigInt\`.\\"\\"\\"
+"""A range of \`BigInt\`."""
 input BigIntRangeInput {
-  \\"\\"\\"The ending bound of our range.\\"\\"\\"
+  """The ending bound of our range."""
   end: BigIntRangeBoundInput
 
-  \\"\\"\\"The starting bound of our range.\\"\\"\\"
+  """The starting bound of our range."""
   start: BigIntRangeBoundInput
 }
 
-\\"\\"\\"
+"""
 A filter to be used against BigIntRange List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input BigIntRangeListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: BigIntRangeInput
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: BigIntRangeInput
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: BigIntRangeInput
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: BigIntRangeInput
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: BigIntRangeInput
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: BigIntRangeInput
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [BigIntRangeInput]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [BigIntRangeInput]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [BigIntRangeInput]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [BigIntRangeInput]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [BigIntRangeInput]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [BigIntRangeInput]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [BigIntRangeInput]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [BigIntRangeInput]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [BigIntRangeInput]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [BigIntRangeInput]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [BigIntRangeInput]
 }
 
-\\"\\"\\"A string representing a series of binary bits\\"\\"\\"
+"""A string representing a series of binary bits"""
 scalar BitString
 
-\\"\\"\\"
+"""
 A filter to be used against BitString fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input BitStringFilter {
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: BitString
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: BitString
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: BitString
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: BitString
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [BitString!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: BitString
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: BitString
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: BitString
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: BitString
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [BitString!]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against BitString List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input BitStringListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: BitString
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: BitString
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: BitString
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: BitString
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: BitString
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: BitString
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [BitString]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [BitString]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [BitString]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [BitString]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [BitString]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [BitString]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [BitString]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [BitString]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [BitString]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [BitString]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [BitString]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against Boolean fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input BooleanFilter {
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: Boolean
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: Boolean
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: Boolean
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: Boolean
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [Boolean!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: Boolean
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: Boolean
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: Boolean
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: Boolean
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [Boolean!]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against Boolean List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input BooleanListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: Boolean
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: Boolean
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: Boolean
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: Boolean
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: Boolean
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: Boolean
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [Boolean]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [Boolean]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [Boolean]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [Boolean]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [Boolean]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [Boolean]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [Boolean]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [Boolean]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [Boolean]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [Boolean]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [Boolean]
 }
 
 scalar Char4Domain
 
-\\"\\"\\"
+"""
 A filter to be used against Char4Domain fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input Char4DomainFilter {
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: Char4Domain
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value (case-insensitive).
-  \\"\\"\\"
+  """
   distinctFromInsensitive: Char4Domain
 
-  \\"\\"\\"Ends with the specified string (case-sensitive).\\"\\"\\"
+  """Ends with the specified string (case-sensitive)."""
   endsWith: Char4Domain
 
-  \\"\\"\\"Ends with the specified string (case-insensitive).\\"\\"\\"
+  """Ends with the specified string (case-insensitive)."""
   endsWithInsensitive: Char4Domain
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: Char4Domain
 
-  \\"\\"\\"Equal to the specified value (case-insensitive).\\"\\"\\"
+  """Equal to the specified value (case-insensitive)."""
   equalToInsensitive: Char4Domain
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: Char4Domain
 
-  \\"\\"\\"Greater than the specified value (case-insensitive).\\"\\"\\"
+  """Greater than the specified value (case-insensitive)."""
   greaterThanInsensitive: Char4Domain
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: Char4Domain
 
-  \\"\\"\\"Greater than or equal to the specified value (case-insensitive).\\"\\"\\"
+  """Greater than or equal to the specified value (case-insensitive)."""
   greaterThanOrEqualToInsensitive: Char4Domain
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [Char4Domain!]
 
-  \\"\\"\\"Included in the specified list (case-insensitive).\\"\\"\\"
-  inInsensitive: [Char4Domain!]
-
-  \\"\\"\\"Contains the specified string (case-sensitive).\\"\\"\\"
+  """Contains the specified string (case-sensitive)."""
   includes: Char4Domain
 
-  \\"\\"\\"Contains the specified string (case-insensitive).\\"\\"\\"
+  """Contains the specified string (case-insensitive)."""
   includesInsensitive: Char4Domain
 
-  \\"\\"\\"
+  """Included in the specified list (case-insensitive)."""
+  inInsensitive: [Char4Domain!]
+
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: Char4Domain
 
-  \\"\\"\\"Less than the specified value (case-insensitive).\\"\\"\\"
+  """Less than the specified value (case-insensitive)."""
   lessThanInsensitive: Char4Domain
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: Char4Domain
 
-  \\"\\"\\"Less than or equal to the specified value (case-insensitive).\\"\\"\\"
+  """Less than or equal to the specified value (case-insensitive)."""
   lessThanOrEqualToInsensitive: Char4Domain
 
-  \\"\\"\\"
+  """
   Matches the specified pattern (case-sensitive). An underscore (_) matches any
   single character; a percent sign (%) matches any sequence of zero or more characters.
-  \\"\\"\\"
+  """
   like: Char4Domain
 
-  \\"\\"\\"
+  """
   Matches the specified pattern (case-insensitive). An underscore (_) matches
   any single character; a percent sign (%) matches any sequence of zero or more characters.
-  \\"\\"\\"
+  """
   likeInsensitive: Char4Domain
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: Char4Domain
 
-  \\"\\"\\"
+  """
   Equal to the specified value, treating null like an ordinary value (case-insensitive).
-  \\"\\"\\"
+  """
   notDistinctFromInsensitive: Char4Domain
 
-  \\"\\"\\"Does not end with the specified string (case-sensitive).\\"\\"\\"
+  """Does not end with the specified string (case-sensitive)."""
   notEndsWith: Char4Domain
 
-  \\"\\"\\"Does not end with the specified string (case-insensitive).\\"\\"\\"
+  """Does not end with the specified string (case-insensitive)."""
   notEndsWithInsensitive: Char4Domain
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: Char4Domain
 
-  \\"\\"\\"Not equal to the specified value (case-insensitive).\\"\\"\\"
+  """Not equal to the specified value (case-insensitive)."""
   notEqualToInsensitive: Char4Domain
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [Char4Domain!]
 
-  \\"\\"\\"Not included in the specified list (case-insensitive).\\"\\"\\"
-  notInInsensitive: [Char4Domain!]
-
-  \\"\\"\\"Does not contain the specified string (case-sensitive).\\"\\"\\"
+  """Does not contain the specified string (case-sensitive)."""
   notIncludes: Char4Domain
 
-  \\"\\"\\"Does not contain the specified string (case-insensitive).\\"\\"\\"
+  """Does not contain the specified string (case-insensitive)."""
   notIncludesInsensitive: Char4Domain
 
-  \\"\\"\\"
+  """Not included in the specified list (case-insensitive)."""
+  notInInsensitive: [Char4Domain!]
+
+  """
   Does not match the specified pattern (case-sensitive). An underscore (_)
   matches any single character; a percent sign (%) matches any sequence of zero
   or more characters.
-  \\"\\"\\"
+  """
   notLike: Char4Domain
 
-  \\"\\"\\"
+  """
   Does not match the specified pattern (case-insensitive). An underscore (_)
   matches any single character; a percent sign (%) matches any sequence of zero
   or more characters.
-  \\"\\"\\"
+  """
   notLikeInsensitive: Char4Domain
 
-  \\"\\"\\"Does not start with the specified string (case-sensitive).\\"\\"\\"
+  """Does not start with the specified string (case-sensitive)."""
   notStartsWith: Char4Domain
 
-  \\"\\"\\"Does not start with the specified string (case-insensitive).\\"\\"\\"
+  """Does not start with the specified string (case-insensitive)."""
   notStartsWithInsensitive: Char4Domain
 
-  \\"\\"\\"Starts with the specified string (case-sensitive).\\"\\"\\"
+  """Starts with the specified string (case-sensitive)."""
   startsWith: Char4Domain
 
-  \\"\\"\\"Starts with the specified string (case-insensitive).\\"\\"\\"
+  """Starts with the specified string (case-insensitive)."""
   startsWithInsensitive: Char4Domain
 }
 
 type Child implements Node {
-  \\"\\"\\"Reads a single \`Filterable\` that is related to this \`Child\`.\\"\\"\\"
+  """Reads a single \`Filterable\` that is related to this \`Child\`."""
   filterableByFilterableId: Filterable
   filterableId: Int
   id: Int!
   name: String!
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`Child\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input ChildFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [ChildFilter!]
 
-  \\"\\"\\"Filter by the object’s \`filterableId\` field.\\"\\"\\"
+  """Filter by the object’s \`filterableId\` field."""
   filterableId: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`name\` field.\\"\\"\\"
+  """Filter by the object’s \`name\` field."""
   name: StringFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: ChildFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [ChildFilter!]
 }
 
 type ChildNoRelatedFilter implements Node {
-  \\"\\"\\"
+  """
   Reads a single \`Filterable\` that is related to this \`ChildNoRelatedFilter\`.
-  \\"\\"\\"
+  """
   filterableByFilterableId: Filterable
   filterableId: Int
   id: Int!
   name: String!
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 
-  \\"\\"\\"
+  """
   Reads a single \`Unfilterable\` that is related to this \`ChildNoRelatedFilter\`.
-  \\"\\"\\"
+  """
   unfilterableByUnfilterableId: Unfilterable
   unfilterableId: Int
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`ChildNoRelatedFilter\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input ChildNoRelatedFilterFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [ChildNoRelatedFilterFilter!]
 
-  \\"\\"\\"Filter by the object’s \`filterableId\` field.\\"\\"\\"
+  """Filter by the object’s \`filterableId\` field."""
   filterableId: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`name\` field.\\"\\"\\"
+  """Filter by the object’s \`name\` field."""
   name: StringFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: ChildNoRelatedFilterFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [ChildNoRelatedFilterFilter!]
 
-  \\"\\"\\"Filter by the object’s \`unfilterableId\` field.\\"\\"\\"
+  """Filter by the object’s \`unfilterableId\` field."""
   unfilterableId: IntFilter
 }
 
-\\"\\"\\"A connection to a list of \`ChildNoRelatedFilter\` values.\\"\\"\\"
+"""A connection to a list of \`ChildNoRelatedFilter\` values."""
 type ChildNoRelatedFiltersConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`ChildNoRelatedFilter\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [ChildNoRelatedFiltersEdge!]!
 
-  \\"\\"\\"A list of \`ChildNoRelatedFilter\` objects.\\"\\"\\"
+  """A list of \`ChildNoRelatedFilter\` objects."""
   nodes: [ChildNoRelatedFilter]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"
+  """
   The count of *all* \`ChildNoRelatedFilter\` you could get from the connection.
-  \\"\\"\\"
+  """
   totalCount: Int!
 }
 
-\\"\\"\\"A \`ChildNoRelatedFilter\` edge in the connection.\\"\\"\\"
+"""A \`ChildNoRelatedFilter\` edge in the connection."""
 type ChildNoRelatedFiltersEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`ChildNoRelatedFilter\` at the end of the edge.\\"\\"\\"
+  """The \`ChildNoRelatedFilter\` at the end of the edge."""
   node: ChildNoRelatedFilter
 }
 
-\\"\\"\\"Methods to use when ordering \`ChildNoRelatedFilter\`.\\"\\"\\"
+"""Methods to use when ordering \`ChildNoRelatedFilter\`."""
 enum ChildNoRelatedFiltersOrderBy {
   FILTERABLE_ID_ASC
   FILTERABLE_ID_DESC
@@ -1433,33 +1433,33 @@ enum ChildNoRelatedFiltersOrderBy {
   UNFILTERABLE_ID_DESC
 }
 
-\\"\\"\\"A connection to a list of \`Child\` values.\\"\\"\\"
+"""A connection to a list of \`Child\` values."""
 type ChildrenConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`Child\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [ChildrenEdge!]!
 
-  \\"\\"\\"A list of \`Child\` objects.\\"\\"\\"
+  """A list of \`Child\` objects."""
   nodes: [Child]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`Child\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`Child\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`Child\` edge in the connection.\\"\\"\\"
+"""A \`Child\` edge in the connection."""
 type ChildrenEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`Child\` at the end of the edge.\\"\\"\\"
+  """The \`Child\` at the end of the edge."""
   node: Child
 }
 
-\\"\\"\\"Methods to use when ordering \`Child\`.\\"\\"\\"
+"""Methods to use when ordering \`Child\`."""
 enum ChildrenOrderBy {
   FILTERABLE_ID_ASC
   FILTERABLE_ID_DESC
@@ -1477,633 +1477,633 @@ type Composite {
   b: String
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`Composite\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input CompositeFilter {
-  \\"\\"\\"Filter by the object’s \`a\` field.\\"\\"\\"
+  """Filter by the object’s \`a\` field."""
   a: IntFilter
 
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [CompositeFilter!]
 
-  \\"\\"\\"Filter by the object’s \`b\` field.\\"\\"\\"
+  """Filter by the object’s \`b\` field."""
   b: StringFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: CompositeFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [CompositeFilter!]
 }
 
-\\"\\"\\"A location in a connection that can be used for resuming pagination.\\"\\"\\"
+"""A location in a connection that can be used for resuming pagination."""
 scalar Cursor
 
-\\"\\"\\"The day, does not include a time.\\"\\"\\"
+"""The day, does not include a time."""
 scalar Date
 
 scalar DateDomain
 
-\\"\\"\\"
+"""
 A filter to be used against DateDomain fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input DateDomainFilter {
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: DateDomain
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: DateDomain
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: DateDomain
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: DateDomain
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [DateDomain!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: DateDomain
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: DateDomain
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: DateDomain
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: DateDomain
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [DateDomain!]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against Date fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input DateFilter {
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: Date
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: Date
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: Date
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: Date
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [Date!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: Date
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: Date
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: Date
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: Date
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [Date!]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against Date List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input DateListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: Date
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: Date
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: Date
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: Date
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: Date
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: Date
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [Date]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [Date]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [Date]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [Date]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [Date]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [Date]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [Date]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [Date]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [Date]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [Date]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [Date]
 }
 
-\\"\\"\\"A range of \`Date\`.\\"\\"\\"
+"""A range of \`Date\`."""
 type DateRange {
-  \\"\\"\\"The ending bound of our range.\\"\\"\\"
+  """The ending bound of our range."""
   end: DateRangeBound
 
-  \\"\\"\\"The starting bound of our range.\\"\\"\\"
+  """The starting bound of our range."""
   start: DateRangeBound
 }
 
-\\"\\"\\"
+"""
 The value at one end of a range. A range can either include this value, or not.
-\\"\\"\\"
+"""
 type DateRangeBound {
-  \\"\\"\\"Whether or not the value of this bound is included in the range.\\"\\"\\"
+  """Whether or not the value of this bound is included in the range."""
   inclusive: Boolean!
 
-  \\"\\"\\"The value at one end of our range.\\"\\"\\"
+  """The value at one end of our range."""
   value: Date!
 }
 
-\\"\\"\\"
+"""
 The value at one end of a range. A range can either include this value, or not.
-\\"\\"\\"
+"""
 input DateRangeBoundInput {
-  \\"\\"\\"Whether or not the value of this bound is included in the range.\\"\\"\\"
+  """Whether or not the value of this bound is included in the range."""
   inclusive: Boolean!
 
-  \\"\\"\\"The value at one end of our range.\\"\\"\\"
+  """The value at one end of our range."""
   value: Date!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against DateRange fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input DateRangeFilter {
-  \\"\\"\\"Adjacent to the specified range.\\"\\"\\"
+  """Adjacent to the specified range."""
   adjacentTo: DateRangeInput
 
-  \\"\\"\\"Contained by the specified range.\\"\\"\\"
+  """Contained by the specified range."""
   containedBy: DateRangeInput
 
-  \\"\\"\\"Contains the specified range.\\"\\"\\"
+  """Contains the specified range."""
   contains: DateRangeInput
 
-  \\"\\"\\"Contains the specified value.\\"\\"\\"
+  """Contains the specified value."""
   containsElement: Date
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: DateRangeInput
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: DateRangeInput
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: DateRangeInput
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: DateRangeInput
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [DateRangeInput!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: DateRangeInput
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: DateRangeInput
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: DateRangeInput
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: DateRangeInput
 
-  \\"\\"\\"Does not extend left of the specified range.\\"\\"\\"
+  """Does not extend left of the specified range."""
   notExtendsLeftOf: DateRangeInput
 
-  \\"\\"\\"Does not extend right of the specified range.\\"\\"\\"
+  """Does not extend right of the specified range."""
   notExtendsRightOf: DateRangeInput
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [DateRangeInput!]
 
-  \\"\\"\\"Overlaps the specified range.\\"\\"\\"
+  """Overlaps the specified range."""
   overlaps: DateRangeInput
 
-  \\"\\"\\"Strictly left of the specified range.\\"\\"\\"
+  """Strictly left of the specified range."""
   strictlyLeftOf: DateRangeInput
 
-  \\"\\"\\"Strictly right of the specified range.\\"\\"\\"
+  """Strictly right of the specified range."""
   strictlyRightOf: DateRangeInput
 }
 
-\\"\\"\\"A range of \`Date\`.\\"\\"\\"
+"""A range of \`Date\`."""
 input DateRangeInput {
-  \\"\\"\\"The ending bound of our range.\\"\\"\\"
+  """The ending bound of our range."""
   end: DateRangeBoundInput
 
-  \\"\\"\\"The starting bound of our range.\\"\\"\\"
+  """The starting bound of our range."""
   start: DateRangeBoundInput
 }
 
-\\"\\"\\"
+"""
 A filter to be used against DateRange List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input DateRangeListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: DateRangeInput
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: DateRangeInput
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: DateRangeInput
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: DateRangeInput
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: DateRangeInput
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: DateRangeInput
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [DateRangeInput]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [DateRangeInput]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [DateRangeInput]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [DateRangeInput]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [DateRangeInput]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [DateRangeInput]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [DateRangeInput]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [DateRangeInput]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [DateRangeInput]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [DateRangeInput]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [DateRangeInput]
 }
 
-\\"\\"\\"
+"""
 A point in time as described by the [ISO
 8601](https://en.wikipedia.org/wiki/ISO_8601) standard. May or may not include a timezone.
-\\"\\"\\"
+"""
 scalar Datetime
 
-\\"\\"\\"
+"""
 A filter to be used against Datetime fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input DatetimeFilter {
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: Datetime
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: Datetime
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: Datetime
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: Datetime
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [Datetime!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: Datetime
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: Datetime
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: Datetime
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: Datetime
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [Datetime!]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against Datetime List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input DatetimeListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: Datetime
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: Datetime
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: Datetime
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: Datetime
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: Datetime
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: Datetime
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [Datetime]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [Datetime]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [Datetime]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [Datetime]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [Datetime]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [Datetime]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [Datetime]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [Datetime]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [Datetime]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [Datetime]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [Datetime]
 }
 
-\\"\\"\\"A range of \`Datetime\`.\\"\\"\\"
+"""A range of \`Datetime\`."""
 type DatetimeRange {
-  \\"\\"\\"The ending bound of our range.\\"\\"\\"
+  """The ending bound of our range."""
   end: DatetimeRangeBound
 
-  \\"\\"\\"The starting bound of our range.\\"\\"\\"
+  """The starting bound of our range."""
   start: DatetimeRangeBound
 }
 
-\\"\\"\\"
+"""
 The value at one end of a range. A range can either include this value, or not.
-\\"\\"\\"
+"""
 type DatetimeRangeBound {
-  \\"\\"\\"Whether or not the value of this bound is included in the range.\\"\\"\\"
+  """Whether or not the value of this bound is included in the range."""
   inclusive: Boolean!
 
-  \\"\\"\\"The value at one end of our range.\\"\\"\\"
+  """The value at one end of our range."""
   value: Datetime!
 }
 
-\\"\\"\\"
+"""
 The value at one end of a range. A range can either include this value, or not.
-\\"\\"\\"
+"""
 input DatetimeRangeBoundInput {
-  \\"\\"\\"Whether or not the value of this bound is included in the range.\\"\\"\\"
+  """Whether or not the value of this bound is included in the range."""
   inclusive: Boolean!
 
-  \\"\\"\\"The value at one end of our range.\\"\\"\\"
+  """The value at one end of our range."""
   value: Datetime!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against DatetimeRange fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input DatetimeRangeFilter {
-  \\"\\"\\"Adjacent to the specified range.\\"\\"\\"
+  """Adjacent to the specified range."""
   adjacentTo: DatetimeRangeInput
 
-  \\"\\"\\"Contained by the specified range.\\"\\"\\"
+  """Contained by the specified range."""
   containedBy: DatetimeRangeInput
 
-  \\"\\"\\"Contains the specified range.\\"\\"\\"
+  """Contains the specified range."""
   contains: DatetimeRangeInput
 
-  \\"\\"\\"Contains the specified value.\\"\\"\\"
+  """Contains the specified value."""
   containsElement: Datetime
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: DatetimeRangeInput
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: DatetimeRangeInput
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: DatetimeRangeInput
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: DatetimeRangeInput
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [DatetimeRangeInput!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: DatetimeRangeInput
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: DatetimeRangeInput
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: DatetimeRangeInput
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: DatetimeRangeInput
 
-  \\"\\"\\"Does not extend left of the specified range.\\"\\"\\"
+  """Does not extend left of the specified range."""
   notExtendsLeftOf: DatetimeRangeInput
 
-  \\"\\"\\"Does not extend right of the specified range.\\"\\"\\"
+  """Does not extend right of the specified range."""
   notExtendsRightOf: DatetimeRangeInput
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [DatetimeRangeInput!]
 
-  \\"\\"\\"Overlaps the specified range.\\"\\"\\"
+  """Overlaps the specified range."""
   overlaps: DatetimeRangeInput
 
-  \\"\\"\\"Strictly left of the specified range.\\"\\"\\"
+  """Strictly left of the specified range."""
   strictlyLeftOf: DatetimeRangeInput
 
-  \\"\\"\\"Strictly right of the specified range.\\"\\"\\"
+  """Strictly right of the specified range."""
   strictlyRightOf: DatetimeRangeInput
 }
 
-\\"\\"\\"A range of \`Datetime\`.\\"\\"\\"
+"""A range of \`Datetime\`."""
 input DatetimeRangeInput {
-  \\"\\"\\"The ending bound of our range.\\"\\"\\"
+  """The ending bound of our range."""
   end: DatetimeRangeBoundInput
 
-  \\"\\"\\"The starting bound of our range.\\"\\"\\"
+  """The starting bound of our range."""
   start: DatetimeRangeBoundInput
 }
 
-\\"\\"\\"
+"""
 A filter to be used against DatetimeRange List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input DatetimeRangeListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: DatetimeRangeInput
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: DatetimeRangeInput
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: DatetimeRangeInput
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: DatetimeRangeInput
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: DatetimeRangeInput
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: DatetimeRangeInput
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [DatetimeRangeInput]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [DatetimeRangeInput]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [DatetimeRangeInput]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [DatetimeRangeInput]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [DatetimeRangeInput]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [DatetimeRangeInput]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [DatetimeRangeInput]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [DatetimeRangeInput]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [DatetimeRangeInput]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [DatetimeRangeInput]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [DatetimeRangeInput]
 }
 
@@ -2113,65 +2113,65 @@ type DomainType implements Node {
   id: Int!
   int4Domain: Int4Domain
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`DomainType\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input DomainTypeFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [DomainTypeFilter!]
 
-  \\"\\"\\"Filter by the object’s \`char4Domain\` field.\\"\\"\\"
+  """Filter by the object’s \`char4Domain\` field."""
   char4Domain: Char4DomainFilter
 
-  \\"\\"\\"Filter by the object’s \`dateDomain\` field.\\"\\"\\"
+  """Filter by the object’s \`dateDomain\` field."""
   dateDomain: DateDomainFilter
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`int4Domain\` field.\\"\\"\\"
+  """Filter by the object’s \`int4Domain\` field."""
   int4Domain: Int4DomainFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: DomainTypeFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [DomainTypeFilter!]
 }
 
-\\"\\"\\"A connection to a list of \`DomainType\` values.\\"\\"\\"
+"""A connection to a list of \`DomainType\` values."""
 type DomainTypesConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`DomainType\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [DomainTypesEdge!]!
 
-  \\"\\"\\"A list of \`DomainType\` objects.\\"\\"\\"
+  """A list of \`DomainType\` objects."""
   nodes: [DomainType]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`DomainType\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`DomainType\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`DomainType\` edge in the connection.\\"\\"\\"
+"""A \`DomainType\` edge in the connection."""
 type DomainTypesEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`DomainType\` at the end of the edge.\\"\\"\\"
+  """The \`DomainType\` at the end of the edge."""
   node: DomainType
 }
 
-\\"\\"\\"Methods to use when ordering \`DomainType\`.\\"\\"\\"
+"""Methods to use when ordering \`DomainType\`."""
 enum DomainTypesOrderBy {
   CHAR4_DOMAIN_ASC
   CHAR4_DOMAIN_DESC
@@ -2190,59 +2190,59 @@ type EnumArrayType implements Node {
   enumArray: [Mood]
   id: Int!
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`EnumArrayType\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input EnumArrayTypeFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [EnumArrayTypeFilter!]
 
-  \\"\\"\\"Filter by the object’s \`enumArray\` field.\\"\\"\\"
+  """Filter by the object’s \`enumArray\` field."""
   enumArray: MoodListFilter
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: EnumArrayTypeFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [EnumArrayTypeFilter!]
 }
 
-\\"\\"\\"A connection to a list of \`EnumArrayType\` values.\\"\\"\\"
+"""A connection to a list of \`EnumArrayType\` values."""
 type EnumArrayTypesConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`EnumArrayType\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [EnumArrayTypesEdge!]!
 
-  \\"\\"\\"A list of \`EnumArrayType\` objects.\\"\\"\\"
+  """A list of \`EnumArrayType\` objects."""
   nodes: [EnumArrayType]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`EnumArrayType\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`EnumArrayType\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`EnumArrayType\` edge in the connection.\\"\\"\\"
+"""A \`EnumArrayType\` edge in the connection."""
 type EnumArrayTypesEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`EnumArrayType\` at the end of the edge.\\"\\"\\"
+  """The \`EnumArrayType\` at the end of the edge."""
   node: EnumArrayType
 }
 
-\\"\\"\\"Methods to use when ordering \`EnumArrayType\`.\\"\\"\\"
+"""Methods to use when ordering \`EnumArrayType\`."""
 enum EnumArrayTypesOrderBy {
   ENUM_ARRAY_ASC
   ENUM_ARRAY_DESC
@@ -2257,59 +2257,59 @@ type EnumType implements Node {
   enum: Mood
   id: Int!
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`EnumType\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input EnumTypeFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [EnumTypeFilter!]
 
-  \\"\\"\\"Filter by the object’s \`enum\` field.\\"\\"\\"
+  """Filter by the object’s \`enum\` field."""
   enum: MoodFilter
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: EnumTypeFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [EnumTypeFilter!]
 }
 
-\\"\\"\\"A connection to a list of \`EnumType\` values.\\"\\"\\"
+"""A connection to a list of \`EnumType\` values."""
 type EnumTypesConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`EnumType\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [EnumTypesEdge!]!
 
-  \\"\\"\\"A list of \`EnumType\` objects.\\"\\"\\"
+  """A list of \`EnumType\` objects."""
   nodes: [EnumType]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`EnumType\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`EnumType\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`EnumType\` edge in the connection.\\"\\"\\"
+"""A \`EnumType\` edge in the connection."""
 type EnumTypesEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`EnumType\` at the end of the edge.\\"\\"\\"
+  """The \`EnumType\` at the end of the edge."""
   node: EnumType
 }
 
-\\"\\"\\"Methods to use when ordering \`EnumType\`.\\"\\"\\"
+"""Methods to use when ordering \`EnumType\`."""
 enum EnumTypesOrderBy {
   ENUM_ASC
   ENUM_DESC
@@ -2321,14 +2321,14 @@ enum EnumTypesOrderBy {
 }
 
 type Filterable implements Node {
-  \\"\\"\\"Reads a single \`Backward\` that is related to this \`Filterable\`.\\"\\"\\"
+  """Reads a single \`Backward\` that is related to this \`Filterable\`."""
   backwardByFilterableId: Backward
   backwardCompound1: Int
   backwardCompound2: Int
 
-  \\"\\"\\"
+  """
   Reads a single \`BackwardCompound\` that is related to this \`Filterable\`.
-  \\"\\"\\"
+  """
   backwardCompoundByBackwardCompound1AndBackwardCompound2: BackwardCompound
   bit4: BitString
   bool: Boolean
@@ -2336,61 +2336,61 @@ type Filterable implements Node {
   bytea: String
   char4: String
 
-  \\"\\"\\"Reads and enables pagination through a set of \`ChildNoRelatedFilter\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`ChildNoRelatedFilter\`."""
   childNoRelatedFiltersByFilterableId(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: ChildNoRelatedFilterFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`ChildNoRelatedFilter\`.\\"\\"\\"
+    """The method to use when ordering \`ChildNoRelatedFilter\`."""
     orderBy: [ChildNoRelatedFiltersOrderBy!] = [PRIMARY_KEY_ASC]
   ): ChildNoRelatedFiltersConnection!
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Child\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Child\`."""
   childrenByFilterableId(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: ChildFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`Child\`.\\"\\"\\"
+    """The method to use when ordering \`Child\`."""
     orderBy: [ChildrenOrderBy!] = [PRIMARY_KEY_ASC]
   ): ChildrenConnection!
   cidr: String
@@ -2401,126 +2401,126 @@ type Filterable implements Node {
   computedChild: Child
   computedIntArray: [Int]
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Child\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Child\`."""
   computedSetofChild(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: ChildFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
   ): ChildrenConnection!
   computedSetofInt(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: IntFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
   ): FilterableComputedSetofIntConnection!
   computedTaggedFilterable: Int
   computedWithRequiredArg(i: Int!): Int
   date: Date
 
-  \\"\\"\\"Reads and enables pagination through a set of \`FilterableClosure\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`FilterableClosure\`."""
   filterableClosuresByAncestorId(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: FilterableClosureFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`FilterableClosure\`.\\"\\"\\"
+    """The method to use when ordering \`FilterableClosure\`."""
     orderBy: [FilterableClosuresOrderBy!] = [PRIMARY_KEY_ASC]
   ): FilterableClosuresConnection!
 
-  \\"\\"\\"Reads and enables pagination through a set of \`FilterableClosure\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`FilterableClosure\`."""
   filterableClosuresByDescendantId(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: FilterableClosureFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`FilterableClosure\`.\\"\\"\\"
+    """The method to use when ordering \`FilterableClosure\`."""
     orderBy: [FilterableClosuresOrderBy!] = [PRIMARY_KEY_ASC]
   ): FilterableClosuresConnection!
   float4: Float
   float8: Float
 
-  \\"\\"\\"Reads a single \`Forward\` that is related to this \`Filterable\`.\\"\\"\\"
+  """Reads a single \`Forward\` that is related to this \`Filterable\`."""
   forwardByForwardId: Forward
   forwardColumn: Forward
   forwardCompound1: Int
   forwardCompound2: Int
 
-  \\"\\"\\"Reads a single \`ForwardCompound\` that is related to this \`Filterable\`.\\"\\"\\"
+  """Reads a single \`ForwardCompound\` that is related to this \`Filterable\`."""
   forwardCompoundByForwardCompound1AndForwardCompound2: ForwardCompound
   forwardId: Int
   hstore: KeyValueHash
@@ -2536,13 +2536,13 @@ type Filterable implements Node {
   money: Float
   name: String
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
   numeric: BigFloat
 
-  \\"\\"\\"Reads a single \`Parent\` that is related to this \`Filterable\`.\\"\\"\\"
+  """Reads a single \`Parent\` that is related to this \`Filterable\`."""
   parentByParentId: Parent
   parentId: Int
   text: String
@@ -2562,78 +2562,78 @@ type FilterableClosure implements Node {
   depth: Int!
   descendantId: Int!
 
-  \\"\\"\\"
+  """
   Reads a single \`Filterable\` that is related to this \`FilterableClosure\`.
-  \\"\\"\\"
+  """
   filterableByAncestorId: Filterable
 
-  \\"\\"\\"
+  """
   Reads a single \`Filterable\` that is related to this \`FilterableClosure\`.
-  \\"\\"\\"
+  """
   filterableByDescendantId: Filterable
   id: Int!
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`FilterableClosure\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input FilterableClosureFilter {
-  \\"\\"\\"Filter by the object’s \`ancestorId\` field.\\"\\"\\"
+  """Filter by the object’s \`ancestorId\` field."""
   ancestorId: IntFilter
 
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [FilterableClosureFilter!]
 
-  \\"\\"\\"Filter by the object’s \`depth\` field.\\"\\"\\"
+  """Filter by the object’s \`depth\` field."""
   depth: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`descendantId\` field.\\"\\"\\"
+  """Filter by the object’s \`descendantId\` field."""
   descendantId: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: FilterableClosureFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [FilterableClosureFilter!]
 }
 
-\\"\\"\\"A connection to a list of \`FilterableClosure\` values.\\"\\"\\"
+"""A connection to a list of \`FilterableClosure\` values."""
 type FilterableClosuresConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`FilterableClosure\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [FilterableClosuresEdge!]!
 
-  \\"\\"\\"A list of \`FilterableClosure\` objects.\\"\\"\\"
+  """A list of \`FilterableClosure\` objects."""
   nodes: [FilterableClosure]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"
+  """
   The count of *all* \`FilterableClosure\` you could get from the connection.
-  \\"\\"\\"
+  """
   totalCount: Int!
 }
 
-\\"\\"\\"A \`FilterableClosure\` edge in the connection.\\"\\"\\"
+"""A \`FilterableClosure\` edge in the connection."""
 type FilterableClosuresEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`FilterableClosure\` at the end of the edge.\\"\\"\\"
+  """The \`FilterableClosure\` at the end of the edge."""
   node: FilterableClosure
 }
 
-\\"\\"\\"Methods to use when ordering \`FilterableClosure\`.\\"\\"\\"
+"""Methods to use when ordering \`FilterableClosure\`."""
 enum FilterableClosuresOrderBy {
   ANCESTOR_ID_ASC
   ANCESTOR_ID_DESC
@@ -2648,181 +2648,181 @@ enum FilterableClosuresOrderBy {
   PRIMARY_KEY_DESC
 }
 
-\\"\\"\\"A connection to a list of \`Int\` values.\\"\\"\\"
+"""A connection to a list of \`Int\` values."""
 type FilterableComputedSetofIntConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`Int\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [FilterableComputedSetofIntEdge!]!
 
-  \\"\\"\\"A list of \`Int\` objects.\\"\\"\\"
+  """A list of \`Int\` objects."""
   nodes: [Int]!
 
-  \\"\\"\\"The count of *all* \`Int\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`Int\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`Int\` edge in the connection.\\"\\"\\"
+"""A \`Int\` edge in the connection."""
 type FilterableComputedSetofIntEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`Int\` at the end of the edge.\\"\\"\\"
+  """The \`Int\` at the end of the edge."""
   node: Int
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`Filterable\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input FilterableFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [FilterableFilter!]
 
-  \\"\\"\\"Filter by the object’s \`backwardCompound1\` field.\\"\\"\\"
+  """Filter by the object’s \`backwardCompound1\` field."""
   backwardCompound1: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`backwardCompound2\` field.\\"\\"\\"
+  """Filter by the object’s \`backwardCompound2\` field."""
   backwardCompound2: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`bit4\` field.\\"\\"\\"
+  """Filter by the object’s \`bit4\` field."""
   bit4: BitStringFilter
 
-  \\"\\"\\"Filter by the object’s \`bool\` field.\\"\\"\\"
+  """Filter by the object’s \`bool\` field."""
   bool: BooleanFilter
 
-  \\"\\"\\"Filter by the object’s \`bpchar4\` field.\\"\\"\\"
+  """Filter by the object’s \`bpchar4\` field."""
   bpchar4: StringFilter
 
-  \\"\\"\\"Filter by the object’s \`char4\` field.\\"\\"\\"
+  """Filter by the object’s \`char4\` field."""
   char4: StringFilter
 
-  \\"\\"\\"Filter by the object’s \`citext\` field.\\"\\"\\"
+  """Filter by the object’s \`citext\` field."""
   citext: StringFilter
 
-  \\"\\"\\"Filter by the object’s \`compositeColumn\` field.\\"\\"\\"
+  """Filter by the object’s \`compositeColumn\` field."""
   compositeColumn: CompositeFilter
 
-  \\"\\"\\"Filter by the object’s \`computed\` field.\\"\\"\\"
+  """Filter by the object’s \`computed\` field."""
   computed: StringFilter
 
-  \\"\\"\\"Filter by the object’s \`computedIntArray\` field.\\"\\"\\"
+  """Filter by the object’s \`computedIntArray\` field."""
   computedIntArray: IntListFilter
 
-  \\"\\"\\"Filter by the object’s \`computedTaggedFilterable\` field.\\"\\"\\"
+  """Filter by the object’s \`computedTaggedFilterable\` field."""
   computedTaggedFilterable: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`date\` field.\\"\\"\\"
+  """Filter by the object’s \`date\` field."""
   date: DateFilter
 
-  \\"\\"\\"Filter by the object’s \`float4\` field.\\"\\"\\"
+  """Filter by the object’s \`float4\` field."""
   float4: FloatFilter
 
-  \\"\\"\\"Filter by the object’s \`float8\` field.\\"\\"\\"
+  """Filter by the object’s \`float8\` field."""
   float8: FloatFilter
 
-  \\"\\"\\"Filter by the object’s \`forwardCompound1\` field.\\"\\"\\"
+  """Filter by the object’s \`forwardCompound1\` field."""
   forwardCompound1: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`forwardCompound2\` field.\\"\\"\\"
+  """Filter by the object’s \`forwardCompound2\` field."""
   forwardCompound2: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`forwardId\` field.\\"\\"\\"
+  """Filter by the object’s \`forwardId\` field."""
   forwardId: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`hstore\` field.\\"\\"\\"
+  """Filter by the object’s \`hstore\` field."""
   hstore: KeyValueHashFilter
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`inet\` field.\\"\\"\\"
+  """Filter by the object’s \`inet\` field."""
   inet: InternetAddressFilter
 
-  \\"\\"\\"Filter by the object’s \`int2\` field.\\"\\"\\"
+  """Filter by the object’s \`int2\` field."""
   int2: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`int4\` field.\\"\\"\\"
+  """Filter by the object’s \`int4\` field."""
   int4: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`int8\` field.\\"\\"\\"
+  """Filter by the object’s \`int8\` field."""
   int8: BigIntFilter
 
-  \\"\\"\\"Filter by the object’s \`interval\` field.\\"\\"\\"
+  """Filter by the object’s \`interval\` field."""
   interval: IntervalFilter
 
-  \\"\\"\\"Filter by the object’s \`jsonb\` field.\\"\\"\\"
+  """Filter by the object’s \`jsonb\` field."""
   jsonb: JSONFilter
 
-  \\"\\"\\"Filter by the object’s \`money\` field.\\"\\"\\"
+  """Filter by the object’s \`money\` field."""
   money: FloatFilter
 
-  \\"\\"\\"Filter by the object’s \`name\` field.\\"\\"\\"
+  """Filter by the object’s \`name\` field."""
   name: StringFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: FilterableFilter
 
-  \\"\\"\\"Filter by the object’s \`numeric\` field.\\"\\"\\"
+  """Filter by the object’s \`numeric\` field."""
   numeric: BigFloatFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [FilterableFilter!]
 
-  \\"\\"\\"Filter by the object’s \`parentId\` field.\\"\\"\\"
+  """Filter by the object’s \`parentId\` field."""
   parentId: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`text\` field.\\"\\"\\"
+  """Filter by the object’s \`text\` field."""
   text: StringFilter
 
-  \\"\\"\\"Filter by the object’s \`time\` field.\\"\\"\\"
+  """Filter by the object’s \`time\` field."""
   time: TimeFilter
 
-  \\"\\"\\"Filter by the object’s \`timestamp\` field.\\"\\"\\"
+  """Filter by the object’s \`timestamp\` field."""
   timestamp: DatetimeFilter
 
-  \\"\\"\\"Filter by the object’s \`timestamptz\` field.\\"\\"\\"
+  """Filter by the object’s \`timestamptz\` field."""
   timestamptz: DatetimeFilter
 
-  \\"\\"\\"Filter by the object’s \`timetz\` field.\\"\\"\\"
+  """Filter by the object’s \`timetz\` field."""
   timetz: TimeFilter
 
-  \\"\\"\\"Filter by the object’s \`uuid\` field.\\"\\"\\"
+  """Filter by the object’s \`uuid\` field."""
   uuid: UUIDFilter
 
-  \\"\\"\\"Filter by the object’s \`varbit\` field.\\"\\"\\"
+  """Filter by the object’s \`varbit\` field."""
   varbit: BitStringFilter
 
-  \\"\\"\\"Filter by the object’s \`varchar\` field.\\"\\"\\"
+  """Filter by the object’s \`varchar\` field."""
   varchar: StringFilter
 }
 
-\\"\\"\\"A connection to a list of \`Filterable\` values.\\"\\"\\"
+"""A connection to a list of \`Filterable\` values."""
 type FilterablesConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`Filterable\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [FilterablesEdge!]!
 
-  \\"\\"\\"A list of \`Filterable\` objects.\\"\\"\\"
+  """A list of \`Filterable\` objects."""
   nodes: [Filterable]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`Filterable\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`Filterable\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`Filterable\` edge in the connection.\\"\\"\\"
+"""A \`Filterable\` edge in the connection."""
 type FilterablesEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`Filterable\` at the end of the edge.\\"\\"\\"
+  """The \`Filterable\` at the end of the edge."""
   node: Filterable
 }
 
-\\"\\"\\"Methods to use when ordering \`Filterable\`.\\"\\"\\"
+"""Methods to use when ordering \`Filterable\`."""
 enum FilterablesOrderBy {
   BACKWARD_COMPOUND_1_ASC
   BACKWARD_COMPOUND_1_DESC
@@ -2911,188 +2911,188 @@ enum FilterablesOrderBy {
   XML_DESC
 }
 
-\\"\\"\\"
+"""
 A filter to be used against Float fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input FloatFilter {
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: Float
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: Float
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: Float
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: Float
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [Float!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: Float
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: Float
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: Float
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: Float
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [Float!]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against Float List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input FloatListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: Float
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: Float
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: Float
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: Float
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: Float
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: Float
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [Float]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [Float]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [Float]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [Float]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [Float]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [Float]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [Float]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [Float]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [Float]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [Float]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [Float]
 }
 
 type Forward implements Node {
-  \\"\\"\\"Reads a single \`Filterable\` that is related to this \`Forward\`.\\"\\"\\"
+  """Reads a single \`Filterable\` that is related to this \`Forward\`."""
   filterableByForwardId: Filterable
   id: Int!
   name: String!
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
 type ForwardCompound implements Node {
-  \\"\\"\\"Reads a single \`Filterable\` that is related to this \`ForwardCompound\`.\\"\\"\\"
+  """Reads a single \`Filterable\` that is related to this \`ForwardCompound\`."""
   filterableByForwardCompound1AndForwardCompound2: Filterable
   forwardCompound1: Int!
   forwardCompound2: Int!
   name: String
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`ForwardCompound\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input ForwardCompoundFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [ForwardCompoundFilter!]
 
-  \\"\\"\\"Filter by the object’s \`forwardCompound1\` field.\\"\\"\\"
+  """Filter by the object’s \`forwardCompound1\` field."""
   forwardCompound1: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`forwardCompound2\` field.\\"\\"\\"
+  """Filter by the object’s \`forwardCompound2\` field."""
   forwardCompound2: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`name\` field.\\"\\"\\"
+  """Filter by the object’s \`name\` field."""
   name: StringFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: ForwardCompoundFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [ForwardCompoundFilter!]
 }
 
-\\"\\"\\"A connection to a list of \`ForwardCompound\` values.\\"\\"\\"
+"""A connection to a list of \`ForwardCompound\` values."""
 type ForwardCompoundsConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`ForwardCompound\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [ForwardCompoundsEdge!]!
 
-  \\"\\"\\"A list of \`ForwardCompound\` objects.\\"\\"\\"
+  """A list of \`ForwardCompound\` objects."""
   nodes: [ForwardCompound]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"
+  """
   The count of *all* \`ForwardCompound\` you could get from the connection.
-  \\"\\"\\"
+  """
   totalCount: Int!
 }
 
-\\"\\"\\"A \`ForwardCompound\` edge in the connection.\\"\\"\\"
+"""A \`ForwardCompound\` edge in the connection."""
 type ForwardCompoundsEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`ForwardCompound\` at the end of the edge.\\"\\"\\"
+  """The \`ForwardCompound\` at the end of the edge."""
   node: ForwardCompound
 }
 
-\\"\\"\\"Methods to use when ordering \`ForwardCompound\`.\\"\\"\\"
+"""Methods to use when ordering \`ForwardCompound\`."""
 enum ForwardCompoundsOrderBy {
   FORWARD_COMPOUND_1_ASC
   FORWARD_COMPOUND_1_DESC
@@ -3105,53 +3105,53 @@ enum ForwardCompoundsOrderBy {
   PRIMARY_KEY_DESC
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`Forward\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input ForwardFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [ForwardFilter!]
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`name\` field.\\"\\"\\"
+  """Filter by the object’s \`name\` field."""
   name: StringFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: ForwardFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [ForwardFilter!]
 }
 
-\\"\\"\\"A connection to a list of \`Forward\` values.\\"\\"\\"
+"""A connection to a list of \`Forward\` values."""
 type ForwardsConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`Forward\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [ForwardsEdge!]!
 
-  \\"\\"\\"A list of \`Forward\` objects.\\"\\"\\"
+  """A list of \`Forward\` objects."""
   nodes: [Forward]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`Forward\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`Forward\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`Forward\` edge in the connection.\\"\\"\\"
+"""A \`Forward\` edge in the connection."""
 type ForwardsEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`Forward\` at the end of the edge.\\"\\"\\"
+  """The \`Forward\` at the end of the edge."""
   node: Forward
 }
 
-\\"\\"\\"Methods to use when ordering \`Forward\`.\\"\\"\\"
+"""Methods to use when ordering \`Forward\`."""
 enum ForwardsOrderBy {
   ID_ASC
   ID_DESC
@@ -3165,40 +3165,40 @@ enum ForwardsOrderBy {
 type FullyOmitted implements Node {
   id: Int!
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
   text: String
 }
 
-\\"\\"\\"A connection to a list of \`FullyOmitted\` values.\\"\\"\\"
+"""A connection to a list of \`FullyOmitted\` values."""
 type FullyOmittedsConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`FullyOmitted\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [FullyOmittedsEdge!]!
 
-  \\"\\"\\"A list of \`FullyOmitted\` objects.\\"\\"\\"
+  """A list of \`FullyOmitted\` objects."""
   nodes: [FullyOmitted]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`FullyOmitted\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`FullyOmitted\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`FullyOmitted\` edge in the connection.\\"\\"\\"
+"""A \`FullyOmitted\` edge in the connection."""
 type FullyOmittedsEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`FullyOmitted\` at the end of the edge.\\"\\"\\"
+  """The \`FullyOmitted\` at the end of the edge."""
   node: FullyOmitted
 }
 
-\\"\\"\\"Methods to use when ordering \`FullyOmitted\`.\\"\\"\\"
+"""Methods to use when ordering \`FullyOmitted\`."""
 enum FullyOmittedsOrderBy {
   ID_ASC
   ID_DESC
@@ -3209,755 +3209,755 @@ enum FullyOmittedsOrderBy {
   TEXT_DESC
 }
 
-\\"\\"\\"A connection to a list of \`FuncReturnsTableMultiColRecord\` values.\\"\\"\\"
+"""A connection to a list of \`FuncReturnsTableMultiColRecord\` values."""
 type FuncReturnsTableMultiColConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`FuncReturnsTableMultiColRecord\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [FuncReturnsTableMultiColEdge!]!
 
-  \\"\\"\\"A list of \`FuncReturnsTableMultiColRecord\` objects.\\"\\"\\"
+  """A list of \`FuncReturnsTableMultiColRecord\` objects."""
   nodes: [FuncReturnsTableMultiColRecord]!
 
-  \\"\\"\\"
+  """
   The count of *all* \`FuncReturnsTableMultiColRecord\` you could get from the connection.
-  \\"\\"\\"
+  """
   totalCount: Int!
 }
 
-\\"\\"\\"A \`FuncReturnsTableMultiColRecord\` edge in the connection.\\"\\"\\"
+"""A \`FuncReturnsTableMultiColRecord\` edge in the connection."""
 type FuncReturnsTableMultiColEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`FuncReturnsTableMultiColRecord\` at the end of the edge.\\"\\"\\"
+  """The \`FuncReturnsTableMultiColRecord\` at the end of the edge."""
   node: FuncReturnsTableMultiColRecord
 }
 
-\\"\\"\\"The return type of our \`funcReturnsTableMultiCol\` query.\\"\\"\\"
+"""The return type of our \`funcReturnsTableMultiCol\` query."""
 type FuncReturnsTableMultiColRecord {
   col1: Int
   col2: String
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`FuncReturnsTableMultiColRecord\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input FuncReturnsTableMultiColRecordFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [FuncReturnsTableMultiColRecordFilter!]
 
-  \\"\\"\\"Filter by the object’s \`col1\` field.\\"\\"\\"
+  """Filter by the object’s \`col1\` field."""
   col1: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`col2\` field.\\"\\"\\"
+  """Filter by the object’s \`col2\` field."""
   col2: StringFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: FuncReturnsTableMultiColRecordFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [FuncReturnsTableMultiColRecordFilter!]
 }
 
-\\"\\"\\"A connection to a list of \`Int\` values.\\"\\"\\"
+"""A connection to a list of \`Int\` values."""
 type FuncReturnsTableOneColConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`Int\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [FuncReturnsTableOneColEdge!]!
 
-  \\"\\"\\"A list of \`Int\` objects.\\"\\"\\"
+  """A list of \`Int\` objects."""
   nodes: [Int]!
 
-  \\"\\"\\"The count of *all* \`Int\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`Int\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`Int\` edge in the connection.\\"\\"\\"
+"""A \`Int\` edge in the connection."""
 type FuncReturnsTableOneColEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`Int\` at the end of the edge.\\"\\"\\"
+  """The \`Int\` at the end of the edge."""
   node: Int
 }
 
-\\"\\"\\"
+"""
 A connection to a list of \`FuncTaggedFilterableReturnsTableMultiColRecord\` values.
-\\"\\"\\"
+"""
 type FuncTaggedFilterableReturnsTableMultiColConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`FuncTaggedFilterableReturnsTableMultiColRecord\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [FuncTaggedFilterableReturnsTableMultiColEdge!]!
 
-  \\"\\"\\"A list of \`FuncTaggedFilterableReturnsTableMultiColRecord\` objects.\\"\\"\\"
+  """A list of \`FuncTaggedFilterableReturnsTableMultiColRecord\` objects."""
   nodes: [FuncTaggedFilterableReturnsTableMultiColRecord]!
 
-  \\"\\"\\"
+  """
   The count of *all* \`FuncTaggedFilterableReturnsTableMultiColRecord\` you could get from the connection.
-  \\"\\"\\"
+  """
   totalCount: Int!
 }
 
-\\"\\"\\"
+"""
 A \`FuncTaggedFilterableReturnsTableMultiColRecord\` edge in the connection.
-\\"\\"\\"
+"""
 type FuncTaggedFilterableReturnsTableMultiColEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"
+  """
   The \`FuncTaggedFilterableReturnsTableMultiColRecord\` at the end of the edge.
-  \\"\\"\\"
+  """
   node: FuncTaggedFilterableReturnsTableMultiColRecord
 }
 
-\\"\\"\\"
+"""
 The return type of our \`funcTaggedFilterableReturnsTableMultiCol\` query.
-\\"\\"\\"
+"""
 type FuncTaggedFilterableReturnsTableMultiColRecord {
   col1: Int
   col2: String
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`FuncTaggedFilterableReturnsTableMultiColRecord\`
 object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input FuncTaggedFilterableReturnsTableMultiColRecordFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [FuncTaggedFilterableReturnsTableMultiColRecordFilter!]
 
-  \\"\\"\\"Filter by the object’s \`col1\` field.\\"\\"\\"
+  """Filter by the object’s \`col1\` field."""
   col1: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`col2\` field.\\"\\"\\"
+  """Filter by the object’s \`col2\` field."""
   col2: StringFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: FuncTaggedFilterableReturnsTableMultiColRecordFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [FuncTaggedFilterableReturnsTableMultiColRecordFilter!]
 }
 
 scalar Int4Domain
 
-\\"\\"\\"
+"""
 A filter to be used against Int4Domain fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input Int4DomainFilter {
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: Int4Domain
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: Int4Domain
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: Int4Domain
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: Int4Domain
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [Int4Domain!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: Int4Domain
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: Int4Domain
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: Int4Domain
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: Int4Domain
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [Int4Domain!]
 }
 
-\\"\\"\\"An IPv4 or IPv6 host address, and optionally its subnet.\\"\\"\\"
+"""An IPv4 or IPv6 host address, and optionally its subnet."""
 scalar InternetAddress
 
-\\"\\"\\"
+"""
 A filter to be used against InternetAddress fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input InternetAddressFilter {
-  \\"\\"\\"Contained by the specified internet address.\\"\\"\\"
+  """Contained by the specified internet address."""
   containedBy: InternetAddress
 
-  \\"\\"\\"Contained by or equal to the specified internet address.\\"\\"\\"
+  """Contained by or equal to the specified internet address."""
   containedByOrEqualTo: InternetAddress
 
-  \\"\\"\\"Contains the specified internet address.\\"\\"\\"
+  """Contains the specified internet address."""
   contains: InternetAddress
 
-  \\"\\"\\"Contains or contained by the specified internet address.\\"\\"\\"
+  """Contains or contained by the specified internet address."""
   containsOrContainedBy: InternetAddress
 
-  \\"\\"\\"Contains or equal to the specified internet address.\\"\\"\\"
+  """Contains or equal to the specified internet address."""
   containsOrEqualTo: InternetAddress
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: InternetAddress
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: InternetAddress
 
-  \\"\\"\\"Address family equal to specified value.\\"\\"\\"
+  """Address family equal to specified value."""
   familyEqualTo: Int
 
-  \\"\\"\\"Address family equal to specified value.\\"\\"\\"
+  """Address family equal to specified value."""
   familyNotEqualTo: Int
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: InternetAddress
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: InternetAddress
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [InternetAddress!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Address family equal to specified value.\\"\\"\\"
+  """Address family equal to specified value."""
   isV4: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: InternetAddress
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: InternetAddress
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: InternetAddress
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: InternetAddress
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [InternetAddress!]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against InternetAddress List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input InternetAddressListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: InternetAddress
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: InternetAddress
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: InternetAddress
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: InternetAddress
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: InternetAddress
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: InternetAddress
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [InternetAddress]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [InternetAddress]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [InternetAddress]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [InternetAddress]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [InternetAddress]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [InternetAddress]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [InternetAddress]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [InternetAddress]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [InternetAddress]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [InternetAddress]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [InternetAddress]
 }
 
-\\"\\"\\"
+"""
 An interval of time that has passed where the smallest distinct unit is a second.
-\\"\\"\\"
+"""
 type Interval {
-  \\"\\"\\"A quantity of days.\\"\\"\\"
+  """A quantity of days."""
   days: Int
 
-  \\"\\"\\"A quantity of hours.\\"\\"\\"
+  """A quantity of hours."""
   hours: Int
 
-  \\"\\"\\"A quantity of minutes.\\"\\"\\"
+  """A quantity of minutes."""
   minutes: Int
 
-  \\"\\"\\"A quantity of months.\\"\\"\\"
+  """A quantity of months."""
   months: Int
 
-  \\"\\"\\"
+  """
   A quantity of seconds. This is the only non-integer field, as all the other
   fields will dump their overflow into a smaller unit of time. Intervals don’t
   have a smaller unit than seconds.
-  \\"\\"\\"
+  """
   seconds: Float
 
-  \\"\\"\\"A quantity of years.\\"\\"\\"
+  """A quantity of years."""
   years: Int
 }
 
-\\"\\"\\"
+"""
 A filter to be used against Interval fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input IntervalFilter {
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: IntervalInput
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: IntervalInput
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: IntervalInput
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: IntervalInput
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [IntervalInput!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: IntervalInput
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: IntervalInput
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: IntervalInput
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: IntervalInput
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [IntervalInput!]
 }
 
-\\"\\"\\"
+"""
 An interval of time that has passed where the smallest distinct unit is a second.
-\\"\\"\\"
+"""
 input IntervalInput {
-  \\"\\"\\"A quantity of days.\\"\\"\\"
+  """A quantity of days."""
   days: Int
 
-  \\"\\"\\"A quantity of hours.\\"\\"\\"
+  """A quantity of hours."""
   hours: Int
 
-  \\"\\"\\"A quantity of minutes.\\"\\"\\"
+  """A quantity of minutes."""
   minutes: Int
 
-  \\"\\"\\"A quantity of months.\\"\\"\\"
+  """A quantity of months."""
   months: Int
 
-  \\"\\"\\"
+  """
   A quantity of seconds. This is the only non-integer field, as all the other
   fields will dump their overflow into a smaller unit of time. Intervals don’t
   have a smaller unit than seconds.
-  \\"\\"\\"
+  """
   seconds: Float
 
-  \\"\\"\\"A quantity of years.\\"\\"\\"
+  """A quantity of years."""
   years: Int
 }
 
-\\"\\"\\"
+"""
 A filter to be used against Interval List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input IntervalListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: IntervalInput
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: IntervalInput
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: IntervalInput
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: IntervalInput
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: IntervalInput
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: IntervalInput
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [IntervalInput]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [IntervalInput]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [IntervalInput]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [IntervalInput]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [IntervalInput]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [IntervalInput]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [IntervalInput]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [IntervalInput]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [IntervalInput]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [IntervalInput]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [IntervalInput]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against Int fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input IntFilter {
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: Int
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: Int
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: Int
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: Int
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [Int!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: Int
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: Int
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: Int
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: Int
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [Int!]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against Int List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input IntListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: Int
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: Int
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: Int
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: Int
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: Int
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: Int
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [Int]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [Int]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [Int]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [Int]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [Int]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [Int]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [Int]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [Int]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [Int]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [Int]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [Int]
 }
 
-\\"\\"\\"A range of \`Int\`.\\"\\"\\"
+"""A range of \`Int\`."""
 type IntRange {
-  \\"\\"\\"The ending bound of our range.\\"\\"\\"
+  """The ending bound of our range."""
   end: IntRangeBound
 
-  \\"\\"\\"The starting bound of our range.\\"\\"\\"
+  """The starting bound of our range."""
   start: IntRangeBound
 }
 
-\\"\\"\\"
+"""
 The value at one end of a range. A range can either include this value, or not.
-\\"\\"\\"
+"""
 type IntRangeBound {
-  \\"\\"\\"Whether or not the value of this bound is included in the range.\\"\\"\\"
+  """Whether or not the value of this bound is included in the range."""
   inclusive: Boolean!
 
-  \\"\\"\\"The value at one end of our range.\\"\\"\\"
+  """The value at one end of our range."""
   value: Int!
 }
 
-\\"\\"\\"
+"""
 The value at one end of a range. A range can either include this value, or not.
-\\"\\"\\"
+"""
 input IntRangeBoundInput {
-  \\"\\"\\"Whether or not the value of this bound is included in the range.\\"\\"\\"
+  """Whether or not the value of this bound is included in the range."""
   inclusive: Boolean!
 
-  \\"\\"\\"The value at one end of our range.\\"\\"\\"
+  """The value at one end of our range."""
   value: Int!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against IntRange fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input IntRangeFilter {
-  \\"\\"\\"Adjacent to the specified range.\\"\\"\\"
+  """Adjacent to the specified range."""
   adjacentTo: IntRangeInput
 
-  \\"\\"\\"Contained by the specified range.\\"\\"\\"
+  """Contained by the specified range."""
   containedBy: IntRangeInput
 
-  \\"\\"\\"Contains the specified range.\\"\\"\\"
+  """Contains the specified range."""
   contains: IntRangeInput
 
-  \\"\\"\\"Contains the specified value.\\"\\"\\"
+  """Contains the specified value."""
   containsElement: Int
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: IntRangeInput
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: IntRangeInput
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: IntRangeInput
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: IntRangeInput
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [IntRangeInput!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: IntRangeInput
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: IntRangeInput
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: IntRangeInput
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: IntRangeInput
 
-  \\"\\"\\"Does not extend left of the specified range.\\"\\"\\"
+  """Does not extend left of the specified range."""
   notExtendsLeftOf: IntRangeInput
 
-  \\"\\"\\"Does not extend right of the specified range.\\"\\"\\"
+  """Does not extend right of the specified range."""
   notExtendsRightOf: IntRangeInput
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [IntRangeInput!]
 
-  \\"\\"\\"Overlaps the specified range.\\"\\"\\"
+  """Overlaps the specified range."""
   overlaps: IntRangeInput
 
-  \\"\\"\\"Strictly left of the specified range.\\"\\"\\"
+  """Strictly left of the specified range."""
   strictlyLeftOf: IntRangeInput
 
-  \\"\\"\\"Strictly right of the specified range.\\"\\"\\"
+  """Strictly right of the specified range."""
   strictlyRightOf: IntRangeInput
 }
 
-\\"\\"\\"A range of \`Int\`.\\"\\"\\"
+"""A range of \`Int\`."""
 input IntRangeInput {
-  \\"\\"\\"The ending bound of our range.\\"\\"\\"
+  """The ending bound of our range."""
   end: IntRangeBoundInput
 
-  \\"\\"\\"The starting bound of our range.\\"\\"\\"
+  """The starting bound of our range."""
   start: IntRangeBoundInput
 }
 
-\\"\\"\\"
+"""
 A filter to be used against IntRange List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input IntRangeListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: IntRangeInput
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: IntRangeInput
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: IntRangeInput
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: IntRangeInput
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: IntRangeInput
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: IntRangeInput
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [IntRangeInput]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [IntRangeInput]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [IntRangeInput]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [IntRangeInput]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [IntRangeInput]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [IntRangeInput]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [IntRangeInput]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [IntRangeInput]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [IntRangeInput]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [IntRangeInput]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [IntRangeInput]
 }
 
-\\"\\"\\"
+"""
 A JavaScript object encoded in the JSON format as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf).
-\\"\\"\\"
+"""
 scalar JSON
 
 type JsonbTest implements Node {
@@ -3965,62 +3965,62 @@ type JsonbTest implements Node {
   jsonbWithArray: JSON
   jsonbWithObject: JSON
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`JsonbTest\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input JsonbTestFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [JsonbTestFilter!]
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`jsonbWithArray\` field.\\"\\"\\"
+  """Filter by the object’s \`jsonbWithArray\` field."""
   jsonbWithArray: JSONFilter
 
-  \\"\\"\\"Filter by the object’s \`jsonbWithObject\` field.\\"\\"\\"
+  """Filter by the object’s \`jsonbWithObject\` field."""
   jsonbWithObject: JSONFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: JsonbTestFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [JsonbTestFilter!]
 }
 
-\\"\\"\\"A connection to a list of \`JsonbTest\` values.\\"\\"\\"
+"""A connection to a list of \`JsonbTest\` values."""
 type JsonbTestsConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`JsonbTest\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [JsonbTestsEdge!]!
 
-  \\"\\"\\"A list of \`JsonbTest\` objects.\\"\\"\\"
+  """A list of \`JsonbTest\` objects."""
   nodes: [JsonbTest]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`JsonbTest\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`JsonbTest\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`JsonbTest\` edge in the connection.\\"\\"\\"
+"""A \`JsonbTest\` edge in the connection."""
 type JsonbTestsEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`JsonbTest\` at the end of the edge.\\"\\"\\"
+  """The \`JsonbTest\` at the end of the edge."""
   node: JsonbTest
 }
 
-\\"\\"\\"Methods to use when ordering \`JsonbTest\`.\\"\\"\\"
+"""Methods to use when ordering \`JsonbTest\`."""
 enum JsonbTestsOrderBy {
   ID_ASC
   ID_DESC
@@ -4033,188 +4033,188 @@ enum JsonbTestsOrderBy {
   PRIMARY_KEY_DESC
 }
 
-\\"\\"\\"
+"""
 A filter to be used against JSON fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input JSONFilter {
-  \\"\\"\\"Contained by the specified JSON.\\"\\"\\"
+  """Contained by the specified JSON."""
   containedBy: JSON
 
-  \\"\\"\\"Contains the specified JSON.\\"\\"\\"
+  """Contains the specified JSON."""
   contains: JSON
 
-  \\"\\"\\"Contains all of the specified keys.\\"\\"\\"
+  """Contains all of the specified keys."""
   containsAllKeys: [String!]
 
-  \\"\\"\\"Contains any of the specified keys.\\"\\"\\"
+  """Contains any of the specified keys."""
   containsAnyKeys: [String!]
 
-  \\"\\"\\"Contains the specified key.\\"\\"\\"
+  """Contains the specified key."""
   containsKey: String
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: JSON
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: JSON
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: JSON
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: JSON
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [JSON!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: JSON
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: JSON
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: JSON
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: JSON
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [JSON!]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against JSON List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input JSONListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: JSON
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: JSON
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: JSON
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: JSON
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: JSON
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: JSON
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [JSON]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [JSON]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [JSON]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [JSON]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [JSON]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [JSON]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [JSON]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [JSON]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [JSON]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [JSON]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [JSON]
 }
 
 type Junction implements Node {
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 
-  \\"\\"\\"Reads a single \`SideA\` that is related to this \`Junction\`.\\"\\"\\"
+  """Reads a single \`SideA\` that is related to this \`Junction\`."""
   sideABySideAId: SideA
   sideAId: Int!
 
-  \\"\\"\\"Reads a single \`SideB\` that is related to this \`Junction\`.\\"\\"\\"
+  """Reads a single \`SideB\` that is related to this \`Junction\`."""
   sideBBySideBId: SideB
   sideBId: Int!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`Junction\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input JunctionFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [JunctionFilter!]
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: JunctionFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [JunctionFilter!]
 
-  \\"\\"\\"Filter by the object’s \`sideAId\` field.\\"\\"\\"
+  """Filter by the object’s \`sideAId\` field."""
   sideAId: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`sideBId\` field.\\"\\"\\"
+  """Filter by the object’s \`sideBId\` field."""
   sideBId: IntFilter
 }
 
-\\"\\"\\"A connection to a list of \`Junction\` values.\\"\\"\\"
+"""A connection to a list of \`Junction\` values."""
 type JunctionsConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`Junction\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [JunctionsEdge!]!
 
-  \\"\\"\\"A list of \`Junction\` objects.\\"\\"\\"
+  """A list of \`Junction\` objects."""
   nodes: [Junction]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`Junction\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`Junction\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`Junction\` edge in the connection.\\"\\"\\"
+"""A \`Junction\` edge in the connection."""
 type JunctionsEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`Junction\` at the end of the edge.\\"\\"\\"
+  """The \`Junction\` at the end of the edge."""
   node: Junction
 }
 
-\\"\\"\\"Methods to use when ordering \`Junction\`.\\"\\"\\"
+"""Methods to use when ordering \`Junction\`."""
 enum JunctionsOrderBy {
   NATURAL
   PRIMARY_KEY_ASC
@@ -4225,116 +4225,116 @@ enum JunctionsOrderBy {
   SIDE_B_ID_DESC
 }
 
-\\"\\"\\"
+"""
 A set of key/value pairs, keys are strings, values may be a string or null. Exposed as a JSON object.
-\\"\\"\\"
+"""
 scalar KeyValueHash
 
-\\"\\"\\"
+"""
 A filter to be used against KeyValueHash fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input KeyValueHashFilter {
-  \\"\\"\\"Contained by the specified KeyValueHash.\\"\\"\\"
+  """Contained by the specified KeyValueHash."""
   containedBy: KeyValueHash
 
-  \\"\\"\\"Contains the specified KeyValueHash.\\"\\"\\"
+  """Contains the specified KeyValueHash."""
   contains: KeyValueHash
 
-  \\"\\"\\"Contains all of the specified keys.\\"\\"\\"
+  """Contains all of the specified keys."""
   containsAllKeys: [String!]
 
-  \\"\\"\\"Contains any of the specified keys.\\"\\"\\"
+  """Contains any of the specified keys."""
   containsAnyKeys: [String!]
 
-  \\"\\"\\"Contains the specified key.\\"\\"\\"
+  """Contains the specified key."""
   containsKey: String
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: KeyValueHash
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: KeyValueHash
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [KeyValueHash!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: KeyValueHash
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: KeyValueHash
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [KeyValueHash!]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against KeyValueHash List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input KeyValueHashListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: KeyValueHash
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: KeyValueHash
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: KeyValueHash
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: KeyValueHash
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: KeyValueHash
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: KeyValueHash
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [KeyValueHash]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [KeyValueHash]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [KeyValueHash]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [KeyValueHash]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [KeyValueHash]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [KeyValueHash]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [KeyValueHash]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [KeyValueHash]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [KeyValueHash]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [KeyValueHash]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [KeyValueHash]
 }
 
@@ -4344,219 +4344,219 @@ enum Mood {
   SAD
 }
 
-\\"\\"\\"
+"""
 A filter to be used against Mood fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input MoodFilter {
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: Mood
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: Mood
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: Mood
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: Mood
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [Mood!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: Mood
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: Mood
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: Mood
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: Mood
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [Mood!]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against Mood List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input MoodListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: Mood
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: Mood
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: Mood
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: Mood
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: Mood
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: Mood
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [Mood]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [Mood]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [Mood]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [Mood]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [Mood]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [Mood]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [Mood]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [Mood]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [Mood]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [Mood]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [Mood]
 }
 
-\\"\\"\\"An object with a globally unique \`ID\`.\\"\\"\\"
+"""An object with a globally unique \`ID\`."""
 interface Node {
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
-\\"\\"\\"Information about pagination in a connection.\\"\\"\\"
+"""Information about pagination in a connection."""
 type PageInfo {
-  \\"\\"\\"When paginating forwards, the cursor to continue.\\"\\"\\"
+  """When paginating forwards, the cursor to continue."""
   endCursor: Cursor
 
-  \\"\\"\\"When paginating forwards, are there more items?\\"\\"\\"
+  """When paginating forwards, are there more items?"""
   hasNextPage: Boolean!
 
-  \\"\\"\\"When paginating backwards, are there more items?\\"\\"\\"
+  """When paginating backwards, are there more items?"""
   hasPreviousPage: Boolean!
 
-  \\"\\"\\"When paginating backwards, the cursor to continue.\\"\\"\\"
+  """When paginating backwards, the cursor to continue."""
   startCursor: Cursor
 }
 
 type Parent implements Node {
-  \\"\\"\\"Reads and enables pagination through a set of \`Filterable\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Filterable\`."""
   filterablesByParentId(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: FilterableFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`Filterable\`.\\"\\"\\"
+    """The method to use when ordering \`Filterable\`."""
     orderBy: [FilterablesOrderBy!] = [PRIMARY_KEY_ASC]
   ): FilterablesConnection!
   id: Int!
   name: String!
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`Parent\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input ParentFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [ParentFilter!]
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`name\` field.\\"\\"\\"
+  """Filter by the object’s \`name\` field."""
   name: StringFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: ParentFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [ParentFilter!]
 }
 
-\\"\\"\\"A connection to a list of \`Parent\` values.\\"\\"\\"
+"""A connection to a list of \`Parent\` values."""
 type ParentsConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`Parent\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [ParentsEdge!]!
 
-  \\"\\"\\"A list of \`Parent\` objects.\\"\\"\\"
+  """A list of \`Parent\` objects."""
   nodes: [Parent]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`Parent\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`Parent\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`Parent\` edge in the connection.\\"\\"\\"
+"""A \`Parent\` edge in the connection."""
 type ParentsEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`Parent\` at the end of the edge.\\"\\"\\"
+  """The \`Parent\` at the end of the edge."""
   node: Parent
 }
 
-\\"\\"\\"Methods to use when ordering \`Parent\`.\\"\\"\\"
+"""Methods to use when ordering \`Parent\`."""
 enum ParentsOrderBy {
   ID_ASC
   ID_DESC
@@ -4571,704 +4571,704 @@ type Protected implements Node {
   id: Int!
   name: String
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
   otherId: Int
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`Protected\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input ProtectedFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [ProtectedFilter!]
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`name\` field.\\"\\"\\"
+  """Filter by the object’s \`name\` field."""
   name: StringFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: ProtectedFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [ProtectedFilter!]
 
-  \\"\\"\\"Filter by the object’s \`otherId\` field.\\"\\"\\"
+  """Filter by the object’s \`otherId\` field."""
   otherId: IntFilter
 }
 
-\\"\\"\\"A connection to a list of \`Protected\` values.\\"\\"\\"
+"""A connection to a list of \`Protected\` values."""
 type ProtectedsConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`Protected\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [ProtectedsEdge!]!
 
-  \\"\\"\\"A list of \`Protected\` objects.\\"\\"\\"
+  """A list of \`Protected\` objects."""
   nodes: [Protected]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`Protected\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`Protected\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`Protected\` edge in the connection.\\"\\"\\"
+"""A \`Protected\` edge in the connection."""
 type ProtectedsEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`Protected\` at the end of the edge.\\"\\"\\"
+  """The \`Protected\` at the end of the edge."""
   node: Protected
 }
 
-\\"\\"\\"The root query type which gives access points into the data universe.\\"\\"\\"
+"""The root query type which gives access points into the data universe."""
 type Query implements Node {
-  \\"\\"\\"Reads and enables pagination through a set of \`ArrayType\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`ArrayType\`."""
   allArrayTypes(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: ArrayTypeFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`ArrayType\`.\\"\\"\\"
+    """The method to use when ordering \`ArrayType\`."""
     orderBy: [ArrayTypesOrderBy!] = [PRIMARY_KEY_ASC]
   ): ArrayTypesConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`BackwardCompound\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`BackwardCompound\`."""
   allBackwardCompounds(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: BackwardCompoundFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`BackwardCompound\`.\\"\\"\\"
+    """The method to use when ordering \`BackwardCompound\`."""
     orderBy: [BackwardCompoundsOrderBy!] = [PRIMARY_KEY_ASC]
   ): BackwardCompoundsConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Backward\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Backward\`."""
   allBackwards(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: BackwardFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`Backward\`.\\"\\"\\"
+    """The method to use when ordering \`Backward\`."""
     orderBy: [BackwardsOrderBy!] = [PRIMARY_KEY_ASC]
   ): BackwardsConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`ChildNoRelatedFilter\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`ChildNoRelatedFilter\`."""
   allChildNoRelatedFilters(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: ChildNoRelatedFilterFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`ChildNoRelatedFilter\`.\\"\\"\\"
+    """The method to use when ordering \`ChildNoRelatedFilter\`."""
     orderBy: [ChildNoRelatedFiltersOrderBy!] = [PRIMARY_KEY_ASC]
   ): ChildNoRelatedFiltersConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Child\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Child\`."""
   allChildren(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: ChildFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`Child\`.\\"\\"\\"
+    """The method to use when ordering \`Child\`."""
     orderBy: [ChildrenOrderBy!] = [PRIMARY_KEY_ASC]
   ): ChildrenConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`DomainType\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`DomainType\`."""
   allDomainTypes(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: DomainTypeFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`DomainType\`.\\"\\"\\"
+    """The method to use when ordering \`DomainType\`."""
     orderBy: [DomainTypesOrderBy!] = [PRIMARY_KEY_ASC]
   ): DomainTypesConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`EnumArrayType\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`EnumArrayType\`."""
   allEnumArrayTypes(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: EnumArrayTypeFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`EnumArrayType\`.\\"\\"\\"
+    """The method to use when ordering \`EnumArrayType\`."""
     orderBy: [EnumArrayTypesOrderBy!] = [PRIMARY_KEY_ASC]
   ): EnumArrayTypesConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`EnumType\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`EnumType\`."""
   allEnumTypes(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: EnumTypeFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`EnumType\`.\\"\\"\\"
+    """The method to use when ordering \`EnumType\`."""
     orderBy: [EnumTypesOrderBy!] = [PRIMARY_KEY_ASC]
   ): EnumTypesConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Filterable\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Filterable\`."""
   allFilterables(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: FilterableFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`Filterable\`.\\"\\"\\"
+    """The method to use when ordering \`Filterable\`."""
     orderBy: [FilterablesOrderBy!] = [PRIMARY_KEY_ASC]
   ): FilterablesConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`ForwardCompound\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`ForwardCompound\`."""
   allForwardCompounds(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: ForwardCompoundFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`ForwardCompound\`.\\"\\"\\"
+    """The method to use when ordering \`ForwardCompound\`."""
     orderBy: [ForwardCompoundsOrderBy!] = [PRIMARY_KEY_ASC]
   ): ForwardCompoundsConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Forward\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Forward\`."""
   allForwards(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: ForwardFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`Forward\`.\\"\\"\\"
+    """The method to use when ordering \`Forward\`."""
     orderBy: [ForwardsOrderBy!] = [PRIMARY_KEY_ASC]
   ): ForwardsConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`FullyOmitted\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`FullyOmitted\`."""
   allFullyOmitteds(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`FullyOmitted\`.\\"\\"\\"
+    """The method to use when ordering \`FullyOmitted\`."""
     orderBy: [FullyOmittedsOrderBy!] = [PRIMARY_KEY_ASC]
   ): FullyOmittedsConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`JsonbTest\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`JsonbTest\`."""
   allJsonbTests(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: JsonbTestFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`JsonbTest\`.\\"\\"\\"
+    """The method to use when ordering \`JsonbTest\`."""
     orderBy: [JsonbTestsOrderBy!] = [PRIMARY_KEY_ASC]
   ): JsonbTestsConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Junction\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Junction\`."""
   allJunctions(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: JunctionFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`Junction\`.\\"\\"\\"
+    """The method to use when ordering \`Junction\`."""
     orderBy: [JunctionsOrderBy!] = [PRIMARY_KEY_ASC]
   ): JunctionsConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Parent\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Parent\`."""
   allParents(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: ParentFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`Parent\`.\\"\\"\\"
+    """The method to use when ordering \`Parent\`."""
     orderBy: [ParentsOrderBy!] = [PRIMARY_KEY_ASC]
   ): ParentsConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`RangeArrayType\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`RangeArrayType\`."""
   allRangeArrayTypes(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: RangeArrayTypeFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`RangeArrayType\`.\\"\\"\\"
+    """The method to use when ordering \`RangeArrayType\`."""
     orderBy: [RangeArrayTypesOrderBy!] = [PRIMARY_KEY_ASC]
   ): RangeArrayTypesConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`RangeType\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`RangeType\`."""
   allRangeTypes(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: RangeTypeFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`RangeType\`.\\"\\"\\"
+    """The method to use when ordering \`RangeType\`."""
     orderBy: [RangeTypesOrderBy!] = [PRIMARY_KEY_ASC]
   ): RangeTypesConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`SideA\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`SideA\`."""
   allSideAs(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: SideAFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`SideA\`.\\"\\"\\"
+    """The method to use when ordering \`SideA\`."""
     orderBy: [SideAsOrderBy!] = [PRIMARY_KEY_ASC]
   ): SideAsConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`SideB\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`SideB\`."""
   allSideBs(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: SideBFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`SideB\`.\\"\\"\\"
+    """The method to use when ordering \`SideB\`."""
     orderBy: [SideBsOrderBy!] = [PRIMARY_KEY_ASC]
   ): SideBsConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Unfilterable\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Unfilterable\`."""
   allUnfilterables(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`Unfilterable\`.\\"\\"\\"
+    """The method to use when ordering \`Unfilterable\`."""
     orderBy: [UnfilterablesOrderBy!] = [PRIMARY_KEY_ASC]
   ): UnfilterablesConnection
 
-  \\"\\"\\"Reads a single \`ArrayType\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`ArrayType\` using its globally unique \`ID\`."""
   arrayType(
-    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`ArrayType\`.\\"\\"\\"
+    """The globally unique \`ID\` to be used in selecting a single \`ArrayType\`."""
     nodeId: ID!
   ): ArrayType
   arrayTypeById(id: Int!): ArrayType
 
-  \\"\\"\\"Reads a single \`Backward\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`Backward\` using its globally unique \`ID\`."""
   backward(
-    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`Backward\`.\\"\\"\\"
+    """The globally unique \`ID\` to be used in selecting a single \`Backward\`."""
     nodeId: ID!
   ): Backward
   backwardByFilterableId(filterableId: Int!): Backward
   backwardById(id: Int!): Backward
 
-  \\"\\"\\"Reads a single \`BackwardCompound\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`BackwardCompound\` using its globally unique \`ID\`."""
   backwardCompound(
-    \\"\\"\\"
+    """
     The globally unique \`ID\` to be used in selecting a single \`BackwardCompound\`.
-    \\"\\"\\"
+    """
     nodeId: ID!
   ): BackwardCompound
   backwardCompoundByBackwardCompound1AndBackwardCompound2(backwardCompound1: Int!, backwardCompound2: Int!): BackwardCompound
 
-  \\"\\"\\"Reads a single \`Child\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`Child\` using its globally unique \`ID\`."""
   child(
-    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`Child\`.\\"\\"\\"
+    """The globally unique \`ID\` to be used in selecting a single \`Child\`."""
     nodeId: ID!
   ): Child
   childById(id: Int!): Child
 
-  \\"\\"\\"Reads a single \`ChildNoRelatedFilter\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`ChildNoRelatedFilter\` using its globally unique \`ID\`."""
   childNoRelatedFilter(
-    \\"\\"\\"
+    """
     The globally unique \`ID\` to be used in selecting a single \`ChildNoRelatedFilter\`.
-    \\"\\"\\"
+    """
     nodeId: ID!
   ): ChildNoRelatedFilter
   childNoRelatedFilterById(id: Int!): ChildNoRelatedFilter
 
-  \\"\\"\\"Reads a single \`DomainType\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`DomainType\` using its globally unique \`ID\`."""
   domainType(
-    \\"\\"\\"
+    """
     The globally unique \`ID\` to be used in selecting a single \`DomainType\`.
-    \\"\\"\\"
+    """
     nodeId: ID!
   ): DomainType
   domainTypeById(id: Int!): DomainType
 
-  \\"\\"\\"Reads a single \`EnumArrayType\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`EnumArrayType\` using its globally unique \`ID\`."""
   enumArrayType(
-    \\"\\"\\"
+    """
     The globally unique \`ID\` to be used in selecting a single \`EnumArrayType\`.
-    \\"\\"\\"
+    """
     nodeId: ID!
   ): EnumArrayType
   enumArrayTypeById(id: Int!): EnumArrayType
 
-  \\"\\"\\"Reads a single \`EnumType\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`EnumType\` using its globally unique \`ID\`."""
   enumType(
-    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`EnumType\`.\\"\\"\\"
+    """The globally unique \`ID\` to be used in selecting a single \`EnumType\`."""
     nodeId: ID!
   ): EnumType
   enumTypeById(id: Int!): EnumType
 
-  \\"\\"\\"Reads a single \`Filterable\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`Filterable\` using its globally unique \`ID\`."""
   filterable(
-    \\"\\"\\"
+    """
     The globally unique \`ID\` to be used in selecting a single \`Filterable\`.
-    \\"\\"\\"
+    """
     nodeId: ID!
   ): Filterable
   filterableByBackwardCompound1AndBackwardCompound2(backwardCompound1: Int!, backwardCompound2: Int!): Filterable
@@ -5276,247 +5276,247 @@ type Query implements Node {
   filterableByForwardId(forwardId: Int!): Filterable
   filterableById(id: Int!): Filterable
 
-  \\"\\"\\"Reads a single \`FilterableClosure\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`FilterableClosure\` using its globally unique \`ID\`."""
   filterableClosure(
-    \\"\\"\\"
+    """
     The globally unique \`ID\` to be used in selecting a single \`FilterableClosure\`.
-    \\"\\"\\"
+    """
     nodeId: ID!
   ): FilterableClosure
   filterableClosureById(id: Int!): FilterableClosure
 
-  \\"\\"\\"Reads a single \`Forward\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`Forward\` using its globally unique \`ID\`."""
   forward(
-    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`Forward\`.\\"\\"\\"
+    """The globally unique \`ID\` to be used in selecting a single \`Forward\`."""
     nodeId: ID!
   ): Forward
   forwardById(id: Int!): Forward
 
-  \\"\\"\\"Reads a single \`ForwardCompound\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`ForwardCompound\` using its globally unique \`ID\`."""
   forwardCompound(
-    \\"\\"\\"
+    """
     The globally unique \`ID\` to be used in selecting a single \`ForwardCompound\`.
-    \\"\\"\\"
+    """
     nodeId: ID!
   ): ForwardCompound
   forwardCompoundByForwardCompound1AndForwardCompound2(forwardCompound1: Int!, forwardCompound2: Int!): ForwardCompound
 
-  \\"\\"\\"Reads a single \`FullyOmitted\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`FullyOmitted\` using its globally unique \`ID\`."""
   fullyOmitted(
-    \\"\\"\\"
+    """
     The globally unique \`ID\` to be used in selecting a single \`FullyOmitted\`.
-    \\"\\"\\"
+    """
     nodeId: ID!
   ): FullyOmitted
   fullyOmittedById(id: Int!): FullyOmitted
   funcReturnsTableMultiCol(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: FuncReturnsTableMultiColRecordFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
     i: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
   ): FuncReturnsTableMultiColConnection!
   funcReturnsTableOneCol(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: IntFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
     i: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
   ): FuncReturnsTableOneColConnection!
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Filterable\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Filterable\`."""
   funcTaggedFilterableReturnsSetofFilterable(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: FilterableFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
   ): FilterablesConnection!
   funcTaggedFilterableReturnsTableMultiCol(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: FuncTaggedFilterableReturnsTableMultiColRecordFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
   ): FuncTaggedFilterableReturnsTableMultiColConnection!
 
-  \\"\\"\\"Reads a single \`JsonbTest\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`JsonbTest\` using its globally unique \`ID\`."""
   jsonbTest(
-    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`JsonbTest\`.\\"\\"\\"
+    """The globally unique \`ID\` to be used in selecting a single \`JsonbTest\`."""
     nodeId: ID!
   ): JsonbTest
   jsonbTestById(id: Int!): JsonbTest
 
-  \\"\\"\\"Reads a single \`Junction\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`Junction\` using its globally unique \`ID\`."""
   junction(
-    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`Junction\`.\\"\\"\\"
+    """The globally unique \`ID\` to be used in selecting a single \`Junction\`."""
     nodeId: ID!
   ): Junction
   junctionBySideAIdAndSideBId(sideAId: Int!, sideBId: Int!): Junction
 
-  \\"\\"\\"Fetches an object given its globally unique \`ID\`.\\"\\"\\"
+  """Fetches an object given its globally unique \`ID\`."""
   node(
-    \\"\\"\\"The globally unique \`ID\`.\\"\\"\\"
+    """The globally unique \`ID\`."""
     nodeId: ID!
   ): Node
 
-  \\"\\"\\"
+  """
   The root query type must be a \`Node\` to work well with Relay 1 mutations. This just resolves to \`query\`.
-  \\"\\"\\"
+  """
   nodeId: ID!
 
-  \\"\\"\\"Reads a single \`Parent\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`Parent\` using its globally unique \`ID\`."""
   parent(
-    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`Parent\`.\\"\\"\\"
+    """The globally unique \`ID\` to be used in selecting a single \`Parent\`."""
     nodeId: ID!
   ): Parent
   parentById(id: Int!): Parent
 
-  \\"\\"\\"Reads a single \`Protected\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`Protected\` using its globally unique \`ID\`."""
   protected(
-    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`Protected\`.\\"\\"\\"
+    """The globally unique \`ID\` to be used in selecting a single \`Protected\`."""
     nodeId: ID!
   ): Protected
   protectedById(id: Int!): Protected
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Protected\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Protected\`."""
   protectedsByOtherId(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: ProtectedFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
     otherId: Int
   ): ProtectedsConnection!
 
-  \\"\\"\\"
+  """
   Exposes the root query type nested one level down. This is helpful for Relay 1
   which can only query top level fields if they are in a particular form.
-  \\"\\"\\"
+  """
   query: Query!
 
-  \\"\\"\\"Reads a single \`RangeArrayType\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`RangeArrayType\` using its globally unique \`ID\`."""
   rangeArrayType(
-    \\"\\"\\"
+    """
     The globally unique \`ID\` to be used in selecting a single \`RangeArrayType\`.
-    \\"\\"\\"
+    """
     nodeId: ID!
   ): RangeArrayType
   rangeArrayTypeById(id: Int!): RangeArrayType
 
-  \\"\\"\\"Reads a single \`RangeType\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`RangeType\` using its globally unique \`ID\`."""
   rangeType(
-    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`RangeType\`.\\"\\"\\"
+    """The globally unique \`ID\` to be used in selecting a single \`RangeType\`."""
     nodeId: ID!
   ): RangeType
   rangeTypeById(id: Int!): RangeType
 
-  \\"\\"\\"Reads a single \`SideA\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`SideA\` using its globally unique \`ID\`."""
   sideA(
-    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`SideA\`.\\"\\"\\"
+    """The globally unique \`ID\` to be used in selecting a single \`SideA\`."""
     nodeId: ID!
   ): SideA
   sideAByAId(aId: Int!): SideA
 
-  \\"\\"\\"Reads a single \`SideB\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`SideB\` using its globally unique \`ID\`."""
   sideB(
-    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`SideB\`.\\"\\"\\"
+    """The globally unique \`ID\` to be used in selecting a single \`SideB\`."""
     nodeId: ID!
   ): SideB
   sideBByBId(bId: Int!): SideB
 
-  \\"\\"\\"Reads a single \`Unfilterable\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`Unfilterable\` using its globally unique \`ID\`."""
   unfilterable(
-    \\"\\"\\"
+    """
     The globally unique \`ID\` to be used in selecting a single \`Unfilterable\`.
-    \\"\\"\\"
+    """
     nodeId: ID!
   ): Unfilterable
   unfilterableById(id: Int!): Unfilterable
@@ -5528,77 +5528,77 @@ type RangeArrayType implements Node {
   int4RangeArray: [IntRange]
   int8RangeArray: [BigIntRange]
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
   numericRangeArray: [BigFloatRange]
   timestampRangeArray: [DatetimeRange]
   timestamptzRangeArray: [DatetimeRange]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`RangeArrayType\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input RangeArrayTypeFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [RangeArrayTypeFilter!]
 
-  \\"\\"\\"Filter by the object’s \`dateRangeArray\` field.\\"\\"\\"
+  """Filter by the object’s \`dateRangeArray\` field."""
   dateRangeArray: DateRangeListFilter
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`int4RangeArray\` field.\\"\\"\\"
+  """Filter by the object’s \`int4RangeArray\` field."""
   int4RangeArray: IntRangeListFilter
 
-  \\"\\"\\"Filter by the object’s \`int8RangeArray\` field.\\"\\"\\"
+  """Filter by the object’s \`int8RangeArray\` field."""
   int8RangeArray: BigIntRangeListFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: RangeArrayTypeFilter
 
-  \\"\\"\\"Filter by the object’s \`numericRangeArray\` field.\\"\\"\\"
+  """Filter by the object’s \`numericRangeArray\` field."""
   numericRangeArray: BigFloatRangeListFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [RangeArrayTypeFilter!]
 
-  \\"\\"\\"Filter by the object’s \`timestampRangeArray\` field.\\"\\"\\"
+  """Filter by the object’s \`timestampRangeArray\` field."""
   timestampRangeArray: DatetimeRangeListFilter
 
-  \\"\\"\\"Filter by the object’s \`timestamptzRangeArray\` field.\\"\\"\\"
+  """Filter by the object’s \`timestamptzRangeArray\` field."""
   timestamptzRangeArray: DatetimeRangeListFilter
 }
 
-\\"\\"\\"A connection to a list of \`RangeArrayType\` values.\\"\\"\\"
+"""A connection to a list of \`RangeArrayType\` values."""
 type RangeArrayTypesConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`RangeArrayType\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [RangeArrayTypesEdge!]!
 
-  \\"\\"\\"A list of \`RangeArrayType\` objects.\\"\\"\\"
+  """A list of \`RangeArrayType\` objects."""
   nodes: [RangeArrayType]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`RangeArrayType\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`RangeArrayType\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`RangeArrayType\` edge in the connection.\\"\\"\\"
+"""A \`RangeArrayType\` edge in the connection."""
 type RangeArrayTypesEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`RangeArrayType\` at the end of the edge.\\"\\"\\"
+  """The \`RangeArrayType\` at the end of the edge."""
   node: RangeArrayType
 }
 
-\\"\\"\\"Methods to use when ordering \`RangeArrayType\`.\\"\\"\\"
+"""Methods to use when ordering \`RangeArrayType\`."""
 enum RangeArrayTypesOrderBy {
   DATE_RANGE_ARRAY_ASC
   DATE_RANGE_ARRAY_DESC
@@ -5625,77 +5625,77 @@ type RangeType implements Node {
   int4Range: IntRange
   int8Range: BigIntRange
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
   numericRange: BigFloatRange
   timestampRange: DatetimeRange
   timestamptzRange: DatetimeRange
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`RangeType\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input RangeTypeFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [RangeTypeFilter!]
 
-  \\"\\"\\"Filter by the object’s \`dateRange\` field.\\"\\"\\"
+  """Filter by the object’s \`dateRange\` field."""
   dateRange: DateRangeFilter
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`int4Range\` field.\\"\\"\\"
+  """Filter by the object’s \`int4Range\` field."""
   int4Range: IntRangeFilter
 
-  \\"\\"\\"Filter by the object’s \`int8Range\` field.\\"\\"\\"
+  """Filter by the object’s \`int8Range\` field."""
   int8Range: BigIntRangeFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: RangeTypeFilter
 
-  \\"\\"\\"Filter by the object’s \`numericRange\` field.\\"\\"\\"
+  """Filter by the object’s \`numericRange\` field."""
   numericRange: BigFloatRangeFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [RangeTypeFilter!]
 
-  \\"\\"\\"Filter by the object’s \`timestampRange\` field.\\"\\"\\"
+  """Filter by the object’s \`timestampRange\` field."""
   timestampRange: DatetimeRangeFilter
 
-  \\"\\"\\"Filter by the object’s \`timestamptzRange\` field.\\"\\"\\"
+  """Filter by the object’s \`timestamptzRange\` field."""
   timestamptzRange: DatetimeRangeFilter
 }
 
-\\"\\"\\"A connection to a list of \`RangeType\` values.\\"\\"\\"
+"""A connection to a list of \`RangeType\` values."""
 type RangeTypesConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`RangeType\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [RangeTypesEdge!]!
 
-  \\"\\"\\"A list of \`RangeType\` objects.\\"\\"\\"
+  """A list of \`RangeType\` objects."""
   nodes: [RangeType]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`RangeType\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`RangeType\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`RangeType\` edge in the connection.\\"\\"\\"
+"""A \`RangeType\` edge in the connection."""
 type RangeTypesEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`RangeType\` at the end of the edge.\\"\\"\\"
+  """The \`RangeType\` at the end of the edge."""
   node: RangeType
 }
 
-\\"\\"\\"Methods to use when ordering \`RangeType\`.\\"\\"\\"
+"""Methods to use when ordering \`RangeType\`."""
 enum RangeTypesOrderBy {
   DATE_RANGE_ASC
   DATE_RANGE_DESC
@@ -5719,89 +5719,89 @@ enum RangeTypesOrderBy {
 type SideA implements Node {
   aId: Int!
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Junction\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Junction\`."""
   junctionsBySideAId(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: JunctionFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`Junction\`.\\"\\"\\"
+    """The method to use when ordering \`Junction\`."""
     orderBy: [JunctionsOrderBy!] = [PRIMARY_KEY_ASC]
   ): JunctionsConnection!
   name: String!
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`SideA\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input SideAFilter {
-  \\"\\"\\"Filter by the object’s \`aId\` field.\\"\\"\\"
+  """Filter by the object’s \`aId\` field."""
   aId: IntFilter
 
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [SideAFilter!]
 
-  \\"\\"\\"Filter by the object’s \`name\` field.\\"\\"\\"
+  """Filter by the object’s \`name\` field."""
   name: StringFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: SideAFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [SideAFilter!]
 }
 
-\\"\\"\\"A connection to a list of \`SideA\` values.\\"\\"\\"
+"""A connection to a list of \`SideA\` values."""
 type SideAsConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`SideA\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [SideAsEdge!]!
 
-  \\"\\"\\"A list of \`SideA\` objects.\\"\\"\\"
+  """A list of \`SideA\` objects."""
   nodes: [SideA]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`SideA\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`SideA\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`SideA\` edge in the connection.\\"\\"\\"
+"""A \`SideA\` edge in the connection."""
 type SideAsEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`SideA\` at the end of the edge.\\"\\"\\"
+  """The \`SideA\` at the end of the edge."""
   node: SideA
 }
 
-\\"\\"\\"Methods to use when ordering \`SideA\`.\\"\\"\\"
+"""Methods to use when ordering \`SideA\`."""
 enum SideAsOrderBy {
   A_ID_ASC
   A_ID_DESC
@@ -5815,89 +5815,89 @@ enum SideAsOrderBy {
 type SideB implements Node {
   bId: Int!
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Junction\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Junction\`."""
   junctionsBySideBId(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: JunctionFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`Junction\`.\\"\\"\\"
+    """The method to use when ordering \`Junction\`."""
     orderBy: [JunctionsOrderBy!] = [PRIMARY_KEY_ASC]
   ): JunctionsConnection!
   name: String!
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`SideB\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input SideBFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [SideBFilter!]
 
-  \\"\\"\\"Filter by the object’s \`bId\` field.\\"\\"\\"
+  """Filter by the object’s \`bId\` field."""
   bId: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`name\` field.\\"\\"\\"
+  """Filter by the object’s \`name\` field."""
   name: StringFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: SideBFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [SideBFilter!]
 }
 
-\\"\\"\\"A connection to a list of \`SideB\` values.\\"\\"\\"
+"""A connection to a list of \`SideB\` values."""
 type SideBsConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`SideB\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [SideBsEdge!]!
 
-  \\"\\"\\"A list of \`SideB\` objects.\\"\\"\\"
+  """A list of \`SideB\` objects."""
   nodes: [SideB]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`SideB\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`SideB\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`SideB\` edge in the connection.\\"\\"\\"
+"""A \`SideB\` edge in the connection."""
 type SideBsEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`SideB\` at the end of the edge.\\"\\"\\"
+  """The \`SideB\` at the end of the edge."""
   node: SideB
 }
 
-\\"\\"\\"Methods to use when ordering \`SideB\`.\\"\\"\\"
+"""Methods to use when ordering \`SideB\`."""
 enum SideBsOrderBy {
   B_ID_ASC
   B_ID_DESC
@@ -5908,382 +5908,382 @@ enum SideBsOrderBy {
   PRIMARY_KEY_DESC
 }
 
-\\"\\"\\"
+"""
 A filter to be used against String fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input StringFilter {
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: String
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value (case-insensitive).
-  \\"\\"\\"
+  """
   distinctFromInsensitive: String
 
-  \\"\\"\\"Ends with the specified string (case-sensitive).\\"\\"\\"
+  """Ends with the specified string (case-sensitive)."""
   endsWith: String
 
-  \\"\\"\\"Ends with the specified string (case-insensitive).\\"\\"\\"
+  """Ends with the specified string (case-insensitive)."""
   endsWithInsensitive: String
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: String
 
-  \\"\\"\\"Equal to the specified value (case-insensitive).\\"\\"\\"
+  """Equal to the specified value (case-insensitive)."""
   equalToInsensitive: String
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: String
 
-  \\"\\"\\"Greater than the specified value (case-insensitive).\\"\\"\\"
+  """Greater than the specified value (case-insensitive)."""
   greaterThanInsensitive: String
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: String
 
-  \\"\\"\\"Greater than or equal to the specified value (case-insensitive).\\"\\"\\"
+  """Greater than or equal to the specified value (case-insensitive)."""
   greaterThanOrEqualToInsensitive: String
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [String!]
 
-  \\"\\"\\"Included in the specified list (case-insensitive).\\"\\"\\"
-  inInsensitive: [String!]
-
-  \\"\\"\\"Contains the specified string (case-sensitive).\\"\\"\\"
+  """Contains the specified string (case-sensitive)."""
   includes: String
 
-  \\"\\"\\"Contains the specified string (case-insensitive).\\"\\"\\"
+  """Contains the specified string (case-insensitive)."""
   includesInsensitive: String
 
-  \\"\\"\\"
+  """Included in the specified list (case-insensitive)."""
+  inInsensitive: [String!]
+
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: String
 
-  \\"\\"\\"Less than the specified value (case-insensitive).\\"\\"\\"
+  """Less than the specified value (case-insensitive)."""
   lessThanInsensitive: String
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: String
 
-  \\"\\"\\"Less than or equal to the specified value (case-insensitive).\\"\\"\\"
+  """Less than or equal to the specified value (case-insensitive)."""
   lessThanOrEqualToInsensitive: String
 
-  \\"\\"\\"
+  """
   Matches the specified pattern (case-sensitive). An underscore (_) matches any
   single character; a percent sign (%) matches any sequence of zero or more characters.
-  \\"\\"\\"
+  """
   like: String
 
-  \\"\\"\\"
+  """
   Matches the specified pattern (case-insensitive). An underscore (_) matches
   any single character; a percent sign (%) matches any sequence of zero or more characters.
-  \\"\\"\\"
+  """
   likeInsensitive: String
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: String
 
-  \\"\\"\\"
+  """
   Equal to the specified value, treating null like an ordinary value (case-insensitive).
-  \\"\\"\\"
+  """
   notDistinctFromInsensitive: String
 
-  \\"\\"\\"Does not end with the specified string (case-sensitive).\\"\\"\\"
+  """Does not end with the specified string (case-sensitive)."""
   notEndsWith: String
 
-  \\"\\"\\"Does not end with the specified string (case-insensitive).\\"\\"\\"
+  """Does not end with the specified string (case-insensitive)."""
   notEndsWithInsensitive: String
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: String
 
-  \\"\\"\\"Not equal to the specified value (case-insensitive).\\"\\"\\"
+  """Not equal to the specified value (case-insensitive)."""
   notEqualToInsensitive: String
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [String!]
 
-  \\"\\"\\"Not included in the specified list (case-insensitive).\\"\\"\\"
-  notInInsensitive: [String!]
-
-  \\"\\"\\"Does not contain the specified string (case-sensitive).\\"\\"\\"
+  """Does not contain the specified string (case-sensitive)."""
   notIncludes: String
 
-  \\"\\"\\"Does not contain the specified string (case-insensitive).\\"\\"\\"
+  """Does not contain the specified string (case-insensitive)."""
   notIncludesInsensitive: String
 
-  \\"\\"\\"
+  """Not included in the specified list (case-insensitive)."""
+  notInInsensitive: [String!]
+
+  """
   Does not match the specified pattern (case-sensitive). An underscore (_)
   matches any single character; a percent sign (%) matches any sequence of zero
   or more characters.
-  \\"\\"\\"
+  """
   notLike: String
 
-  \\"\\"\\"
+  """
   Does not match the specified pattern (case-insensitive). An underscore (_)
   matches any single character; a percent sign (%) matches any sequence of zero
   or more characters.
-  \\"\\"\\"
+  """
   notLikeInsensitive: String
 
-  \\"\\"\\"Does not start with the specified string (case-sensitive).\\"\\"\\"
+  """Does not start with the specified string (case-sensitive)."""
   notStartsWith: String
 
-  \\"\\"\\"Does not start with the specified string (case-insensitive).\\"\\"\\"
+  """Does not start with the specified string (case-insensitive)."""
   notStartsWithInsensitive: String
 
-  \\"\\"\\"Starts with the specified string (case-sensitive).\\"\\"\\"
+  """Starts with the specified string (case-sensitive)."""
   startsWith: String
 
-  \\"\\"\\"Starts with the specified string (case-insensitive).\\"\\"\\"
+  """Starts with the specified string (case-insensitive)."""
   startsWithInsensitive: String
 }
 
-\\"\\"\\"
+"""
 A filter to be used against String List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input StringListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: String
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: String
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: String
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: String
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: String
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: String
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [String]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [String]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [String]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [String]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [String]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [String]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [String]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [String]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [String]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [String]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [String]
 }
 
-\\"\\"\\"
+"""
 The exact time of day, does not include the date. May or may not have a timezone offset.
-\\"\\"\\"
+"""
 scalar Time
 
-\\"\\"\\"
+"""
 A filter to be used against Time fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input TimeFilter {
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: Time
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: Time
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: Time
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: Time
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [Time!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: Time
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: Time
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: Time
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: Time
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [Time!]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against Time List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input TimeListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: Time
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: Time
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: Time
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: Time
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: Time
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: Time
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [Time]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [Time]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [Time]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [Time]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [Time]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [Time]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [Time]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [Time]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [Time]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [Time]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [Time]
 }
 
 type Unfilterable implements Node {
-  \\"\\"\\"Reads and enables pagination through a set of \`ChildNoRelatedFilter\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`ChildNoRelatedFilter\`."""
   childNoRelatedFiltersByUnfilterableId(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: ChildNoRelatedFilterFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`ChildNoRelatedFilter\`.\\"\\"\\"
+    """The method to use when ordering \`ChildNoRelatedFilter\`."""
     orderBy: [ChildNoRelatedFiltersOrderBy!] = [PRIMARY_KEY_ASC]
   ): ChildNoRelatedFiltersConnection!
   id: Int!
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
   text: String
 }
 
-\\"\\"\\"A connection to a list of \`Unfilterable\` values.\\"\\"\\"
+"""A connection to a list of \`Unfilterable\` values."""
 type UnfilterablesConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`Unfilterable\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [UnfilterablesEdge!]!
 
-  \\"\\"\\"A list of \`Unfilterable\` objects.\\"\\"\\"
+  """A list of \`Unfilterable\` objects."""
   nodes: [Unfilterable]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`Unfilterable\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`Unfilterable\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`Unfilterable\` edge in the connection.\\"\\"\\"
+"""A \`Unfilterable\` edge in the connection."""
 type UnfilterablesEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`Unfilterable\` at the end of the edge.\\"\\"\\"
+  """The \`Unfilterable\` at the end of the edge."""
   node: Unfilterable
 }
 
-\\"\\"\\"Methods to use when ordering \`Unfilterable\`.\\"\\"\\"
+"""Methods to use when ordering \`Unfilterable\`."""
 enum UnfilterablesOrderBy {
   ID_ASC
   ID_DESC
@@ -6294,114 +6294,114 @@ enum UnfilterablesOrderBy {
   TEXT_DESC
 }
 
-\\"\\"\\"
+"""
 A universally unique identifier as defined by [RFC 4122](https://tools.ietf.org/html/rfc4122).
-\\"\\"\\"
+"""
 scalar UUID
 
-\\"\\"\\"
+"""
 A filter to be used against UUID fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input UUIDFilter {
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: UUID
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: UUID
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: UUID
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: UUID
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [UUID!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: UUID
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: UUID
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: UUID
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: UUID
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [UUID!]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against UUID List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input UUIDListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: UUID
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: UUID
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: UUID
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: UUID
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: UUID
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: UUID
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [UUID]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [UUID]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [UUID]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [UUID]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [UUID]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [UUID]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [UUID]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [UUID]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [UUID]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [UUID]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [UUID]
 }
-"
+
 `;

--- a/__tests__/integration/schema/__snapshots__/allowedFieldTypes.test.ts.snap
+++ b/__tests__/integration/schema/__snapshots__/allowedFieldTypes.test.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`prints a schema with the filter plugin and the connectionFilterAllowedFieldTypes option 1`] = `
-"type ArrayType implements Node {
+type ArrayType implements Node {
   bit4Array: [BitString]
   boolArray: [Boolean]
   bpchar4Array: [String]
@@ -25,9 +25,9 @@ exports[`prints a schema with the filter plugin and the connectionFilterAllowedF
   moneyArray: [Float]
   nameArray: [String]
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
   numericArray: [BigFloat]
   textArray: [String]
@@ -41,74 +41,74 @@ exports[`prints a schema with the filter plugin and the connectionFilterAllowedF
   xmlArray: [String]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`ArrayType\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input ArrayTypeFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [ArrayTypeFilter!]
 
-  \\"\\"\\"Filter by the object’s \`bpchar4Array\` field.\\"\\"\\"
+  """Filter by the object’s \`bpchar4Array\` field."""
   bpchar4Array: StringListFilter
 
-  \\"\\"\\"Filter by the object’s \`char4Array\` field.\\"\\"\\"
+  """Filter by the object’s \`char4Array\` field."""
   char4Array: StringListFilter
 
-  \\"\\"\\"Filter by the object’s \`citextArray\` field.\\"\\"\\"
+  """Filter by the object’s \`citextArray\` field."""
   citextArray: StringListFilter
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`int2Array\` field.\\"\\"\\"
+  """Filter by the object’s \`int2Array\` field."""
   int2Array: IntListFilter
 
-  \\"\\"\\"Filter by the object’s \`int4Array\` field.\\"\\"\\"
+  """Filter by the object’s \`int4Array\` field."""
   int4Array: IntListFilter
 
-  \\"\\"\\"Filter by the object’s \`nameArray\` field.\\"\\"\\"
+  """Filter by the object’s \`nameArray\` field."""
   nameArray: StringListFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: ArrayTypeFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [ArrayTypeFilter!]
 
-  \\"\\"\\"Filter by the object’s \`textArray\` field.\\"\\"\\"
+  """Filter by the object’s \`textArray\` field."""
   textArray: StringListFilter
 
-  \\"\\"\\"Filter by the object’s \`varcharArray\` field.\\"\\"\\"
+  """Filter by the object’s \`varcharArray\` field."""
   varcharArray: StringListFilter
 }
 
-\\"\\"\\"A connection to a list of \`ArrayType\` values.\\"\\"\\"
+"""A connection to a list of \`ArrayType\` values."""
 type ArrayTypesConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`ArrayType\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [ArrayTypesEdge!]!
 
-  \\"\\"\\"A list of \`ArrayType\` objects.\\"\\"\\"
+  """A list of \`ArrayType\` objects."""
   nodes: [ArrayType]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`ArrayType\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`ArrayType\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`ArrayType\` edge in the connection.\\"\\"\\"
+"""A \`ArrayType\` edge in the connection."""
 type ArrayTypesEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`ArrayType\` at the end of the edge.\\"\\"\\"
+  """The \`ArrayType\` at the end of the edge."""
   node: ArrayType
 }
 
-\\"\\"\\"Methods to use when ordering \`ArrayType\`.\\"\\"\\"
+"""Methods to use when ordering \`ArrayType\`."""
 enum ArrayTypesOrderBy {
   BIT4_ARRAY_ASC
   BIT4_ARRAY_DESC
@@ -180,15 +180,15 @@ enum ArrayTypesOrderBy {
 }
 
 type Backward implements Node {
-  \\"\\"\\"Reads a single \`Filterable\` that is related to this \`Backward\`.\\"\\"\\"
+  """Reads a single \`Filterable\` that is related to this \`Backward\`."""
   filterableByFilterableId: Filterable
   filterableId: Int
   id: Int!
   name: String!
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
@@ -196,70 +196,70 @@ type BackwardCompound implements Node {
   backwardCompound1: Int!
   backwardCompound2: Int!
 
-  \\"\\"\\"
+  """
   Reads a single \`Filterable\` that is related to this \`BackwardCompound\`.
-  \\"\\"\\"
+  """
   filterableByBackwardCompound1AndBackwardCompound2: Filterable
   name: String
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`BackwardCompound\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input BackwardCompoundFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [BackwardCompoundFilter!]
 
-  \\"\\"\\"Filter by the object’s \`backwardCompound1\` field.\\"\\"\\"
+  """Filter by the object’s \`backwardCompound1\` field."""
   backwardCompound1: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`backwardCompound2\` field.\\"\\"\\"
+  """Filter by the object’s \`backwardCompound2\` field."""
   backwardCompound2: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`name\` field.\\"\\"\\"
+  """Filter by the object’s \`name\` field."""
   name: StringFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: BackwardCompoundFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [BackwardCompoundFilter!]
 }
 
-\\"\\"\\"A connection to a list of \`BackwardCompound\` values.\\"\\"\\"
+"""A connection to a list of \`BackwardCompound\` values."""
 type BackwardCompoundsConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`BackwardCompound\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [BackwardCompoundsEdge!]!
 
-  \\"\\"\\"A list of \`BackwardCompound\` objects.\\"\\"\\"
+  """A list of \`BackwardCompound\` objects."""
   nodes: [BackwardCompound]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"
+  """
   The count of *all* \`BackwardCompound\` you could get from the connection.
-  \\"\\"\\"
+  """
   totalCount: Int!
 }
 
-\\"\\"\\"A \`BackwardCompound\` edge in the connection.\\"\\"\\"
+"""A \`BackwardCompound\` edge in the connection."""
 type BackwardCompoundsEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`BackwardCompound\` at the end of the edge.\\"\\"\\"
+  """The \`BackwardCompound\` at the end of the edge."""
   node: BackwardCompound
 }
 
-\\"\\"\\"Methods to use when ordering \`BackwardCompound\`.\\"\\"\\"
+"""Methods to use when ordering \`BackwardCompound\`."""
 enum BackwardCompoundsOrderBy {
   BACKWARD_COMPOUND_1_ASC
   BACKWARD_COMPOUND_1_DESC
@@ -272,56 +272,56 @@ enum BackwardCompoundsOrderBy {
   PRIMARY_KEY_DESC
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`Backward\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input BackwardFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [BackwardFilter!]
 
-  \\"\\"\\"Filter by the object’s \`filterableId\` field.\\"\\"\\"
+  """Filter by the object’s \`filterableId\` field."""
   filterableId: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`name\` field.\\"\\"\\"
+  """Filter by the object’s \`name\` field."""
   name: StringFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: BackwardFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [BackwardFilter!]
 }
 
-\\"\\"\\"A connection to a list of \`Backward\` values.\\"\\"\\"
+"""A connection to a list of \`Backward\` values."""
 type BackwardsConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`Backward\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [BackwardsEdge!]!
 
-  \\"\\"\\"A list of \`Backward\` objects.\\"\\"\\"
+  """A list of \`Backward\` objects."""
   nodes: [Backward]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`Backward\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`Backward\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`Backward\` edge in the connection.\\"\\"\\"
+"""A \`Backward\` edge in the connection."""
 type BackwardsEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`Backward\` at the end of the edge.\\"\\"\\"
+  """The \`Backward\` at the end of the edge."""
   node: Backward
 }
 
-\\"\\"\\"Methods to use when ordering \`Backward\`.\\"\\"\\"
+"""Methods to use when ordering \`Backward\`."""
 enum BackwardsOrderBy {
   FILTERABLE_ID_ASC
   FILTERABLE_ID_DESC
@@ -334,175 +334,175 @@ enum BackwardsOrderBy {
   PRIMARY_KEY_DESC
 }
 
-\\"\\"\\"
+"""
 A floating point number that requires more precision than IEEE 754 binary 64
-\\"\\"\\"
+"""
 scalar BigFloat
 
-\\"\\"\\"A range of \`BigFloat\`.\\"\\"\\"
+"""A range of \`BigFloat\`."""
 type BigFloatRange {
-  \\"\\"\\"The ending bound of our range.\\"\\"\\"
+  """The ending bound of our range."""
   end: BigFloatRangeBound
 
-  \\"\\"\\"The starting bound of our range.\\"\\"\\"
+  """The starting bound of our range."""
   start: BigFloatRangeBound
 }
 
-\\"\\"\\"
+"""
 The value at one end of a range. A range can either include this value, or not.
-\\"\\"\\"
+"""
 type BigFloatRangeBound {
-  \\"\\"\\"Whether or not the value of this bound is included in the range.\\"\\"\\"
+  """Whether or not the value of this bound is included in the range."""
   inclusive: Boolean!
 
-  \\"\\"\\"The value at one end of our range.\\"\\"\\"
+  """The value at one end of our range."""
   value: BigFloat!
 }
 
-\\"\\"\\"
+"""
 A signed eight-byte integer. The upper big integer values are greater than the
 max value for a JavaScript number. Therefore all big integers will be output as
 strings and not numbers.
-\\"\\"\\"
+"""
 scalar BigInt
 
-\\"\\"\\"A range of \`BigInt\`.\\"\\"\\"
+"""A range of \`BigInt\`."""
 type BigIntRange {
-  \\"\\"\\"The ending bound of our range.\\"\\"\\"
+  """The ending bound of our range."""
   end: BigIntRangeBound
 
-  \\"\\"\\"The starting bound of our range.\\"\\"\\"
+  """The starting bound of our range."""
   start: BigIntRangeBound
 }
 
-\\"\\"\\"
+"""
 The value at one end of a range. A range can either include this value, or not.
-\\"\\"\\"
+"""
 type BigIntRangeBound {
-  \\"\\"\\"Whether or not the value of this bound is included in the range.\\"\\"\\"
+  """Whether or not the value of this bound is included in the range."""
   inclusive: Boolean!
 
-  \\"\\"\\"The value at one end of our range.\\"\\"\\"
+  """The value at one end of our range."""
   value: BigInt!
 }
 
-\\"\\"\\"A string representing a series of binary bits\\"\\"\\"
+"""A string representing a series of binary bits"""
 scalar BitString
 
 scalar Char4Domain
 
 type Child implements Node {
-  \\"\\"\\"Reads a single \`Filterable\` that is related to this \`Child\`.\\"\\"\\"
+  """Reads a single \`Filterable\` that is related to this \`Child\`."""
   filterableByFilterableId: Filterable
   filterableId: Int
   id: Int!
   name: String!
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`Child\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input ChildFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [ChildFilter!]
 
-  \\"\\"\\"Filter by the object’s \`filterableId\` field.\\"\\"\\"
+  """Filter by the object’s \`filterableId\` field."""
   filterableId: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`name\` field.\\"\\"\\"
+  """Filter by the object’s \`name\` field."""
   name: StringFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: ChildFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [ChildFilter!]
 }
 
 type ChildNoRelatedFilter implements Node {
-  \\"\\"\\"
+  """
   Reads a single \`Filterable\` that is related to this \`ChildNoRelatedFilter\`.
-  \\"\\"\\"
+  """
   filterableByFilterableId: Filterable
   filterableId: Int
   id: Int!
   name: String!
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 
-  \\"\\"\\"
+  """
   Reads a single \`Unfilterable\` that is related to this \`ChildNoRelatedFilter\`.
-  \\"\\"\\"
+  """
   unfilterableByUnfilterableId: Unfilterable
   unfilterableId: Int
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`ChildNoRelatedFilter\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input ChildNoRelatedFilterFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [ChildNoRelatedFilterFilter!]
 
-  \\"\\"\\"Filter by the object’s \`filterableId\` field.\\"\\"\\"
+  """Filter by the object’s \`filterableId\` field."""
   filterableId: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`name\` field.\\"\\"\\"
+  """Filter by the object’s \`name\` field."""
   name: StringFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: ChildNoRelatedFilterFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [ChildNoRelatedFilterFilter!]
 
-  \\"\\"\\"Filter by the object’s \`unfilterableId\` field.\\"\\"\\"
+  """Filter by the object’s \`unfilterableId\` field."""
   unfilterableId: IntFilter
 }
 
-\\"\\"\\"A connection to a list of \`ChildNoRelatedFilter\` values.\\"\\"\\"
+"""A connection to a list of \`ChildNoRelatedFilter\` values."""
 type ChildNoRelatedFiltersConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`ChildNoRelatedFilter\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [ChildNoRelatedFiltersEdge!]!
 
-  \\"\\"\\"A list of \`ChildNoRelatedFilter\` objects.\\"\\"\\"
+  """A list of \`ChildNoRelatedFilter\` objects."""
   nodes: [ChildNoRelatedFilter]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"
+  """
   The count of *all* \`ChildNoRelatedFilter\` you could get from the connection.
-  \\"\\"\\"
+  """
   totalCount: Int!
 }
 
-\\"\\"\\"A \`ChildNoRelatedFilter\` edge in the connection.\\"\\"\\"
+"""A \`ChildNoRelatedFilter\` edge in the connection."""
 type ChildNoRelatedFiltersEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`ChildNoRelatedFilter\` at the end of the edge.\\"\\"\\"
+  """The \`ChildNoRelatedFilter\` at the end of the edge."""
   node: ChildNoRelatedFilter
 }
 
-\\"\\"\\"Methods to use when ordering \`ChildNoRelatedFilter\`.\\"\\"\\"
+"""Methods to use when ordering \`ChildNoRelatedFilter\`."""
 enum ChildNoRelatedFiltersOrderBy {
   FILTERABLE_ID_ASC
   FILTERABLE_ID_DESC
@@ -517,33 +517,33 @@ enum ChildNoRelatedFiltersOrderBy {
   UNFILTERABLE_ID_DESC
 }
 
-\\"\\"\\"A connection to a list of \`Child\` values.\\"\\"\\"
+"""A connection to a list of \`Child\` values."""
 type ChildrenConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`Child\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [ChildrenEdge!]!
 
-  \\"\\"\\"A list of \`Child\` objects.\\"\\"\\"
+  """A list of \`Child\` objects."""
   nodes: [Child]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`Child\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`Child\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`Child\` edge in the connection.\\"\\"\\"
+"""A \`Child\` edge in the connection."""
 type ChildrenEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`Child\` at the end of the edge.\\"\\"\\"
+  """The \`Child\` at the end of the edge."""
   node: Child
 }
 
-\\"\\"\\"Methods to use when ordering \`Child\`.\\"\\"\\"
+"""Methods to use when ordering \`Child\`."""
 enum ChildrenOrderBy {
   FILTERABLE_ID_ASC
   FILTERABLE_ID_DESC
@@ -561,57 +561,57 @@ type Composite {
   b: String
 }
 
-\\"\\"\\"A location in a connection that can be used for resuming pagination.\\"\\"\\"
+"""A location in a connection that can be used for resuming pagination."""
 scalar Cursor
 
-\\"\\"\\"The day, does not include a time.\\"\\"\\"
+"""The day, does not include a time."""
 scalar Date
 
 scalar DateDomain
 
-\\"\\"\\"A range of \`Date\`.\\"\\"\\"
+"""A range of \`Date\`."""
 type DateRange {
-  \\"\\"\\"The ending bound of our range.\\"\\"\\"
+  """The ending bound of our range."""
   end: DateRangeBound
 
-  \\"\\"\\"The starting bound of our range.\\"\\"\\"
+  """The starting bound of our range."""
   start: DateRangeBound
 }
 
-\\"\\"\\"
+"""
 The value at one end of a range. A range can either include this value, or not.
-\\"\\"\\"
+"""
 type DateRangeBound {
-  \\"\\"\\"Whether or not the value of this bound is included in the range.\\"\\"\\"
+  """Whether or not the value of this bound is included in the range."""
   inclusive: Boolean!
 
-  \\"\\"\\"The value at one end of our range.\\"\\"\\"
+  """The value at one end of our range."""
   value: Date!
 }
 
-\\"\\"\\"
+"""
 A point in time as described by the [ISO
 8601](https://en.wikipedia.org/wiki/ISO_8601) standard. May or may not include a timezone.
-\\"\\"\\"
+"""
 scalar Datetime
 
-\\"\\"\\"A range of \`Datetime\`.\\"\\"\\"
+"""A range of \`Datetime\`."""
 type DatetimeRange {
-  \\"\\"\\"The ending bound of our range.\\"\\"\\"
+  """The ending bound of our range."""
   end: DatetimeRangeBound
 
-  \\"\\"\\"The starting bound of our range.\\"\\"\\"
+  """The starting bound of our range."""
   start: DatetimeRangeBound
 }
 
-\\"\\"\\"
+"""
 The value at one end of a range. A range can either include this value, or not.
-\\"\\"\\"
+"""
 type DatetimeRangeBound {
-  \\"\\"\\"Whether or not the value of this bound is included in the range.\\"\\"\\"
+  """Whether or not the value of this bound is included in the range."""
   inclusive: Boolean!
 
-  \\"\\"\\"The value at one end of our range.\\"\\"\\"
+  """The value at one end of our range."""
   value: Datetime!
 }
 
@@ -621,56 +621,56 @@ type DomainType implements Node {
   id: Int!
   int4Domain: Int4Domain
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`DomainType\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input DomainTypeFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [DomainTypeFilter!]
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: DomainTypeFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [DomainTypeFilter!]
 }
 
-\\"\\"\\"A connection to a list of \`DomainType\` values.\\"\\"\\"
+"""A connection to a list of \`DomainType\` values."""
 type DomainTypesConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`DomainType\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [DomainTypesEdge!]!
 
-  \\"\\"\\"A list of \`DomainType\` objects.\\"\\"\\"
+  """A list of \`DomainType\` objects."""
   nodes: [DomainType]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`DomainType\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`DomainType\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`DomainType\` edge in the connection.\\"\\"\\"
+"""A \`DomainType\` edge in the connection."""
 type DomainTypesEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`DomainType\` at the end of the edge.\\"\\"\\"
+  """The \`DomainType\` at the end of the edge."""
   node: DomainType
 }
 
-\\"\\"\\"Methods to use when ordering \`DomainType\`.\\"\\"\\"
+"""Methods to use when ordering \`DomainType\`."""
 enum DomainTypesOrderBy {
   CHAR4_DOMAIN_ASC
   CHAR4_DOMAIN_DESC
@@ -689,56 +689,56 @@ type EnumArrayType implements Node {
   enumArray: [Mood]
   id: Int!
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`EnumArrayType\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input EnumArrayTypeFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [EnumArrayTypeFilter!]
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: EnumArrayTypeFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [EnumArrayTypeFilter!]
 }
 
-\\"\\"\\"A connection to a list of \`EnumArrayType\` values.\\"\\"\\"
+"""A connection to a list of \`EnumArrayType\` values."""
 type EnumArrayTypesConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`EnumArrayType\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [EnumArrayTypesEdge!]!
 
-  \\"\\"\\"A list of \`EnumArrayType\` objects.\\"\\"\\"
+  """A list of \`EnumArrayType\` objects."""
   nodes: [EnumArrayType]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`EnumArrayType\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`EnumArrayType\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`EnumArrayType\` edge in the connection.\\"\\"\\"
+"""A \`EnumArrayType\` edge in the connection."""
 type EnumArrayTypesEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`EnumArrayType\` at the end of the edge.\\"\\"\\"
+  """The \`EnumArrayType\` at the end of the edge."""
   node: EnumArrayType
 }
 
-\\"\\"\\"Methods to use when ordering \`EnumArrayType\`.\\"\\"\\"
+"""Methods to use when ordering \`EnumArrayType\`."""
 enum EnumArrayTypesOrderBy {
   ENUM_ARRAY_ASC
   ENUM_ARRAY_DESC
@@ -753,56 +753,56 @@ type EnumType implements Node {
   enum: Mood
   id: Int!
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`EnumType\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input EnumTypeFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [EnumTypeFilter!]
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: EnumTypeFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [EnumTypeFilter!]
 }
 
-\\"\\"\\"A connection to a list of \`EnumType\` values.\\"\\"\\"
+"""A connection to a list of \`EnumType\` values."""
 type EnumTypesConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`EnumType\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [EnumTypesEdge!]!
 
-  \\"\\"\\"A list of \`EnumType\` objects.\\"\\"\\"
+  """A list of \`EnumType\` objects."""
   nodes: [EnumType]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`EnumType\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`EnumType\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`EnumType\` edge in the connection.\\"\\"\\"
+"""A \`EnumType\` edge in the connection."""
 type EnumTypesEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`EnumType\` at the end of the edge.\\"\\"\\"
+  """The \`EnumType\` at the end of the edge."""
   node: EnumType
 }
 
-\\"\\"\\"Methods to use when ordering \`EnumType\`.\\"\\"\\"
+"""Methods to use when ordering \`EnumType\`."""
 enum EnumTypesOrderBy {
   ENUM_ASC
   ENUM_DESC
@@ -814,14 +814,14 @@ enum EnumTypesOrderBy {
 }
 
 type Filterable implements Node {
-  \\"\\"\\"Reads a single \`Backward\` that is related to this \`Filterable\`.\\"\\"\\"
+  """Reads a single \`Backward\` that is related to this \`Filterable\`."""
   backwardByFilterableId: Backward
   backwardCompound1: Int
   backwardCompound2: Int
 
-  \\"\\"\\"
+  """
   Reads a single \`BackwardCompound\` that is related to this \`Filterable\`.
-  \\"\\"\\"
+  """
   backwardCompoundByBackwardCompound1AndBackwardCompound2: BackwardCompound
   bit4: BitString
   bool: Boolean
@@ -829,61 +829,61 @@ type Filterable implements Node {
   bytea: String
   char4: String
 
-  \\"\\"\\"Reads and enables pagination through a set of \`ChildNoRelatedFilter\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`ChildNoRelatedFilter\`."""
   childNoRelatedFiltersByFilterableId(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: ChildNoRelatedFilterFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`ChildNoRelatedFilter\`.\\"\\"\\"
+    """The method to use when ordering \`ChildNoRelatedFilter\`."""
     orderBy: [ChildNoRelatedFiltersOrderBy!] = [PRIMARY_KEY_ASC]
   ): ChildNoRelatedFiltersConnection!
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Child\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Child\`."""
   childrenByFilterableId(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: ChildFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`Child\`.\\"\\"\\"
+    """The method to use when ordering \`Child\`."""
     orderBy: [ChildrenOrderBy!] = [PRIMARY_KEY_ASC]
   ): ChildrenConnection!
   cidr: String
@@ -894,126 +894,126 @@ type Filterable implements Node {
   computedChild: Child
   computedIntArray: [Int]
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Child\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Child\`."""
   computedSetofChild(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: ChildFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
   ): ChildrenConnection!
   computedSetofInt(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: IntFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
   ): FilterableComputedSetofIntConnection!
   computedTaggedFilterable: Int
   computedWithRequiredArg(i: Int!): Int
   date: Date
 
-  \\"\\"\\"Reads and enables pagination through a set of \`FilterableClosure\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`FilterableClosure\`."""
   filterableClosuresByAncestorId(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: FilterableClosureFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`FilterableClosure\`.\\"\\"\\"
+    """The method to use when ordering \`FilterableClosure\`."""
     orderBy: [FilterableClosuresOrderBy!] = [PRIMARY_KEY_ASC]
   ): FilterableClosuresConnection!
 
-  \\"\\"\\"Reads and enables pagination through a set of \`FilterableClosure\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`FilterableClosure\`."""
   filterableClosuresByDescendantId(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: FilterableClosureFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`FilterableClosure\`.\\"\\"\\"
+    """The method to use when ordering \`FilterableClosure\`."""
     orderBy: [FilterableClosuresOrderBy!] = [PRIMARY_KEY_ASC]
   ): FilterableClosuresConnection!
   float4: Float
   float8: Float
 
-  \\"\\"\\"Reads a single \`Forward\` that is related to this \`Filterable\`.\\"\\"\\"
+  """Reads a single \`Forward\` that is related to this \`Filterable\`."""
   forwardByForwardId: Forward
   forwardColumn: Forward
   forwardCompound1: Int
   forwardCompound2: Int
 
-  \\"\\"\\"Reads a single \`ForwardCompound\` that is related to this \`Filterable\`.\\"\\"\\"
+  """Reads a single \`ForwardCompound\` that is related to this \`Filterable\`."""
   forwardCompoundByForwardCompound1AndForwardCompound2: ForwardCompound
   forwardId: Int
   hstore: KeyValueHash
@@ -1029,13 +1029,13 @@ type Filterable implements Node {
   money: Float
   name: String
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
   numeric: BigFloat
 
-  \\"\\"\\"Reads a single \`Parent\` that is related to this \`Filterable\`.\\"\\"\\"
+  """Reads a single \`Parent\` that is related to this \`Filterable\`."""
   parentByParentId: Parent
   parentId: Int
   text: String
@@ -1055,78 +1055,78 @@ type FilterableClosure implements Node {
   depth: Int!
   descendantId: Int!
 
-  \\"\\"\\"
+  """
   Reads a single \`Filterable\` that is related to this \`FilterableClosure\`.
-  \\"\\"\\"
+  """
   filterableByAncestorId: Filterable
 
-  \\"\\"\\"
+  """
   Reads a single \`Filterable\` that is related to this \`FilterableClosure\`.
-  \\"\\"\\"
+  """
   filterableByDescendantId: Filterable
   id: Int!
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`FilterableClosure\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input FilterableClosureFilter {
-  \\"\\"\\"Filter by the object’s \`ancestorId\` field.\\"\\"\\"
+  """Filter by the object’s \`ancestorId\` field."""
   ancestorId: IntFilter
 
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [FilterableClosureFilter!]
 
-  \\"\\"\\"Filter by the object’s \`depth\` field.\\"\\"\\"
+  """Filter by the object’s \`depth\` field."""
   depth: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`descendantId\` field.\\"\\"\\"
+  """Filter by the object’s \`descendantId\` field."""
   descendantId: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: FilterableClosureFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [FilterableClosureFilter!]
 }
 
-\\"\\"\\"A connection to a list of \`FilterableClosure\` values.\\"\\"\\"
+"""A connection to a list of \`FilterableClosure\` values."""
 type FilterableClosuresConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`FilterableClosure\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [FilterableClosuresEdge!]!
 
-  \\"\\"\\"A list of \`FilterableClosure\` objects.\\"\\"\\"
+  """A list of \`FilterableClosure\` objects."""
   nodes: [FilterableClosure]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"
+  """
   The count of *all* \`FilterableClosure\` you could get from the connection.
-  \\"\\"\\"
+  """
   totalCount: Int!
 }
 
-\\"\\"\\"A \`FilterableClosure\` edge in the connection.\\"\\"\\"
+"""A \`FilterableClosure\` edge in the connection."""
 type FilterableClosuresEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`FilterableClosure\` at the end of the edge.\\"\\"\\"
+  """The \`FilterableClosure\` at the end of the edge."""
   node: FilterableClosure
 }
 
-\\"\\"\\"Methods to use when ordering \`FilterableClosure\`.\\"\\"\\"
+"""Methods to use when ordering \`FilterableClosure\`."""
 enum FilterableClosuresOrderBy {
   ANCESTOR_ID_ASC
   ANCESTOR_ID_DESC
@@ -1141,124 +1141,124 @@ enum FilterableClosuresOrderBy {
   PRIMARY_KEY_DESC
 }
 
-\\"\\"\\"A connection to a list of \`Int\` values.\\"\\"\\"
+"""A connection to a list of \`Int\` values."""
 type FilterableComputedSetofIntConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`Int\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [FilterableComputedSetofIntEdge!]!
 
-  \\"\\"\\"A list of \`Int\` objects.\\"\\"\\"
+  """A list of \`Int\` objects."""
   nodes: [Int]!
 
-  \\"\\"\\"The count of *all* \`Int\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`Int\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`Int\` edge in the connection.\\"\\"\\"
+"""A \`Int\` edge in the connection."""
 type FilterableComputedSetofIntEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`Int\` at the end of the edge.\\"\\"\\"
+  """The \`Int\` at the end of the edge."""
   node: Int
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`Filterable\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input FilterableFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [FilterableFilter!]
 
-  \\"\\"\\"Filter by the object’s \`backwardCompound1\` field.\\"\\"\\"
+  """Filter by the object’s \`backwardCompound1\` field."""
   backwardCompound1: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`backwardCompound2\` field.\\"\\"\\"
+  """Filter by the object’s \`backwardCompound2\` field."""
   backwardCompound2: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`bpchar4\` field.\\"\\"\\"
+  """Filter by the object’s \`bpchar4\` field."""
   bpchar4: StringFilter
 
-  \\"\\"\\"Filter by the object’s \`char4\` field.\\"\\"\\"
+  """Filter by the object’s \`char4\` field."""
   char4: StringFilter
 
-  \\"\\"\\"Filter by the object’s \`citext\` field.\\"\\"\\"
+  """Filter by the object’s \`citext\` field."""
   citext: StringFilter
 
-  \\"\\"\\"Filter by the object’s \`computed\` field.\\"\\"\\"
+  """Filter by the object’s \`computed\` field."""
   computed: StringFilter
 
-  \\"\\"\\"Filter by the object’s \`computedIntArray\` field.\\"\\"\\"
+  """Filter by the object’s \`computedIntArray\` field."""
   computedIntArray: IntListFilter
 
-  \\"\\"\\"Filter by the object’s \`computedTaggedFilterable\` field.\\"\\"\\"
+  """Filter by the object’s \`computedTaggedFilterable\` field."""
   computedTaggedFilterable: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`forwardCompound1\` field.\\"\\"\\"
+  """Filter by the object’s \`forwardCompound1\` field."""
   forwardCompound1: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`forwardCompound2\` field.\\"\\"\\"
+  """Filter by the object’s \`forwardCompound2\` field."""
   forwardCompound2: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`forwardId\` field.\\"\\"\\"
+  """Filter by the object’s \`forwardId\` field."""
   forwardId: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`int2\` field.\\"\\"\\"
+  """Filter by the object’s \`int2\` field."""
   int2: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`int4\` field.\\"\\"\\"
+  """Filter by the object’s \`int4\` field."""
   int4: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`name\` field.\\"\\"\\"
+  """Filter by the object’s \`name\` field."""
   name: StringFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: FilterableFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [FilterableFilter!]
 
-  \\"\\"\\"Filter by the object’s \`parentId\` field.\\"\\"\\"
+  """Filter by the object’s \`parentId\` field."""
   parentId: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`text\` field.\\"\\"\\"
+  """Filter by the object’s \`text\` field."""
   text: StringFilter
 
-  \\"\\"\\"Filter by the object’s \`varchar\` field.\\"\\"\\"
+  """Filter by the object’s \`varchar\` field."""
   varchar: StringFilter
 }
 
-\\"\\"\\"A connection to a list of \`Filterable\` values.\\"\\"\\"
+"""A connection to a list of \`Filterable\` values."""
 type FilterablesConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`Filterable\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [FilterablesEdge!]!
 
-  \\"\\"\\"A list of \`Filterable\` objects.\\"\\"\\"
+  """A list of \`Filterable\` objects."""
   nodes: [Filterable]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`Filterable\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`Filterable\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`Filterable\` edge in the connection.\\"\\"\\"
+"""A \`Filterable\` edge in the connection."""
 type FilterablesEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`Filterable\` at the end of the edge.\\"\\"\\"
+  """The \`Filterable\` at the end of the edge."""
   node: Filterable
 }
 
-\\"\\"\\"Methods to use when ordering \`Filterable\`.\\"\\"\\"
+"""Methods to use when ordering \`Filterable\`."""
 enum FilterablesOrderBy {
   BACKWARD_COMPOUND_1_ASC
   BACKWARD_COMPOUND_1_DESC
@@ -1348,82 +1348,82 @@ enum FilterablesOrderBy {
 }
 
 type Forward implements Node {
-  \\"\\"\\"Reads a single \`Filterable\` that is related to this \`Forward\`.\\"\\"\\"
+  """Reads a single \`Filterable\` that is related to this \`Forward\`."""
   filterableByForwardId: Filterable
   id: Int!
   name: String!
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
 type ForwardCompound implements Node {
-  \\"\\"\\"Reads a single \`Filterable\` that is related to this \`ForwardCompound\`.\\"\\"\\"
+  """Reads a single \`Filterable\` that is related to this \`ForwardCompound\`."""
   filterableByForwardCompound1AndForwardCompound2: Filterable
   forwardCompound1: Int!
   forwardCompound2: Int!
   name: String
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`ForwardCompound\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input ForwardCompoundFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [ForwardCompoundFilter!]
 
-  \\"\\"\\"Filter by the object’s \`forwardCompound1\` field.\\"\\"\\"
+  """Filter by the object’s \`forwardCompound1\` field."""
   forwardCompound1: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`forwardCompound2\` field.\\"\\"\\"
+  """Filter by the object’s \`forwardCompound2\` field."""
   forwardCompound2: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`name\` field.\\"\\"\\"
+  """Filter by the object’s \`name\` field."""
   name: StringFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: ForwardCompoundFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [ForwardCompoundFilter!]
 }
 
-\\"\\"\\"A connection to a list of \`ForwardCompound\` values.\\"\\"\\"
+"""A connection to a list of \`ForwardCompound\` values."""
 type ForwardCompoundsConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`ForwardCompound\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [ForwardCompoundsEdge!]!
 
-  \\"\\"\\"A list of \`ForwardCompound\` objects.\\"\\"\\"
+  """A list of \`ForwardCompound\` objects."""
   nodes: [ForwardCompound]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"
+  """
   The count of *all* \`ForwardCompound\` you could get from the connection.
-  \\"\\"\\"
+  """
   totalCount: Int!
 }
 
-\\"\\"\\"A \`ForwardCompound\` edge in the connection.\\"\\"\\"
+"""A \`ForwardCompound\` edge in the connection."""
 type ForwardCompoundsEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`ForwardCompound\` at the end of the edge.\\"\\"\\"
+  """The \`ForwardCompound\` at the end of the edge."""
   node: ForwardCompound
 }
 
-\\"\\"\\"Methods to use when ordering \`ForwardCompound\`.\\"\\"\\"
+"""Methods to use when ordering \`ForwardCompound\`."""
 enum ForwardCompoundsOrderBy {
   FORWARD_COMPOUND_1_ASC
   FORWARD_COMPOUND_1_DESC
@@ -1436,53 +1436,53 @@ enum ForwardCompoundsOrderBy {
   PRIMARY_KEY_DESC
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`Forward\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input ForwardFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [ForwardFilter!]
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`name\` field.\\"\\"\\"
+  """Filter by the object’s \`name\` field."""
   name: StringFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: ForwardFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [ForwardFilter!]
 }
 
-\\"\\"\\"A connection to a list of \`Forward\` values.\\"\\"\\"
+"""A connection to a list of \`Forward\` values."""
 type ForwardsConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`Forward\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [ForwardsEdge!]!
 
-  \\"\\"\\"A list of \`Forward\` objects.\\"\\"\\"
+  """A list of \`Forward\` objects."""
   nodes: [Forward]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`Forward\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`Forward\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`Forward\` edge in the connection.\\"\\"\\"
+"""A \`Forward\` edge in the connection."""
 type ForwardsEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`Forward\` at the end of the edge.\\"\\"\\"
+  """The \`Forward\` at the end of the edge."""
   node: Forward
 }
 
-\\"\\"\\"Methods to use when ordering \`Forward\`.\\"\\"\\"
+"""Methods to use when ordering \`Forward\`."""
 enum ForwardsOrderBy {
   ID_ASC
   ID_DESC
@@ -1496,40 +1496,40 @@ enum ForwardsOrderBy {
 type FullyOmitted implements Node {
   id: Int!
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
   text: String
 }
 
-\\"\\"\\"A connection to a list of \`FullyOmitted\` values.\\"\\"\\"
+"""A connection to a list of \`FullyOmitted\` values."""
 type FullyOmittedsConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`FullyOmitted\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [FullyOmittedsEdge!]!
 
-  \\"\\"\\"A list of \`FullyOmitted\` objects.\\"\\"\\"
+  """A list of \`FullyOmitted\` objects."""
   nodes: [FullyOmitted]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`FullyOmitted\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`FullyOmitted\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`FullyOmitted\` edge in the connection.\\"\\"\\"
+"""A \`FullyOmitted\` edge in the connection."""
 type FullyOmittedsEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`FullyOmitted\` at the end of the edge.\\"\\"\\"
+  """The \`FullyOmitted\` at the end of the edge."""
   node: FullyOmitted
 }
 
-\\"\\"\\"Methods to use when ordering \`FullyOmitted\`.\\"\\"\\"
+"""Methods to use when ordering \`FullyOmitted\`."""
 enum FullyOmittedsOrderBy {
   ID_ASC
   ID_DESC
@@ -1540,300 +1540,300 @@ enum FullyOmittedsOrderBy {
   TEXT_DESC
 }
 
-\\"\\"\\"A connection to a list of \`FuncReturnsTableMultiColRecord\` values.\\"\\"\\"
+"""A connection to a list of \`FuncReturnsTableMultiColRecord\` values."""
 type FuncReturnsTableMultiColConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`FuncReturnsTableMultiColRecord\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [FuncReturnsTableMultiColEdge!]!
 
-  \\"\\"\\"A list of \`FuncReturnsTableMultiColRecord\` objects.\\"\\"\\"
+  """A list of \`FuncReturnsTableMultiColRecord\` objects."""
   nodes: [FuncReturnsTableMultiColRecord]!
 
-  \\"\\"\\"
+  """
   The count of *all* \`FuncReturnsTableMultiColRecord\` you could get from the connection.
-  \\"\\"\\"
+  """
   totalCount: Int!
 }
 
-\\"\\"\\"A \`FuncReturnsTableMultiColRecord\` edge in the connection.\\"\\"\\"
+"""A \`FuncReturnsTableMultiColRecord\` edge in the connection."""
 type FuncReturnsTableMultiColEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`FuncReturnsTableMultiColRecord\` at the end of the edge.\\"\\"\\"
+  """The \`FuncReturnsTableMultiColRecord\` at the end of the edge."""
   node: FuncReturnsTableMultiColRecord
 }
 
-\\"\\"\\"The return type of our \`funcReturnsTableMultiCol\` query.\\"\\"\\"
+"""The return type of our \`funcReturnsTableMultiCol\` query."""
 type FuncReturnsTableMultiColRecord {
   col1: Int
   col2: String
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`FuncReturnsTableMultiColRecord\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input FuncReturnsTableMultiColRecordFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [FuncReturnsTableMultiColRecordFilter!]
 
-  \\"\\"\\"Filter by the object’s \`col1\` field.\\"\\"\\"
+  """Filter by the object’s \`col1\` field."""
   col1: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`col2\` field.\\"\\"\\"
+  """Filter by the object’s \`col2\` field."""
   col2: StringFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: FuncReturnsTableMultiColRecordFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [FuncReturnsTableMultiColRecordFilter!]
 }
 
-\\"\\"\\"A connection to a list of \`Int\` values.\\"\\"\\"
+"""A connection to a list of \`Int\` values."""
 type FuncReturnsTableOneColConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`Int\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [FuncReturnsTableOneColEdge!]!
 
-  \\"\\"\\"A list of \`Int\` objects.\\"\\"\\"
+  """A list of \`Int\` objects."""
   nodes: [Int]!
 
-  \\"\\"\\"The count of *all* \`Int\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`Int\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`Int\` edge in the connection.\\"\\"\\"
+"""A \`Int\` edge in the connection."""
 type FuncReturnsTableOneColEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`Int\` at the end of the edge.\\"\\"\\"
+  """The \`Int\` at the end of the edge."""
   node: Int
 }
 
-\\"\\"\\"
+"""
 A connection to a list of \`FuncTaggedFilterableReturnsTableMultiColRecord\` values.
-\\"\\"\\"
+"""
 type FuncTaggedFilterableReturnsTableMultiColConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`FuncTaggedFilterableReturnsTableMultiColRecord\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [FuncTaggedFilterableReturnsTableMultiColEdge!]!
 
-  \\"\\"\\"A list of \`FuncTaggedFilterableReturnsTableMultiColRecord\` objects.\\"\\"\\"
+  """A list of \`FuncTaggedFilterableReturnsTableMultiColRecord\` objects."""
   nodes: [FuncTaggedFilterableReturnsTableMultiColRecord]!
 
-  \\"\\"\\"
+  """
   The count of *all* \`FuncTaggedFilterableReturnsTableMultiColRecord\` you could get from the connection.
-  \\"\\"\\"
+  """
   totalCount: Int!
 }
 
-\\"\\"\\"
+"""
 A \`FuncTaggedFilterableReturnsTableMultiColRecord\` edge in the connection.
-\\"\\"\\"
+"""
 type FuncTaggedFilterableReturnsTableMultiColEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"
+  """
   The \`FuncTaggedFilterableReturnsTableMultiColRecord\` at the end of the edge.
-  \\"\\"\\"
+  """
   node: FuncTaggedFilterableReturnsTableMultiColRecord
 }
 
-\\"\\"\\"
+"""
 The return type of our \`funcTaggedFilterableReturnsTableMultiCol\` query.
-\\"\\"\\"
+"""
 type FuncTaggedFilterableReturnsTableMultiColRecord {
   col1: Int
   col2: String
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`FuncTaggedFilterableReturnsTableMultiColRecord\`
 object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input FuncTaggedFilterableReturnsTableMultiColRecordFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [FuncTaggedFilterableReturnsTableMultiColRecordFilter!]
 
-  \\"\\"\\"Filter by the object’s \`col1\` field.\\"\\"\\"
+  """Filter by the object’s \`col1\` field."""
   col1: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`col2\` field.\\"\\"\\"
+  """Filter by the object’s \`col2\` field."""
   col2: StringFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: FuncTaggedFilterableReturnsTableMultiColRecordFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [FuncTaggedFilterableReturnsTableMultiColRecordFilter!]
 }
 
 scalar Int4Domain
 
-\\"\\"\\"An IPv4 or IPv6 host address, and optionally its subnet.\\"\\"\\"
+"""An IPv4 or IPv6 host address, and optionally its subnet."""
 scalar InternetAddress
 
-\\"\\"\\"
+"""
 An interval of time that has passed where the smallest distinct unit is a second.
-\\"\\"\\"
+"""
 type Interval {
-  \\"\\"\\"A quantity of days.\\"\\"\\"
+  """A quantity of days."""
   days: Int
 
-  \\"\\"\\"A quantity of hours.\\"\\"\\"
+  """A quantity of hours."""
   hours: Int
 
-  \\"\\"\\"A quantity of minutes.\\"\\"\\"
+  """A quantity of minutes."""
   minutes: Int
 
-  \\"\\"\\"A quantity of months.\\"\\"\\"
+  """A quantity of months."""
   months: Int
 
-  \\"\\"\\"
+  """
   A quantity of seconds. This is the only non-integer field, as all the other
   fields will dump their overflow into a smaller unit of time. Intervals don’t
   have a smaller unit than seconds.
-  \\"\\"\\"
+  """
   seconds: Float
 
-  \\"\\"\\"A quantity of years.\\"\\"\\"
+  """A quantity of years."""
   years: Int
 }
 
-\\"\\"\\"
+"""
 A filter to be used against Int fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input IntFilter {
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: Int
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: Int
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: Int
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: Int
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [Int!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: Int
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: Int
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: Int
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: Int
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [Int!]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against Int List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input IntListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: Int
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: Int
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: Int
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: Int
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: Int
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: Int
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [Int]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [Int]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [Int]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [Int]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [Int]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [Int]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [Int]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [Int]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [Int]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [Int]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [Int]
 }
 
-\\"\\"\\"A range of \`Int\`.\\"\\"\\"
+"""A range of \`Int\`."""
 type IntRange {
-  \\"\\"\\"The ending bound of our range.\\"\\"\\"
+  """The ending bound of our range."""
   end: IntRangeBound
 
-  \\"\\"\\"The starting bound of our range.\\"\\"\\"
+  """The starting bound of our range."""
   start: IntRangeBound
 }
 
-\\"\\"\\"
+"""
 The value at one end of a range. A range can either include this value, or not.
-\\"\\"\\"
+"""
 type IntRangeBound {
-  \\"\\"\\"Whether or not the value of this bound is included in the range.\\"\\"\\"
+  """Whether or not the value of this bound is included in the range."""
   inclusive: Boolean!
 
-  \\"\\"\\"The value at one end of our range.\\"\\"\\"
+  """The value at one end of our range."""
   value: Int!
 }
 
-\\"\\"\\"
+"""
 A JavaScript object encoded in the JSON format as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf).
-\\"\\"\\"
+"""
 scalar JSON
 
 type JsonbTest implements Node {
@@ -1841,56 +1841,56 @@ type JsonbTest implements Node {
   jsonbWithArray: JSON
   jsonbWithObject: JSON
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`JsonbTest\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input JsonbTestFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [JsonbTestFilter!]
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: JsonbTestFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [JsonbTestFilter!]
 }
 
-\\"\\"\\"A connection to a list of \`JsonbTest\` values.\\"\\"\\"
+"""A connection to a list of \`JsonbTest\` values."""
 type JsonbTestsConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`JsonbTest\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [JsonbTestsEdge!]!
 
-  \\"\\"\\"A list of \`JsonbTest\` objects.\\"\\"\\"
+  """A list of \`JsonbTest\` objects."""
   nodes: [JsonbTest]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`JsonbTest\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`JsonbTest\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`JsonbTest\` edge in the connection.\\"\\"\\"
+"""A \`JsonbTest\` edge in the connection."""
 type JsonbTestsEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`JsonbTest\` at the end of the edge.\\"\\"\\"
+  """The \`JsonbTest\` at the end of the edge."""
   node: JsonbTest
 }
 
-\\"\\"\\"Methods to use when ordering \`JsonbTest\`.\\"\\"\\"
+"""Methods to use when ordering \`JsonbTest\`."""
 enum JsonbTestsOrderBy {
   ID_ASC
   ID_DESC
@@ -1904,67 +1904,67 @@ enum JsonbTestsOrderBy {
 }
 
 type Junction implements Node {
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 
-  \\"\\"\\"Reads a single \`SideA\` that is related to this \`Junction\`.\\"\\"\\"
+  """Reads a single \`SideA\` that is related to this \`Junction\`."""
   sideABySideAId: SideA
   sideAId: Int!
 
-  \\"\\"\\"Reads a single \`SideB\` that is related to this \`Junction\`.\\"\\"\\"
+  """Reads a single \`SideB\` that is related to this \`Junction\`."""
   sideBBySideBId: SideB
   sideBId: Int!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`Junction\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input JunctionFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [JunctionFilter!]
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: JunctionFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [JunctionFilter!]
 
-  \\"\\"\\"Filter by the object’s \`sideAId\` field.\\"\\"\\"
+  """Filter by the object’s \`sideAId\` field."""
   sideAId: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`sideBId\` field.\\"\\"\\"
+  """Filter by the object’s \`sideBId\` field."""
   sideBId: IntFilter
 }
 
-\\"\\"\\"A connection to a list of \`Junction\` values.\\"\\"\\"
+"""A connection to a list of \`Junction\` values."""
 type JunctionsConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`Junction\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [JunctionsEdge!]!
 
-  \\"\\"\\"A list of \`Junction\` objects.\\"\\"\\"
+  """A list of \`Junction\` objects."""
   nodes: [Junction]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`Junction\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`Junction\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`Junction\` edge in the connection.\\"\\"\\"
+"""A \`Junction\` edge in the connection."""
 type JunctionsEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`Junction\` at the end of the edge.\\"\\"\\"
+  """The \`Junction\` at the end of the edge."""
   node: Junction
 }
 
-\\"\\"\\"Methods to use when ordering \`Junction\`.\\"\\"\\"
+"""Methods to use when ordering \`Junction\`."""
 enum JunctionsOrderBy {
   NATURAL
   PRIMARY_KEY_ASC
@@ -1975,9 +1975,9 @@ enum JunctionsOrderBy {
   SIDE_B_ID_DESC
 }
 
-\\"\\"\\"
+"""
 A set of key/value pairs, keys are strings, values may be a string or null. Exposed as a JSON object.
-\\"\\"\\"
+"""
 scalar KeyValueHash
 
 enum Mood {
@@ -1986,114 +1986,114 @@ enum Mood {
   SAD
 }
 
-\\"\\"\\"An object with a globally unique \`ID\`.\\"\\"\\"
+"""An object with a globally unique \`ID\`."""
 interface Node {
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
-\\"\\"\\"Information about pagination in a connection.\\"\\"\\"
+"""Information about pagination in a connection."""
 type PageInfo {
-  \\"\\"\\"When paginating forwards, the cursor to continue.\\"\\"\\"
+  """When paginating forwards, the cursor to continue."""
   endCursor: Cursor
 
-  \\"\\"\\"When paginating forwards, are there more items?\\"\\"\\"
+  """When paginating forwards, are there more items?"""
   hasNextPage: Boolean!
 
-  \\"\\"\\"When paginating backwards, are there more items?\\"\\"\\"
+  """When paginating backwards, are there more items?"""
   hasPreviousPage: Boolean!
 
-  \\"\\"\\"When paginating backwards, the cursor to continue.\\"\\"\\"
+  """When paginating backwards, the cursor to continue."""
   startCursor: Cursor
 }
 
 type Parent implements Node {
-  \\"\\"\\"Reads and enables pagination through a set of \`Filterable\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Filterable\`."""
   filterablesByParentId(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: FilterableFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`Filterable\`.\\"\\"\\"
+    """The method to use when ordering \`Filterable\`."""
     orderBy: [FilterablesOrderBy!] = [PRIMARY_KEY_ASC]
   ): FilterablesConnection!
   id: Int!
   name: String!
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`Parent\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input ParentFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [ParentFilter!]
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`name\` field.\\"\\"\\"
+  """Filter by the object’s \`name\` field."""
   name: StringFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: ParentFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [ParentFilter!]
 }
 
-\\"\\"\\"A connection to a list of \`Parent\` values.\\"\\"\\"
+"""A connection to a list of \`Parent\` values."""
 type ParentsConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`Parent\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [ParentsEdge!]!
 
-  \\"\\"\\"A list of \`Parent\` objects.\\"\\"\\"
+  """A list of \`Parent\` objects."""
   nodes: [Parent]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`Parent\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`Parent\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`Parent\` edge in the connection.\\"\\"\\"
+"""A \`Parent\` edge in the connection."""
 type ParentsEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`Parent\` at the end of the edge.\\"\\"\\"
+  """The \`Parent\` at the end of the edge."""
   node: Parent
 }
 
-\\"\\"\\"Methods to use when ordering \`Parent\`.\\"\\"\\"
+"""Methods to use when ordering \`Parent\`."""
 enum ParentsOrderBy {
   ID_ASC
   ID_DESC
@@ -2108,704 +2108,704 @@ type Protected implements Node {
   id: Int!
   name: String
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
   otherId: Int
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`Protected\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input ProtectedFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [ProtectedFilter!]
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`name\` field.\\"\\"\\"
+  """Filter by the object’s \`name\` field."""
   name: StringFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: ProtectedFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [ProtectedFilter!]
 
-  \\"\\"\\"Filter by the object’s \`otherId\` field.\\"\\"\\"
+  """Filter by the object’s \`otherId\` field."""
   otherId: IntFilter
 }
 
-\\"\\"\\"A connection to a list of \`Protected\` values.\\"\\"\\"
+"""A connection to a list of \`Protected\` values."""
 type ProtectedsConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`Protected\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [ProtectedsEdge!]!
 
-  \\"\\"\\"A list of \`Protected\` objects.\\"\\"\\"
+  """A list of \`Protected\` objects."""
   nodes: [Protected]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`Protected\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`Protected\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`Protected\` edge in the connection.\\"\\"\\"
+"""A \`Protected\` edge in the connection."""
 type ProtectedsEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`Protected\` at the end of the edge.\\"\\"\\"
+  """The \`Protected\` at the end of the edge."""
   node: Protected
 }
 
-\\"\\"\\"The root query type which gives access points into the data universe.\\"\\"\\"
+"""The root query type which gives access points into the data universe."""
 type Query implements Node {
-  \\"\\"\\"Reads and enables pagination through a set of \`ArrayType\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`ArrayType\`."""
   allArrayTypes(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: ArrayTypeFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`ArrayType\`.\\"\\"\\"
+    """The method to use when ordering \`ArrayType\`."""
     orderBy: [ArrayTypesOrderBy!] = [PRIMARY_KEY_ASC]
   ): ArrayTypesConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`BackwardCompound\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`BackwardCompound\`."""
   allBackwardCompounds(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: BackwardCompoundFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`BackwardCompound\`.\\"\\"\\"
+    """The method to use when ordering \`BackwardCompound\`."""
     orderBy: [BackwardCompoundsOrderBy!] = [PRIMARY_KEY_ASC]
   ): BackwardCompoundsConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Backward\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Backward\`."""
   allBackwards(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: BackwardFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`Backward\`.\\"\\"\\"
+    """The method to use when ordering \`Backward\`."""
     orderBy: [BackwardsOrderBy!] = [PRIMARY_KEY_ASC]
   ): BackwardsConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`ChildNoRelatedFilter\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`ChildNoRelatedFilter\`."""
   allChildNoRelatedFilters(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: ChildNoRelatedFilterFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`ChildNoRelatedFilter\`.\\"\\"\\"
+    """The method to use when ordering \`ChildNoRelatedFilter\`."""
     orderBy: [ChildNoRelatedFiltersOrderBy!] = [PRIMARY_KEY_ASC]
   ): ChildNoRelatedFiltersConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Child\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Child\`."""
   allChildren(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: ChildFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`Child\`.\\"\\"\\"
+    """The method to use when ordering \`Child\`."""
     orderBy: [ChildrenOrderBy!] = [PRIMARY_KEY_ASC]
   ): ChildrenConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`DomainType\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`DomainType\`."""
   allDomainTypes(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: DomainTypeFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`DomainType\`.\\"\\"\\"
+    """The method to use when ordering \`DomainType\`."""
     orderBy: [DomainTypesOrderBy!] = [PRIMARY_KEY_ASC]
   ): DomainTypesConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`EnumArrayType\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`EnumArrayType\`."""
   allEnumArrayTypes(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: EnumArrayTypeFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`EnumArrayType\`.\\"\\"\\"
+    """The method to use when ordering \`EnumArrayType\`."""
     orderBy: [EnumArrayTypesOrderBy!] = [PRIMARY_KEY_ASC]
   ): EnumArrayTypesConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`EnumType\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`EnumType\`."""
   allEnumTypes(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: EnumTypeFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`EnumType\`.\\"\\"\\"
+    """The method to use when ordering \`EnumType\`."""
     orderBy: [EnumTypesOrderBy!] = [PRIMARY_KEY_ASC]
   ): EnumTypesConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Filterable\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Filterable\`."""
   allFilterables(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: FilterableFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`Filterable\`.\\"\\"\\"
+    """The method to use when ordering \`Filterable\`."""
     orderBy: [FilterablesOrderBy!] = [PRIMARY_KEY_ASC]
   ): FilterablesConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`ForwardCompound\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`ForwardCompound\`."""
   allForwardCompounds(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: ForwardCompoundFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`ForwardCompound\`.\\"\\"\\"
+    """The method to use when ordering \`ForwardCompound\`."""
     orderBy: [ForwardCompoundsOrderBy!] = [PRIMARY_KEY_ASC]
   ): ForwardCompoundsConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Forward\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Forward\`."""
   allForwards(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: ForwardFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`Forward\`.\\"\\"\\"
+    """The method to use when ordering \`Forward\`."""
     orderBy: [ForwardsOrderBy!] = [PRIMARY_KEY_ASC]
   ): ForwardsConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`FullyOmitted\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`FullyOmitted\`."""
   allFullyOmitteds(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`FullyOmitted\`.\\"\\"\\"
+    """The method to use when ordering \`FullyOmitted\`."""
     orderBy: [FullyOmittedsOrderBy!] = [PRIMARY_KEY_ASC]
   ): FullyOmittedsConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`JsonbTest\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`JsonbTest\`."""
   allJsonbTests(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: JsonbTestFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`JsonbTest\`.\\"\\"\\"
+    """The method to use when ordering \`JsonbTest\`."""
     orderBy: [JsonbTestsOrderBy!] = [PRIMARY_KEY_ASC]
   ): JsonbTestsConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Junction\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Junction\`."""
   allJunctions(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: JunctionFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`Junction\`.\\"\\"\\"
+    """The method to use when ordering \`Junction\`."""
     orderBy: [JunctionsOrderBy!] = [PRIMARY_KEY_ASC]
   ): JunctionsConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Parent\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Parent\`."""
   allParents(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: ParentFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`Parent\`.\\"\\"\\"
+    """The method to use when ordering \`Parent\`."""
     orderBy: [ParentsOrderBy!] = [PRIMARY_KEY_ASC]
   ): ParentsConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`RangeArrayType\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`RangeArrayType\`."""
   allRangeArrayTypes(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: RangeArrayTypeFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`RangeArrayType\`.\\"\\"\\"
+    """The method to use when ordering \`RangeArrayType\`."""
     orderBy: [RangeArrayTypesOrderBy!] = [PRIMARY_KEY_ASC]
   ): RangeArrayTypesConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`RangeType\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`RangeType\`."""
   allRangeTypes(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: RangeTypeFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`RangeType\`.\\"\\"\\"
+    """The method to use when ordering \`RangeType\`."""
     orderBy: [RangeTypesOrderBy!] = [PRIMARY_KEY_ASC]
   ): RangeTypesConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`SideA\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`SideA\`."""
   allSideAs(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: SideAFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`SideA\`.\\"\\"\\"
+    """The method to use when ordering \`SideA\`."""
     orderBy: [SideAsOrderBy!] = [PRIMARY_KEY_ASC]
   ): SideAsConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`SideB\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`SideB\`."""
   allSideBs(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: SideBFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`SideB\`.\\"\\"\\"
+    """The method to use when ordering \`SideB\`."""
     orderBy: [SideBsOrderBy!] = [PRIMARY_KEY_ASC]
   ): SideBsConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Unfilterable\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Unfilterable\`."""
   allUnfilterables(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`Unfilterable\`.\\"\\"\\"
+    """The method to use when ordering \`Unfilterable\`."""
     orderBy: [UnfilterablesOrderBy!] = [PRIMARY_KEY_ASC]
   ): UnfilterablesConnection
 
-  \\"\\"\\"Reads a single \`ArrayType\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`ArrayType\` using its globally unique \`ID\`."""
   arrayType(
-    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`ArrayType\`.\\"\\"\\"
+    """The globally unique \`ID\` to be used in selecting a single \`ArrayType\`."""
     nodeId: ID!
   ): ArrayType
   arrayTypeById(id: Int!): ArrayType
 
-  \\"\\"\\"Reads a single \`Backward\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`Backward\` using its globally unique \`ID\`."""
   backward(
-    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`Backward\`.\\"\\"\\"
+    """The globally unique \`ID\` to be used in selecting a single \`Backward\`."""
     nodeId: ID!
   ): Backward
   backwardByFilterableId(filterableId: Int!): Backward
   backwardById(id: Int!): Backward
 
-  \\"\\"\\"Reads a single \`BackwardCompound\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`BackwardCompound\` using its globally unique \`ID\`."""
   backwardCompound(
-    \\"\\"\\"
+    """
     The globally unique \`ID\` to be used in selecting a single \`BackwardCompound\`.
-    \\"\\"\\"
+    """
     nodeId: ID!
   ): BackwardCompound
   backwardCompoundByBackwardCompound1AndBackwardCompound2(backwardCompound1: Int!, backwardCompound2: Int!): BackwardCompound
 
-  \\"\\"\\"Reads a single \`Child\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`Child\` using its globally unique \`ID\`."""
   child(
-    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`Child\`.\\"\\"\\"
+    """The globally unique \`ID\` to be used in selecting a single \`Child\`."""
     nodeId: ID!
   ): Child
   childById(id: Int!): Child
 
-  \\"\\"\\"Reads a single \`ChildNoRelatedFilter\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`ChildNoRelatedFilter\` using its globally unique \`ID\`."""
   childNoRelatedFilter(
-    \\"\\"\\"
+    """
     The globally unique \`ID\` to be used in selecting a single \`ChildNoRelatedFilter\`.
-    \\"\\"\\"
+    """
     nodeId: ID!
   ): ChildNoRelatedFilter
   childNoRelatedFilterById(id: Int!): ChildNoRelatedFilter
 
-  \\"\\"\\"Reads a single \`DomainType\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`DomainType\` using its globally unique \`ID\`."""
   domainType(
-    \\"\\"\\"
+    """
     The globally unique \`ID\` to be used in selecting a single \`DomainType\`.
-    \\"\\"\\"
+    """
     nodeId: ID!
   ): DomainType
   domainTypeById(id: Int!): DomainType
 
-  \\"\\"\\"Reads a single \`EnumArrayType\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`EnumArrayType\` using its globally unique \`ID\`."""
   enumArrayType(
-    \\"\\"\\"
+    """
     The globally unique \`ID\` to be used in selecting a single \`EnumArrayType\`.
-    \\"\\"\\"
+    """
     nodeId: ID!
   ): EnumArrayType
   enumArrayTypeById(id: Int!): EnumArrayType
 
-  \\"\\"\\"Reads a single \`EnumType\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`EnumType\` using its globally unique \`ID\`."""
   enumType(
-    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`EnumType\`.\\"\\"\\"
+    """The globally unique \`ID\` to be used in selecting a single \`EnumType\`."""
     nodeId: ID!
   ): EnumType
   enumTypeById(id: Int!): EnumType
 
-  \\"\\"\\"Reads a single \`Filterable\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`Filterable\` using its globally unique \`ID\`."""
   filterable(
-    \\"\\"\\"
+    """
     The globally unique \`ID\` to be used in selecting a single \`Filterable\`.
-    \\"\\"\\"
+    """
     nodeId: ID!
   ): Filterable
   filterableByBackwardCompound1AndBackwardCompound2(backwardCompound1: Int!, backwardCompound2: Int!): Filterable
@@ -2813,247 +2813,247 @@ type Query implements Node {
   filterableByForwardId(forwardId: Int!): Filterable
   filterableById(id: Int!): Filterable
 
-  \\"\\"\\"Reads a single \`FilterableClosure\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`FilterableClosure\` using its globally unique \`ID\`."""
   filterableClosure(
-    \\"\\"\\"
+    """
     The globally unique \`ID\` to be used in selecting a single \`FilterableClosure\`.
-    \\"\\"\\"
+    """
     nodeId: ID!
   ): FilterableClosure
   filterableClosureById(id: Int!): FilterableClosure
 
-  \\"\\"\\"Reads a single \`Forward\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`Forward\` using its globally unique \`ID\`."""
   forward(
-    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`Forward\`.\\"\\"\\"
+    """The globally unique \`ID\` to be used in selecting a single \`Forward\`."""
     nodeId: ID!
   ): Forward
   forwardById(id: Int!): Forward
 
-  \\"\\"\\"Reads a single \`ForwardCompound\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`ForwardCompound\` using its globally unique \`ID\`."""
   forwardCompound(
-    \\"\\"\\"
+    """
     The globally unique \`ID\` to be used in selecting a single \`ForwardCompound\`.
-    \\"\\"\\"
+    """
     nodeId: ID!
   ): ForwardCompound
   forwardCompoundByForwardCompound1AndForwardCompound2(forwardCompound1: Int!, forwardCompound2: Int!): ForwardCompound
 
-  \\"\\"\\"Reads a single \`FullyOmitted\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`FullyOmitted\` using its globally unique \`ID\`."""
   fullyOmitted(
-    \\"\\"\\"
+    """
     The globally unique \`ID\` to be used in selecting a single \`FullyOmitted\`.
-    \\"\\"\\"
+    """
     nodeId: ID!
   ): FullyOmitted
   fullyOmittedById(id: Int!): FullyOmitted
   funcReturnsTableMultiCol(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: FuncReturnsTableMultiColRecordFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
     i: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
   ): FuncReturnsTableMultiColConnection!
   funcReturnsTableOneCol(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: IntFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
     i: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
   ): FuncReturnsTableOneColConnection!
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Filterable\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Filterable\`."""
   funcTaggedFilterableReturnsSetofFilterable(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: FilterableFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
   ): FilterablesConnection!
   funcTaggedFilterableReturnsTableMultiCol(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: FuncTaggedFilterableReturnsTableMultiColRecordFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
   ): FuncTaggedFilterableReturnsTableMultiColConnection!
 
-  \\"\\"\\"Reads a single \`JsonbTest\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`JsonbTest\` using its globally unique \`ID\`."""
   jsonbTest(
-    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`JsonbTest\`.\\"\\"\\"
+    """The globally unique \`ID\` to be used in selecting a single \`JsonbTest\`."""
     nodeId: ID!
   ): JsonbTest
   jsonbTestById(id: Int!): JsonbTest
 
-  \\"\\"\\"Reads a single \`Junction\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`Junction\` using its globally unique \`ID\`."""
   junction(
-    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`Junction\`.\\"\\"\\"
+    """The globally unique \`ID\` to be used in selecting a single \`Junction\`."""
     nodeId: ID!
   ): Junction
   junctionBySideAIdAndSideBId(sideAId: Int!, sideBId: Int!): Junction
 
-  \\"\\"\\"Fetches an object given its globally unique \`ID\`.\\"\\"\\"
+  """Fetches an object given its globally unique \`ID\`."""
   node(
-    \\"\\"\\"The globally unique \`ID\`.\\"\\"\\"
+    """The globally unique \`ID\`."""
     nodeId: ID!
   ): Node
 
-  \\"\\"\\"
+  """
   The root query type must be a \`Node\` to work well with Relay 1 mutations. This just resolves to \`query\`.
-  \\"\\"\\"
+  """
   nodeId: ID!
 
-  \\"\\"\\"Reads a single \`Parent\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`Parent\` using its globally unique \`ID\`."""
   parent(
-    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`Parent\`.\\"\\"\\"
+    """The globally unique \`ID\` to be used in selecting a single \`Parent\`."""
     nodeId: ID!
   ): Parent
   parentById(id: Int!): Parent
 
-  \\"\\"\\"Reads a single \`Protected\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`Protected\` using its globally unique \`ID\`."""
   protected(
-    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`Protected\`.\\"\\"\\"
+    """The globally unique \`ID\` to be used in selecting a single \`Protected\`."""
     nodeId: ID!
   ): Protected
   protectedById(id: Int!): Protected
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Protected\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Protected\`."""
   protectedsByOtherId(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: ProtectedFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
     otherId: Int
   ): ProtectedsConnection!
 
-  \\"\\"\\"
+  """
   Exposes the root query type nested one level down. This is helpful for Relay 1
   which can only query top level fields if they are in a particular form.
-  \\"\\"\\"
+  """
   query: Query!
 
-  \\"\\"\\"Reads a single \`RangeArrayType\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`RangeArrayType\` using its globally unique \`ID\`."""
   rangeArrayType(
-    \\"\\"\\"
+    """
     The globally unique \`ID\` to be used in selecting a single \`RangeArrayType\`.
-    \\"\\"\\"
+    """
     nodeId: ID!
   ): RangeArrayType
   rangeArrayTypeById(id: Int!): RangeArrayType
 
-  \\"\\"\\"Reads a single \`RangeType\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`RangeType\` using its globally unique \`ID\`."""
   rangeType(
-    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`RangeType\`.\\"\\"\\"
+    """The globally unique \`ID\` to be used in selecting a single \`RangeType\`."""
     nodeId: ID!
   ): RangeType
   rangeTypeById(id: Int!): RangeType
 
-  \\"\\"\\"Reads a single \`SideA\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`SideA\` using its globally unique \`ID\`."""
   sideA(
-    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`SideA\`.\\"\\"\\"
+    """The globally unique \`ID\` to be used in selecting a single \`SideA\`."""
     nodeId: ID!
   ): SideA
   sideAByAId(aId: Int!): SideA
 
-  \\"\\"\\"Reads a single \`SideB\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`SideB\` using its globally unique \`ID\`."""
   sideB(
-    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`SideB\`.\\"\\"\\"
+    """The globally unique \`ID\` to be used in selecting a single \`SideB\`."""
     nodeId: ID!
   ): SideB
   sideBByBId(bId: Int!): SideB
 
-  \\"\\"\\"Reads a single \`Unfilterable\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`Unfilterable\` using its globally unique \`ID\`."""
   unfilterable(
-    \\"\\"\\"
+    """
     The globally unique \`ID\` to be used in selecting a single \`Unfilterable\`.
-    \\"\\"\\"
+    """
     nodeId: ID!
   ): Unfilterable
   unfilterableById(id: Int!): Unfilterable
@@ -3065,59 +3065,59 @@ type RangeArrayType implements Node {
   int4RangeArray: [IntRange]
   int8RangeArray: [BigIntRange]
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
   numericRangeArray: [BigFloatRange]
   timestampRangeArray: [DatetimeRange]
   timestamptzRangeArray: [DatetimeRange]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`RangeArrayType\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input RangeArrayTypeFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [RangeArrayTypeFilter!]
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: RangeArrayTypeFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [RangeArrayTypeFilter!]
 }
 
-\\"\\"\\"A connection to a list of \`RangeArrayType\` values.\\"\\"\\"
+"""A connection to a list of \`RangeArrayType\` values."""
 type RangeArrayTypesConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`RangeArrayType\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [RangeArrayTypesEdge!]!
 
-  \\"\\"\\"A list of \`RangeArrayType\` objects.\\"\\"\\"
+  """A list of \`RangeArrayType\` objects."""
   nodes: [RangeArrayType]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`RangeArrayType\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`RangeArrayType\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`RangeArrayType\` edge in the connection.\\"\\"\\"
+"""A \`RangeArrayType\` edge in the connection."""
 type RangeArrayTypesEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`RangeArrayType\` at the end of the edge.\\"\\"\\"
+  """The \`RangeArrayType\` at the end of the edge."""
   node: RangeArrayType
 }
 
-\\"\\"\\"Methods to use when ordering \`RangeArrayType\`.\\"\\"\\"
+"""Methods to use when ordering \`RangeArrayType\`."""
 enum RangeArrayTypesOrderBy {
   DATE_RANGE_ARRAY_ASC
   DATE_RANGE_ARRAY_DESC
@@ -3144,59 +3144,59 @@ type RangeType implements Node {
   int4Range: IntRange
   int8Range: BigIntRange
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
   numericRange: BigFloatRange
   timestampRange: DatetimeRange
   timestamptzRange: DatetimeRange
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`RangeType\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input RangeTypeFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [RangeTypeFilter!]
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: RangeTypeFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [RangeTypeFilter!]
 }
 
-\\"\\"\\"A connection to a list of \`RangeType\` values.\\"\\"\\"
+"""A connection to a list of \`RangeType\` values."""
 type RangeTypesConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`RangeType\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [RangeTypesEdge!]!
 
-  \\"\\"\\"A list of \`RangeType\` objects.\\"\\"\\"
+  """A list of \`RangeType\` objects."""
   nodes: [RangeType]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`RangeType\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`RangeType\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`RangeType\` edge in the connection.\\"\\"\\"
+"""A \`RangeType\` edge in the connection."""
 type RangeTypesEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`RangeType\` at the end of the edge.\\"\\"\\"
+  """The \`RangeType\` at the end of the edge."""
   node: RangeType
 }
 
-\\"\\"\\"Methods to use when ordering \`RangeType\`.\\"\\"\\"
+"""Methods to use when ordering \`RangeType\`."""
 enum RangeTypesOrderBy {
   DATE_RANGE_ASC
   DATE_RANGE_DESC
@@ -3220,89 +3220,89 @@ enum RangeTypesOrderBy {
 type SideA implements Node {
   aId: Int!
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Junction\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Junction\`."""
   junctionsBySideAId(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: JunctionFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`Junction\`.\\"\\"\\"
+    """The method to use when ordering \`Junction\`."""
     orderBy: [JunctionsOrderBy!] = [PRIMARY_KEY_ASC]
   ): JunctionsConnection!
   name: String!
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`SideA\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input SideAFilter {
-  \\"\\"\\"Filter by the object’s \`aId\` field.\\"\\"\\"
+  """Filter by the object’s \`aId\` field."""
   aId: IntFilter
 
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [SideAFilter!]
 
-  \\"\\"\\"Filter by the object’s \`name\` field.\\"\\"\\"
+  """Filter by the object’s \`name\` field."""
   name: StringFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: SideAFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [SideAFilter!]
 }
 
-\\"\\"\\"A connection to a list of \`SideA\` values.\\"\\"\\"
+"""A connection to a list of \`SideA\` values."""
 type SideAsConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`SideA\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [SideAsEdge!]!
 
-  \\"\\"\\"A list of \`SideA\` objects.\\"\\"\\"
+  """A list of \`SideA\` objects."""
   nodes: [SideA]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`SideA\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`SideA\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`SideA\` edge in the connection.\\"\\"\\"
+"""A \`SideA\` edge in the connection."""
 type SideAsEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`SideA\` at the end of the edge.\\"\\"\\"
+  """The \`SideA\` at the end of the edge."""
   node: SideA
 }
 
-\\"\\"\\"Methods to use when ordering \`SideA\`.\\"\\"\\"
+"""Methods to use when ordering \`SideA\`."""
 enum SideAsOrderBy {
   A_ID_ASC
   A_ID_DESC
@@ -3316,89 +3316,89 @@ enum SideAsOrderBy {
 type SideB implements Node {
   bId: Int!
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Junction\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Junction\`."""
   junctionsBySideBId(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: JunctionFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`Junction\`.\\"\\"\\"
+    """The method to use when ordering \`Junction\`."""
     orderBy: [JunctionsOrderBy!] = [PRIMARY_KEY_ASC]
   ): JunctionsConnection!
   name: String!
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`SideB\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input SideBFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [SideBFilter!]
 
-  \\"\\"\\"Filter by the object’s \`bId\` field.\\"\\"\\"
+  """Filter by the object’s \`bId\` field."""
   bId: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`name\` field.\\"\\"\\"
+  """Filter by the object’s \`name\` field."""
   name: StringFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: SideBFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [SideBFilter!]
 }
 
-\\"\\"\\"A connection to a list of \`SideB\` values.\\"\\"\\"
+"""A connection to a list of \`SideB\` values."""
 type SideBsConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`SideB\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [SideBsEdge!]!
 
-  \\"\\"\\"A list of \`SideB\` objects.\\"\\"\\"
+  """A list of \`SideB\` objects."""
   nodes: [SideB]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`SideB\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`SideB\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`SideB\` edge in the connection.\\"\\"\\"
+"""A \`SideB\` edge in the connection."""
 type SideBsEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`SideB\` at the end of the edge.\\"\\"\\"
+  """The \`SideB\` at the end of the edge."""
   node: SideB
 }
 
-\\"\\"\\"Methods to use when ordering \`SideB\`.\\"\\"\\"
+"""Methods to use when ordering \`SideB\`."""
 enum SideBsOrderBy {
   B_ID_ASC
   B_ID_DESC
@@ -3409,277 +3409,277 @@ enum SideBsOrderBy {
   PRIMARY_KEY_DESC
 }
 
-\\"\\"\\"
+"""
 A filter to be used against String fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input StringFilter {
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: String
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value (case-insensitive).
-  \\"\\"\\"
+  """
   distinctFromInsensitive: String
 
-  \\"\\"\\"Ends with the specified string (case-sensitive).\\"\\"\\"
+  """Ends with the specified string (case-sensitive)."""
   endsWith: String
 
-  \\"\\"\\"Ends with the specified string (case-insensitive).\\"\\"\\"
+  """Ends with the specified string (case-insensitive)."""
   endsWithInsensitive: String
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: String
 
-  \\"\\"\\"Equal to the specified value (case-insensitive).\\"\\"\\"
+  """Equal to the specified value (case-insensitive)."""
   equalToInsensitive: String
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: String
 
-  \\"\\"\\"Greater than the specified value (case-insensitive).\\"\\"\\"
+  """Greater than the specified value (case-insensitive)."""
   greaterThanInsensitive: String
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: String
 
-  \\"\\"\\"Greater than or equal to the specified value (case-insensitive).\\"\\"\\"
+  """Greater than or equal to the specified value (case-insensitive)."""
   greaterThanOrEqualToInsensitive: String
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [String!]
 
-  \\"\\"\\"Included in the specified list (case-insensitive).\\"\\"\\"
-  inInsensitive: [String!]
-
-  \\"\\"\\"Contains the specified string (case-sensitive).\\"\\"\\"
+  """Contains the specified string (case-sensitive)."""
   includes: String
 
-  \\"\\"\\"Contains the specified string (case-insensitive).\\"\\"\\"
+  """Contains the specified string (case-insensitive)."""
   includesInsensitive: String
 
-  \\"\\"\\"
+  """Included in the specified list (case-insensitive)."""
+  inInsensitive: [String!]
+
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: String
 
-  \\"\\"\\"Less than the specified value (case-insensitive).\\"\\"\\"
+  """Less than the specified value (case-insensitive)."""
   lessThanInsensitive: String
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: String
 
-  \\"\\"\\"Less than or equal to the specified value (case-insensitive).\\"\\"\\"
+  """Less than or equal to the specified value (case-insensitive)."""
   lessThanOrEqualToInsensitive: String
 
-  \\"\\"\\"
+  """
   Matches the specified pattern (case-sensitive). An underscore (_) matches any
   single character; a percent sign (%) matches any sequence of zero or more characters.
-  \\"\\"\\"
+  """
   like: String
 
-  \\"\\"\\"
+  """
   Matches the specified pattern (case-insensitive). An underscore (_) matches
   any single character; a percent sign (%) matches any sequence of zero or more characters.
-  \\"\\"\\"
+  """
   likeInsensitive: String
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: String
 
-  \\"\\"\\"
+  """
   Equal to the specified value, treating null like an ordinary value (case-insensitive).
-  \\"\\"\\"
+  """
   notDistinctFromInsensitive: String
 
-  \\"\\"\\"Does not end with the specified string (case-sensitive).\\"\\"\\"
+  """Does not end with the specified string (case-sensitive)."""
   notEndsWith: String
 
-  \\"\\"\\"Does not end with the specified string (case-insensitive).\\"\\"\\"
+  """Does not end with the specified string (case-insensitive)."""
   notEndsWithInsensitive: String
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: String
 
-  \\"\\"\\"Not equal to the specified value (case-insensitive).\\"\\"\\"
+  """Not equal to the specified value (case-insensitive)."""
   notEqualToInsensitive: String
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [String!]
 
-  \\"\\"\\"Not included in the specified list (case-insensitive).\\"\\"\\"
-  notInInsensitive: [String!]
-
-  \\"\\"\\"Does not contain the specified string (case-sensitive).\\"\\"\\"
+  """Does not contain the specified string (case-sensitive)."""
   notIncludes: String
 
-  \\"\\"\\"Does not contain the specified string (case-insensitive).\\"\\"\\"
+  """Does not contain the specified string (case-insensitive)."""
   notIncludesInsensitive: String
 
-  \\"\\"\\"
+  """Not included in the specified list (case-insensitive)."""
+  notInInsensitive: [String!]
+
+  """
   Does not match the specified pattern (case-sensitive). An underscore (_)
   matches any single character; a percent sign (%) matches any sequence of zero
   or more characters.
-  \\"\\"\\"
+  """
   notLike: String
 
-  \\"\\"\\"
+  """
   Does not match the specified pattern (case-insensitive). An underscore (_)
   matches any single character; a percent sign (%) matches any sequence of zero
   or more characters.
-  \\"\\"\\"
+  """
   notLikeInsensitive: String
 
-  \\"\\"\\"Does not start with the specified string (case-sensitive).\\"\\"\\"
+  """Does not start with the specified string (case-sensitive)."""
   notStartsWith: String
 
-  \\"\\"\\"Does not start with the specified string (case-insensitive).\\"\\"\\"
+  """Does not start with the specified string (case-insensitive)."""
   notStartsWithInsensitive: String
 
-  \\"\\"\\"Starts with the specified string (case-sensitive).\\"\\"\\"
+  """Starts with the specified string (case-sensitive)."""
   startsWith: String
 
-  \\"\\"\\"Starts with the specified string (case-insensitive).\\"\\"\\"
+  """Starts with the specified string (case-insensitive)."""
   startsWithInsensitive: String
 }
 
-\\"\\"\\"
+"""
 A filter to be used against String List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input StringListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: String
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: String
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: String
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: String
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: String
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: String
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [String]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [String]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [String]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [String]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [String]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [String]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [String]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [String]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [String]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [String]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [String]
 }
 
-\\"\\"\\"
+"""
 The exact time of day, does not include the date. May or may not have a timezone offset.
-\\"\\"\\"
+"""
 scalar Time
 
 type Unfilterable implements Node {
-  \\"\\"\\"Reads and enables pagination through a set of \`ChildNoRelatedFilter\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`ChildNoRelatedFilter\`."""
   childNoRelatedFiltersByUnfilterableId(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: ChildNoRelatedFilterFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`ChildNoRelatedFilter\`.\\"\\"\\"
+    """The method to use when ordering \`ChildNoRelatedFilter\`."""
     orderBy: [ChildNoRelatedFiltersOrderBy!] = [PRIMARY_KEY_ASC]
   ): ChildNoRelatedFiltersConnection!
   id: Int!
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
   text: String
 }
 
-\\"\\"\\"A connection to a list of \`Unfilterable\` values.\\"\\"\\"
+"""A connection to a list of \`Unfilterable\` values."""
 type UnfilterablesConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`Unfilterable\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [UnfilterablesEdge!]!
 
-  \\"\\"\\"A list of \`Unfilterable\` objects.\\"\\"\\"
+  """A list of \`Unfilterable\` objects."""
   nodes: [Unfilterable]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`Unfilterable\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`Unfilterable\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`Unfilterable\` edge in the connection.\\"\\"\\"
+"""A \`Unfilterable\` edge in the connection."""
 type UnfilterablesEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`Unfilterable\` at the end of the edge.\\"\\"\\"
+  """The \`Unfilterable\` at the end of the edge."""
   node: Unfilterable
 }
 
-\\"\\"\\"Methods to use when ordering \`Unfilterable\`.\\"\\"\\"
+"""Methods to use when ordering \`Unfilterable\`."""
 enum UnfilterablesOrderBy {
   ID_ASC
   ID_DESC
@@ -3690,9 +3690,9 @@ enum UnfilterablesOrderBy {
   TEXT_DESC
 }
 
-\\"\\"\\"
+"""
 A universally unique identifier as defined by [RFC 4122](https://tools.ietf.org/html/rfc4122).
-\\"\\"\\"
+"""
 scalar UUID
-"
+
 `;

--- a/__tests__/integration/schema/__snapshots__/allowedOperators.test.ts.snap
+++ b/__tests__/integration/schema/__snapshots__/allowedOperators.test.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`prints a schema with the filter plugin and the connectionFilterAllowedOperators option 1`] = `
-"type ArrayType implements Node {
+type ArrayType implements Node {
   bit4Array: [BitString]
   boolArray: [Boolean]
   bpchar4Array: [String]
@@ -25,9 +25,9 @@ exports[`prints a schema with the filter plugin and the connectionFilterAllowedO
   moneyArray: [Float]
   nameArray: [String]
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
   numericArray: [BigFloat]
   textArray: [String]
@@ -41,128 +41,128 @@ exports[`prints a schema with the filter plugin and the connectionFilterAllowedO
   xmlArray: [String]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`ArrayType\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input ArrayTypeFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [ArrayTypeFilter!]
 
-  \\"\\"\\"Filter by the object’s \`bit4Array\` field.\\"\\"\\"
+  """Filter by the object’s \`bit4Array\` field."""
   bit4Array: BitStringListFilter
 
-  \\"\\"\\"Filter by the object’s \`boolArray\` field.\\"\\"\\"
+  """Filter by the object’s \`boolArray\` field."""
   boolArray: BooleanListFilter
 
-  \\"\\"\\"Filter by the object’s \`bpchar4Array\` field.\\"\\"\\"
+  """Filter by the object’s \`bpchar4Array\` field."""
   bpchar4Array: StringListFilter
 
-  \\"\\"\\"Filter by the object’s \`char4Array\` field.\\"\\"\\"
+  """Filter by the object’s \`char4Array\` field."""
   char4Array: StringListFilter
 
-  \\"\\"\\"Filter by the object’s \`citextArray\` field.\\"\\"\\"
+  """Filter by the object’s \`citextArray\` field."""
   citextArray: StringListFilter
 
-  \\"\\"\\"Filter by the object’s \`dateArray\` field.\\"\\"\\"
+  """Filter by the object’s \`dateArray\` field."""
   dateArray: DateListFilter
 
-  \\"\\"\\"Filter by the object’s \`float4Array\` field.\\"\\"\\"
+  """Filter by the object’s \`float4Array\` field."""
   float4Array: FloatListFilter
 
-  \\"\\"\\"Filter by the object’s \`float8Array\` field.\\"\\"\\"
+  """Filter by the object’s \`float8Array\` field."""
   float8Array: FloatListFilter
 
-  \\"\\"\\"Filter by the object’s \`hstoreArray\` field.\\"\\"\\"
+  """Filter by the object’s \`hstoreArray\` field."""
   hstoreArray: KeyValueHashListFilter
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`inetArray\` field.\\"\\"\\"
+  """Filter by the object’s \`inetArray\` field."""
   inetArray: InternetAddressListFilter
 
-  \\"\\"\\"Filter by the object’s \`int2Array\` field.\\"\\"\\"
+  """Filter by the object’s \`int2Array\` field."""
   int2Array: IntListFilter
 
-  \\"\\"\\"Filter by the object’s \`int4Array\` field.\\"\\"\\"
+  """Filter by the object’s \`int4Array\` field."""
   int4Array: IntListFilter
 
-  \\"\\"\\"Filter by the object’s \`int8Array\` field.\\"\\"\\"
+  """Filter by the object’s \`int8Array\` field."""
   int8Array: BigIntListFilter
 
-  \\"\\"\\"Filter by the object’s \`intervalArray\` field.\\"\\"\\"
+  """Filter by the object’s \`intervalArray\` field."""
   intervalArray: IntervalListFilter
 
-  \\"\\"\\"Filter by the object’s \`jsonbArray\` field.\\"\\"\\"
+  """Filter by the object’s \`jsonbArray\` field."""
   jsonbArray: JSONListFilter
 
-  \\"\\"\\"Filter by the object’s \`moneyArray\` field.\\"\\"\\"
+  """Filter by the object’s \`moneyArray\` field."""
   moneyArray: FloatListFilter
 
-  \\"\\"\\"Filter by the object’s \`nameArray\` field.\\"\\"\\"
+  """Filter by the object’s \`nameArray\` field."""
   nameArray: StringListFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: ArrayTypeFilter
 
-  \\"\\"\\"Filter by the object’s \`numericArray\` field.\\"\\"\\"
+  """Filter by the object’s \`numericArray\` field."""
   numericArray: BigFloatListFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [ArrayTypeFilter!]
 
-  \\"\\"\\"Filter by the object’s \`textArray\` field.\\"\\"\\"
+  """Filter by the object’s \`textArray\` field."""
   textArray: StringListFilter
 
-  \\"\\"\\"Filter by the object’s \`timeArray\` field.\\"\\"\\"
+  """Filter by the object’s \`timeArray\` field."""
   timeArray: TimeListFilter
 
-  \\"\\"\\"Filter by the object’s \`timestampArray\` field.\\"\\"\\"
+  """Filter by the object’s \`timestampArray\` field."""
   timestampArray: DatetimeListFilter
 
-  \\"\\"\\"Filter by the object’s \`timestamptzArray\` field.\\"\\"\\"
+  """Filter by the object’s \`timestamptzArray\` field."""
   timestamptzArray: DatetimeListFilter
 
-  \\"\\"\\"Filter by the object’s \`timetzArray\` field.\\"\\"\\"
+  """Filter by the object’s \`timetzArray\` field."""
   timetzArray: TimeListFilter
 
-  \\"\\"\\"Filter by the object’s \`uuidArray\` field.\\"\\"\\"
+  """Filter by the object’s \`uuidArray\` field."""
   uuidArray: UUIDListFilter
 
-  \\"\\"\\"Filter by the object’s \`varbitArray\` field.\\"\\"\\"
+  """Filter by the object’s \`varbitArray\` field."""
   varbitArray: BitStringListFilter
 
-  \\"\\"\\"Filter by the object’s \`varcharArray\` field.\\"\\"\\"
+  """Filter by the object’s \`varcharArray\` field."""
   varcharArray: StringListFilter
 }
 
-\\"\\"\\"A connection to a list of \`ArrayType\` values.\\"\\"\\"
+"""A connection to a list of \`ArrayType\` values."""
 type ArrayTypesConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`ArrayType\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [ArrayTypesEdge!]!
 
-  \\"\\"\\"A list of \`ArrayType\` objects.\\"\\"\\"
+  """A list of \`ArrayType\` objects."""
   nodes: [ArrayType]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`ArrayType\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`ArrayType\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`ArrayType\` edge in the connection.\\"\\"\\"
+"""A \`ArrayType\` edge in the connection."""
 type ArrayTypesEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`ArrayType\` at the end of the edge.\\"\\"\\"
+  """The \`ArrayType\` at the end of the edge."""
   node: ArrayType
 }
 
-\\"\\"\\"Methods to use when ordering \`ArrayType\`.\\"\\"\\"
+"""Methods to use when ordering \`ArrayType\`."""
 enum ArrayTypesOrderBy {
   BIT4_ARRAY_ASC
   BIT4_ARRAY_DESC
@@ -234,15 +234,15 @@ enum ArrayTypesOrderBy {
 }
 
 type Backward implements Node {
-  \\"\\"\\"Reads a single \`Filterable\` that is related to this \`Backward\`.\\"\\"\\"
+  """Reads a single \`Filterable\` that is related to this \`Backward\`."""
   filterableByFilterableId: Filterable
   filterableId: Int
   id: Int!
   name: String!
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
@@ -250,70 +250,70 @@ type BackwardCompound implements Node {
   backwardCompound1: Int!
   backwardCompound2: Int!
 
-  \\"\\"\\"
+  """
   Reads a single \`Filterable\` that is related to this \`BackwardCompound\`.
-  \\"\\"\\"
+  """
   filterableByBackwardCompound1AndBackwardCompound2: Filterable
   name: String
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`BackwardCompound\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input BackwardCompoundFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [BackwardCompoundFilter!]
 
-  \\"\\"\\"Filter by the object’s \`backwardCompound1\` field.\\"\\"\\"
+  """Filter by the object’s \`backwardCompound1\` field."""
   backwardCompound1: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`backwardCompound2\` field.\\"\\"\\"
+  """Filter by the object’s \`backwardCompound2\` field."""
   backwardCompound2: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`name\` field.\\"\\"\\"
+  """Filter by the object’s \`name\` field."""
   name: StringFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: BackwardCompoundFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [BackwardCompoundFilter!]
 }
 
-\\"\\"\\"A connection to a list of \`BackwardCompound\` values.\\"\\"\\"
+"""A connection to a list of \`BackwardCompound\` values."""
 type BackwardCompoundsConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`BackwardCompound\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [BackwardCompoundsEdge!]!
 
-  \\"\\"\\"A list of \`BackwardCompound\` objects.\\"\\"\\"
+  """A list of \`BackwardCompound\` objects."""
   nodes: [BackwardCompound]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"
+  """
   The count of *all* \`BackwardCompound\` you could get from the connection.
-  \\"\\"\\"
+  """
   totalCount: Int!
 }
 
-\\"\\"\\"A \`BackwardCompound\` edge in the connection.\\"\\"\\"
+"""A \`BackwardCompound\` edge in the connection."""
 type BackwardCompoundsEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`BackwardCompound\` at the end of the edge.\\"\\"\\"
+  """The \`BackwardCompound\` at the end of the edge."""
   node: BackwardCompound
 }
 
-\\"\\"\\"Methods to use when ordering \`BackwardCompound\`.\\"\\"\\"
+"""Methods to use when ordering \`BackwardCompound\`."""
 enum BackwardCompoundsOrderBy {
   BACKWARD_COMPOUND_1_ASC
   BACKWARD_COMPOUND_1_DESC
@@ -326,56 +326,56 @@ enum BackwardCompoundsOrderBy {
   PRIMARY_KEY_DESC
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`Backward\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input BackwardFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [BackwardFilter!]
 
-  \\"\\"\\"Filter by the object’s \`filterableId\` field.\\"\\"\\"
+  """Filter by the object’s \`filterableId\` field."""
   filterableId: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`name\` field.\\"\\"\\"
+  """Filter by the object’s \`name\` field."""
   name: StringFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: BackwardFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [BackwardFilter!]
 }
 
-\\"\\"\\"A connection to a list of \`Backward\` values.\\"\\"\\"
+"""A connection to a list of \`Backward\` values."""
 type BackwardsConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`Backward\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [BackwardsEdge!]!
 
-  \\"\\"\\"A list of \`Backward\` objects.\\"\\"\\"
+  """A list of \`Backward\` objects."""
   nodes: [Backward]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`Backward\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`Backward\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`Backward\` edge in the connection.\\"\\"\\"
+"""A \`Backward\` edge in the connection."""
 type BackwardsEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`Backward\` at the end of the edge.\\"\\"\\"
+  """The \`Backward\` at the end of the edge."""
   node: Backward
 }
 
-\\"\\"\\"Methods to use when ordering \`Backward\`.\\"\\"\\"
+"""Methods to use when ordering \`Backward\`."""
 enum BackwardsOrderBy {
   FILTERABLE_ID_ASC
   FILTERABLE_ID_DESC
@@ -388,358 +388,358 @@ enum BackwardsOrderBy {
   PRIMARY_KEY_DESC
 }
 
-\\"\\"\\"
+"""
 A floating point number that requires more precision than IEEE 754 binary 64
-\\"\\"\\"
+"""
 scalar BigFloat
 
-\\"\\"\\"
+"""
 A filter to be used against BigFloat fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input BigFloatFilter {
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: BigFloat
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: BigFloat
 }
 
-\\"\\"\\"
+"""
 A filter to be used against BigFloat List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input BigFloatListFilter {
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [BigFloat]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [BigFloat]
 }
 
-\\"\\"\\"A range of \`BigFloat\`.\\"\\"\\"
+"""A range of \`BigFloat\`."""
 type BigFloatRange {
-  \\"\\"\\"The ending bound of our range.\\"\\"\\"
+  """The ending bound of our range."""
   end: BigFloatRangeBound
 
-  \\"\\"\\"The starting bound of our range.\\"\\"\\"
+  """The starting bound of our range."""
   start: BigFloatRangeBound
 }
 
-\\"\\"\\"
+"""
 The value at one end of a range. A range can either include this value, or not.
-\\"\\"\\"
+"""
 type BigFloatRangeBound {
-  \\"\\"\\"Whether or not the value of this bound is included in the range.\\"\\"\\"
+  """Whether or not the value of this bound is included in the range."""
   inclusive: Boolean!
 
-  \\"\\"\\"The value at one end of our range.\\"\\"\\"
+  """The value at one end of our range."""
   value: BigFloat!
 }
 
-\\"\\"\\"
+"""
 The value at one end of a range. A range can either include this value, or not.
-\\"\\"\\"
+"""
 input BigFloatRangeBoundInput {
-  \\"\\"\\"Whether or not the value of this bound is included in the range.\\"\\"\\"
+  """Whether or not the value of this bound is included in the range."""
   inclusive: Boolean!
 
-  \\"\\"\\"The value at one end of our range.\\"\\"\\"
+  """The value at one end of our range."""
   value: BigFloat!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against BigFloatRange fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input BigFloatRangeFilter {
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: BigFloatRangeInput
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: BigFloatRangeInput
 }
 
-\\"\\"\\"A range of \`BigFloat\`.\\"\\"\\"
+"""A range of \`BigFloat\`."""
 input BigFloatRangeInput {
-  \\"\\"\\"The ending bound of our range.\\"\\"\\"
+  """The ending bound of our range."""
   end: BigFloatRangeBoundInput
 
-  \\"\\"\\"The starting bound of our range.\\"\\"\\"
+  """The starting bound of our range."""
   start: BigFloatRangeBoundInput
 }
 
-\\"\\"\\"
+"""
 A filter to be used against BigFloatRange List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input BigFloatRangeListFilter {
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [BigFloatRangeInput]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [BigFloatRangeInput]
 }
 
-\\"\\"\\"
+"""
 A signed eight-byte integer. The upper big integer values are greater than the
 max value for a JavaScript number. Therefore all big integers will be output as
 strings and not numbers.
-\\"\\"\\"
+"""
 scalar BigInt
 
-\\"\\"\\"
+"""
 A filter to be used against BigInt fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input BigIntFilter {
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: BigInt
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: BigInt
 }
 
-\\"\\"\\"
+"""
 A filter to be used against BigInt List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input BigIntListFilter {
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [BigInt]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [BigInt]
 }
 
-\\"\\"\\"A range of \`BigInt\`.\\"\\"\\"
+"""A range of \`BigInt\`."""
 type BigIntRange {
-  \\"\\"\\"The ending bound of our range.\\"\\"\\"
+  """The ending bound of our range."""
   end: BigIntRangeBound
 
-  \\"\\"\\"The starting bound of our range.\\"\\"\\"
+  """The starting bound of our range."""
   start: BigIntRangeBound
 }
 
-\\"\\"\\"
+"""
 The value at one end of a range. A range can either include this value, or not.
-\\"\\"\\"
+"""
 type BigIntRangeBound {
-  \\"\\"\\"Whether or not the value of this bound is included in the range.\\"\\"\\"
+  """Whether or not the value of this bound is included in the range."""
   inclusive: Boolean!
 
-  \\"\\"\\"The value at one end of our range.\\"\\"\\"
+  """The value at one end of our range."""
   value: BigInt!
 }
 
-\\"\\"\\"
+"""
 The value at one end of a range. A range can either include this value, or not.
-\\"\\"\\"
+"""
 input BigIntRangeBoundInput {
-  \\"\\"\\"Whether or not the value of this bound is included in the range.\\"\\"\\"
+  """Whether or not the value of this bound is included in the range."""
   inclusive: Boolean!
 
-  \\"\\"\\"The value at one end of our range.\\"\\"\\"
+  """The value at one end of our range."""
   value: BigInt!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against BigIntRange fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input BigIntRangeFilter {
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: BigIntRangeInput
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: BigIntRangeInput
 }
 
-\\"\\"\\"A range of \`BigInt\`.\\"\\"\\"
+"""A range of \`BigInt\`."""
 input BigIntRangeInput {
-  \\"\\"\\"The ending bound of our range.\\"\\"\\"
+  """The ending bound of our range."""
   end: BigIntRangeBoundInput
 
-  \\"\\"\\"The starting bound of our range.\\"\\"\\"
+  """The starting bound of our range."""
   start: BigIntRangeBoundInput
 }
 
-\\"\\"\\"
+"""
 A filter to be used against BigIntRange List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input BigIntRangeListFilter {
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [BigIntRangeInput]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [BigIntRangeInput]
 }
 
-\\"\\"\\"A string representing a series of binary bits\\"\\"\\"
+"""A string representing a series of binary bits"""
 scalar BitString
 
-\\"\\"\\"
+"""
 A filter to be used against BitString fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input BitStringFilter {
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: BitString
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: BitString
 }
 
-\\"\\"\\"
+"""
 A filter to be used against BitString List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input BitStringListFilter {
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [BitString]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [BitString]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against Boolean fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input BooleanFilter {
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: Boolean
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: Boolean
 }
 
-\\"\\"\\"
+"""
 A filter to be used against Boolean List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input BooleanListFilter {
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [Boolean]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [Boolean]
 }
 
 scalar Char4Domain
 
-\\"\\"\\"
+"""
 A filter to be used against Char4Domain fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input Char4DomainFilter {
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: Char4Domain
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: Char4Domain
 }
 
 type Child implements Node {
-  \\"\\"\\"Reads a single \`Filterable\` that is related to this \`Child\`.\\"\\"\\"
+  """Reads a single \`Filterable\` that is related to this \`Child\`."""
   filterableByFilterableId: Filterable
   filterableId: Int
   id: Int!
   name: String!
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`Child\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input ChildFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [ChildFilter!]
 
-  \\"\\"\\"Filter by the object’s \`filterableId\` field.\\"\\"\\"
+  """Filter by the object’s \`filterableId\` field."""
   filterableId: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`name\` field.\\"\\"\\"
+  """Filter by the object’s \`name\` field."""
   name: StringFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: ChildFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [ChildFilter!]
 }
 
 type ChildNoRelatedFilter implements Node {
-  \\"\\"\\"
+  """
   Reads a single \`Filterable\` that is related to this \`ChildNoRelatedFilter\`.
-  \\"\\"\\"
+  """
   filterableByFilterableId: Filterable
   filterableId: Int
   id: Int!
   name: String!
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 
-  \\"\\"\\"
+  """
   Reads a single \`Unfilterable\` that is related to this \`ChildNoRelatedFilter\`.
-  \\"\\"\\"
+  """
   unfilterableByUnfilterableId: Unfilterable
   unfilterableId: Int
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`ChildNoRelatedFilter\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input ChildNoRelatedFilterFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [ChildNoRelatedFilterFilter!]
 
-  \\"\\"\\"Filter by the object’s \`filterableId\` field.\\"\\"\\"
+  """Filter by the object’s \`filterableId\` field."""
   filterableId: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`name\` field.\\"\\"\\"
+  """Filter by the object’s \`name\` field."""
   name: StringFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: ChildNoRelatedFilterFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [ChildNoRelatedFilterFilter!]
 
-  \\"\\"\\"Filter by the object’s \`unfilterableId\` field.\\"\\"\\"
+  """Filter by the object’s \`unfilterableId\` field."""
   unfilterableId: IntFilter
 }
 
-\\"\\"\\"A connection to a list of \`ChildNoRelatedFilter\` values.\\"\\"\\"
+"""A connection to a list of \`ChildNoRelatedFilter\` values."""
 type ChildNoRelatedFiltersConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`ChildNoRelatedFilter\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [ChildNoRelatedFiltersEdge!]!
 
-  \\"\\"\\"A list of \`ChildNoRelatedFilter\` objects.\\"\\"\\"
+  """A list of \`ChildNoRelatedFilter\` objects."""
   nodes: [ChildNoRelatedFilter]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"
+  """
   The count of *all* \`ChildNoRelatedFilter\` you could get from the connection.
-  \\"\\"\\"
+  """
   totalCount: Int!
 }
 
-\\"\\"\\"A \`ChildNoRelatedFilter\` edge in the connection.\\"\\"\\"
+"""A \`ChildNoRelatedFilter\` edge in the connection."""
 type ChildNoRelatedFiltersEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`ChildNoRelatedFilter\` at the end of the edge.\\"\\"\\"
+  """The \`ChildNoRelatedFilter\` at the end of the edge."""
   node: ChildNoRelatedFilter
 }
 
-\\"\\"\\"Methods to use when ordering \`ChildNoRelatedFilter\`.\\"\\"\\"
+"""Methods to use when ordering \`ChildNoRelatedFilter\`."""
 enum ChildNoRelatedFiltersOrderBy {
   FILTERABLE_ID_ASC
   FILTERABLE_ID_DESC
@@ -754,33 +754,33 @@ enum ChildNoRelatedFiltersOrderBy {
   UNFILTERABLE_ID_DESC
 }
 
-\\"\\"\\"A connection to a list of \`Child\` values.\\"\\"\\"
+"""A connection to a list of \`Child\` values."""
 type ChildrenConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`Child\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [ChildrenEdge!]!
 
-  \\"\\"\\"A list of \`Child\` objects.\\"\\"\\"
+  """A list of \`Child\` objects."""
   nodes: [Child]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`Child\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`Child\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`Child\` edge in the connection.\\"\\"\\"
+"""A \`Child\` edge in the connection."""
 type ChildrenEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`Child\` at the end of the edge.\\"\\"\\"
+  """The \`Child\` at the end of the edge."""
   node: Child
 }
 
-\\"\\"\\"Methods to use when ordering \`Child\`.\\"\\"\\"
+"""Methods to use when ordering \`Child\`."""
 enum ChildrenOrderBy {
   FILTERABLE_ID_ASC
   FILTERABLE_ID_DESC
@@ -798,216 +798,216 @@ type Composite {
   b: String
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`Composite\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input CompositeFilter {
-  \\"\\"\\"Filter by the object’s \`a\` field.\\"\\"\\"
+  """Filter by the object’s \`a\` field."""
   a: IntFilter
 
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [CompositeFilter!]
 
-  \\"\\"\\"Filter by the object’s \`b\` field.\\"\\"\\"
+  """Filter by the object’s \`b\` field."""
   b: StringFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: CompositeFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [CompositeFilter!]
 }
 
-\\"\\"\\"A location in a connection that can be used for resuming pagination.\\"\\"\\"
+"""A location in a connection that can be used for resuming pagination."""
 scalar Cursor
 
-\\"\\"\\"The day, does not include a time.\\"\\"\\"
+"""The day, does not include a time."""
 scalar Date
 
 scalar DateDomain
 
-\\"\\"\\"
+"""
 A filter to be used against DateDomain fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input DateDomainFilter {
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: DateDomain
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: DateDomain
 }
 
-\\"\\"\\"
+"""
 A filter to be used against Date fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input DateFilter {
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: Date
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: Date
 }
 
-\\"\\"\\"
+"""
 A filter to be used against Date List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input DateListFilter {
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [Date]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [Date]
 }
 
-\\"\\"\\"A range of \`Date\`.\\"\\"\\"
+"""A range of \`Date\`."""
 type DateRange {
-  \\"\\"\\"The ending bound of our range.\\"\\"\\"
+  """The ending bound of our range."""
   end: DateRangeBound
 
-  \\"\\"\\"The starting bound of our range.\\"\\"\\"
+  """The starting bound of our range."""
   start: DateRangeBound
 }
 
-\\"\\"\\"
+"""
 The value at one end of a range. A range can either include this value, or not.
-\\"\\"\\"
+"""
 type DateRangeBound {
-  \\"\\"\\"Whether or not the value of this bound is included in the range.\\"\\"\\"
+  """Whether or not the value of this bound is included in the range."""
   inclusive: Boolean!
 
-  \\"\\"\\"The value at one end of our range.\\"\\"\\"
+  """The value at one end of our range."""
   value: Date!
 }
 
-\\"\\"\\"
+"""
 The value at one end of a range. A range can either include this value, or not.
-\\"\\"\\"
+"""
 input DateRangeBoundInput {
-  \\"\\"\\"Whether or not the value of this bound is included in the range.\\"\\"\\"
+  """Whether or not the value of this bound is included in the range."""
   inclusive: Boolean!
 
-  \\"\\"\\"The value at one end of our range.\\"\\"\\"
+  """The value at one end of our range."""
   value: Date!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against DateRange fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input DateRangeFilter {
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: DateRangeInput
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: DateRangeInput
 }
 
-\\"\\"\\"A range of \`Date\`.\\"\\"\\"
+"""A range of \`Date\`."""
 input DateRangeInput {
-  \\"\\"\\"The ending bound of our range.\\"\\"\\"
+  """The ending bound of our range."""
   end: DateRangeBoundInput
 
-  \\"\\"\\"The starting bound of our range.\\"\\"\\"
+  """The starting bound of our range."""
   start: DateRangeBoundInput
 }
 
-\\"\\"\\"
+"""
 A filter to be used against DateRange List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input DateRangeListFilter {
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [DateRangeInput]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [DateRangeInput]
 }
 
-\\"\\"\\"
+"""
 A point in time as described by the [ISO
 8601](https://en.wikipedia.org/wiki/ISO_8601) standard. May or may not include a timezone.
-\\"\\"\\"
+"""
 scalar Datetime
 
-\\"\\"\\"
+"""
 A filter to be used against Datetime fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input DatetimeFilter {
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: Datetime
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: Datetime
 }
 
-\\"\\"\\"
+"""
 A filter to be used against Datetime List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input DatetimeListFilter {
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [Datetime]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [Datetime]
 }
 
-\\"\\"\\"A range of \`Datetime\`.\\"\\"\\"
+"""A range of \`Datetime\`."""
 type DatetimeRange {
-  \\"\\"\\"The ending bound of our range.\\"\\"\\"
+  """The ending bound of our range."""
   end: DatetimeRangeBound
 
-  \\"\\"\\"The starting bound of our range.\\"\\"\\"
+  """The starting bound of our range."""
   start: DatetimeRangeBound
 }
 
-\\"\\"\\"
+"""
 The value at one end of a range. A range can either include this value, or not.
-\\"\\"\\"
+"""
 type DatetimeRangeBound {
-  \\"\\"\\"Whether or not the value of this bound is included in the range.\\"\\"\\"
+  """Whether or not the value of this bound is included in the range."""
   inclusive: Boolean!
 
-  \\"\\"\\"The value at one end of our range.\\"\\"\\"
+  """The value at one end of our range."""
   value: Datetime!
 }
 
-\\"\\"\\"
+"""
 The value at one end of a range. A range can either include this value, or not.
-\\"\\"\\"
+"""
 input DatetimeRangeBoundInput {
-  \\"\\"\\"Whether or not the value of this bound is included in the range.\\"\\"\\"
+  """Whether or not the value of this bound is included in the range."""
   inclusive: Boolean!
 
-  \\"\\"\\"The value at one end of our range.\\"\\"\\"
+  """The value at one end of our range."""
   value: Datetime!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against DatetimeRange fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input DatetimeRangeFilter {
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: DatetimeRangeInput
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: DatetimeRangeInput
 }
 
-\\"\\"\\"A range of \`Datetime\`.\\"\\"\\"
+"""A range of \`Datetime\`."""
 input DatetimeRangeInput {
-  \\"\\"\\"The ending bound of our range.\\"\\"\\"
+  """The ending bound of our range."""
   end: DatetimeRangeBoundInput
 
-  \\"\\"\\"The starting bound of our range.\\"\\"\\"
+  """The starting bound of our range."""
   start: DatetimeRangeBoundInput
 }
 
-\\"\\"\\"
+"""
 A filter to be used against DatetimeRange List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input DatetimeRangeListFilter {
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [DatetimeRangeInput]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [DatetimeRangeInput]
 }
 
@@ -1017,65 +1017,65 @@ type DomainType implements Node {
   id: Int!
   int4Domain: Int4Domain
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`DomainType\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input DomainTypeFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [DomainTypeFilter!]
 
-  \\"\\"\\"Filter by the object’s \`char4Domain\` field.\\"\\"\\"
+  """Filter by the object’s \`char4Domain\` field."""
   char4Domain: Char4DomainFilter
 
-  \\"\\"\\"Filter by the object’s \`dateDomain\` field.\\"\\"\\"
+  """Filter by the object’s \`dateDomain\` field."""
   dateDomain: DateDomainFilter
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`int4Domain\` field.\\"\\"\\"
+  """Filter by the object’s \`int4Domain\` field."""
   int4Domain: Int4DomainFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: DomainTypeFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [DomainTypeFilter!]
 }
 
-\\"\\"\\"A connection to a list of \`DomainType\` values.\\"\\"\\"
+"""A connection to a list of \`DomainType\` values."""
 type DomainTypesConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`DomainType\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [DomainTypesEdge!]!
 
-  \\"\\"\\"A list of \`DomainType\` objects.\\"\\"\\"
+  """A list of \`DomainType\` objects."""
   nodes: [DomainType]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`DomainType\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`DomainType\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`DomainType\` edge in the connection.\\"\\"\\"
+"""A \`DomainType\` edge in the connection."""
 type DomainTypesEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`DomainType\` at the end of the edge.\\"\\"\\"
+  """The \`DomainType\` at the end of the edge."""
   node: DomainType
 }
 
-\\"\\"\\"Methods to use when ordering \`DomainType\`.\\"\\"\\"
+"""Methods to use when ordering \`DomainType\`."""
 enum DomainTypesOrderBy {
   CHAR4_DOMAIN_ASC
   CHAR4_DOMAIN_DESC
@@ -1094,59 +1094,59 @@ type EnumArrayType implements Node {
   enumArray: [Mood]
   id: Int!
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`EnumArrayType\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input EnumArrayTypeFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [EnumArrayTypeFilter!]
 
-  \\"\\"\\"Filter by the object’s \`enumArray\` field.\\"\\"\\"
+  """Filter by the object’s \`enumArray\` field."""
   enumArray: MoodListFilter
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: EnumArrayTypeFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [EnumArrayTypeFilter!]
 }
 
-\\"\\"\\"A connection to a list of \`EnumArrayType\` values.\\"\\"\\"
+"""A connection to a list of \`EnumArrayType\` values."""
 type EnumArrayTypesConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`EnumArrayType\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [EnumArrayTypesEdge!]!
 
-  \\"\\"\\"A list of \`EnumArrayType\` objects.\\"\\"\\"
+  """A list of \`EnumArrayType\` objects."""
   nodes: [EnumArrayType]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`EnumArrayType\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`EnumArrayType\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`EnumArrayType\` edge in the connection.\\"\\"\\"
+"""A \`EnumArrayType\` edge in the connection."""
 type EnumArrayTypesEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`EnumArrayType\` at the end of the edge.\\"\\"\\"
+  """The \`EnumArrayType\` at the end of the edge."""
   node: EnumArrayType
 }
 
-\\"\\"\\"Methods to use when ordering \`EnumArrayType\`.\\"\\"\\"
+"""Methods to use when ordering \`EnumArrayType\`."""
 enum EnumArrayTypesOrderBy {
   ENUM_ARRAY_ASC
   ENUM_ARRAY_DESC
@@ -1161,59 +1161,59 @@ type EnumType implements Node {
   enum: Mood
   id: Int!
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`EnumType\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input EnumTypeFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [EnumTypeFilter!]
 
-  \\"\\"\\"Filter by the object’s \`enum\` field.\\"\\"\\"
+  """Filter by the object’s \`enum\` field."""
   enum: MoodFilter
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: EnumTypeFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [EnumTypeFilter!]
 }
 
-\\"\\"\\"A connection to a list of \`EnumType\` values.\\"\\"\\"
+"""A connection to a list of \`EnumType\` values."""
 type EnumTypesConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`EnumType\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [EnumTypesEdge!]!
 
-  \\"\\"\\"A list of \`EnumType\` objects.\\"\\"\\"
+  """A list of \`EnumType\` objects."""
   nodes: [EnumType]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`EnumType\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`EnumType\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`EnumType\` edge in the connection.\\"\\"\\"
+"""A \`EnumType\` edge in the connection."""
 type EnumTypesEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`EnumType\` at the end of the edge.\\"\\"\\"
+  """The \`EnumType\` at the end of the edge."""
   node: EnumType
 }
 
-\\"\\"\\"Methods to use when ordering \`EnumType\`.\\"\\"\\"
+"""Methods to use when ordering \`EnumType\`."""
 enum EnumTypesOrderBy {
   ENUM_ASC
   ENUM_DESC
@@ -1225,14 +1225,14 @@ enum EnumTypesOrderBy {
 }
 
 type Filterable implements Node {
-  \\"\\"\\"Reads a single \`Backward\` that is related to this \`Filterable\`.\\"\\"\\"
+  """Reads a single \`Backward\` that is related to this \`Filterable\`."""
   backwardByFilterableId: Backward
   backwardCompound1: Int
   backwardCompound2: Int
 
-  \\"\\"\\"
+  """
   Reads a single \`BackwardCompound\` that is related to this \`Filterable\`.
-  \\"\\"\\"
+  """
   backwardCompoundByBackwardCompound1AndBackwardCompound2: BackwardCompound
   bit4: BitString
   bool: Boolean
@@ -1240,61 +1240,61 @@ type Filterable implements Node {
   bytea: String
   char4: String
 
-  \\"\\"\\"Reads and enables pagination through a set of \`ChildNoRelatedFilter\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`ChildNoRelatedFilter\`."""
   childNoRelatedFiltersByFilterableId(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: ChildNoRelatedFilterFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`ChildNoRelatedFilter\`.\\"\\"\\"
+    """The method to use when ordering \`ChildNoRelatedFilter\`."""
     orderBy: [ChildNoRelatedFiltersOrderBy!] = [PRIMARY_KEY_ASC]
   ): ChildNoRelatedFiltersConnection!
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Child\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Child\`."""
   childrenByFilterableId(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: ChildFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`Child\`.\\"\\"\\"
+    """The method to use when ordering \`Child\`."""
     orderBy: [ChildrenOrderBy!] = [PRIMARY_KEY_ASC]
   ): ChildrenConnection!
   cidr: String
@@ -1305,126 +1305,126 @@ type Filterable implements Node {
   computedChild: Child
   computedIntArray: [Int]
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Child\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Child\`."""
   computedSetofChild(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: ChildFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
   ): ChildrenConnection!
   computedSetofInt(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: IntFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
   ): FilterableComputedSetofIntConnection!
   computedTaggedFilterable: Int
   computedWithRequiredArg(i: Int!): Int
   date: Date
 
-  \\"\\"\\"Reads and enables pagination through a set of \`FilterableClosure\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`FilterableClosure\`."""
   filterableClosuresByAncestorId(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: FilterableClosureFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`FilterableClosure\`.\\"\\"\\"
+    """The method to use when ordering \`FilterableClosure\`."""
     orderBy: [FilterableClosuresOrderBy!] = [PRIMARY_KEY_ASC]
   ): FilterableClosuresConnection!
 
-  \\"\\"\\"Reads and enables pagination through a set of \`FilterableClosure\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`FilterableClosure\`."""
   filterableClosuresByDescendantId(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: FilterableClosureFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`FilterableClosure\`.\\"\\"\\"
+    """The method to use when ordering \`FilterableClosure\`."""
     orderBy: [FilterableClosuresOrderBy!] = [PRIMARY_KEY_ASC]
   ): FilterableClosuresConnection!
   float4: Float
   float8: Float
 
-  \\"\\"\\"Reads a single \`Forward\` that is related to this \`Filterable\`.\\"\\"\\"
+  """Reads a single \`Forward\` that is related to this \`Filterable\`."""
   forwardByForwardId: Forward
   forwardColumn: Forward
   forwardCompound1: Int
   forwardCompound2: Int
 
-  \\"\\"\\"Reads a single \`ForwardCompound\` that is related to this \`Filterable\`.\\"\\"\\"
+  """Reads a single \`ForwardCompound\` that is related to this \`Filterable\`."""
   forwardCompoundByForwardCompound1AndForwardCompound2: ForwardCompound
   forwardId: Int
   hstore: KeyValueHash
@@ -1440,13 +1440,13 @@ type Filterable implements Node {
   money: Float
   name: String
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
   numeric: BigFloat
 
-  \\"\\"\\"Reads a single \`Parent\` that is related to this \`Filterable\`.\\"\\"\\"
+  """Reads a single \`Parent\` that is related to this \`Filterable\`."""
   parentByParentId: Parent
   parentId: Int
   text: String
@@ -1466,78 +1466,78 @@ type FilterableClosure implements Node {
   depth: Int!
   descendantId: Int!
 
-  \\"\\"\\"
+  """
   Reads a single \`Filterable\` that is related to this \`FilterableClosure\`.
-  \\"\\"\\"
+  """
   filterableByAncestorId: Filterable
 
-  \\"\\"\\"
+  """
   Reads a single \`Filterable\` that is related to this \`FilterableClosure\`.
-  \\"\\"\\"
+  """
   filterableByDescendantId: Filterable
   id: Int!
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`FilterableClosure\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input FilterableClosureFilter {
-  \\"\\"\\"Filter by the object’s \`ancestorId\` field.\\"\\"\\"
+  """Filter by the object’s \`ancestorId\` field."""
   ancestorId: IntFilter
 
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [FilterableClosureFilter!]
 
-  \\"\\"\\"Filter by the object’s \`depth\` field.\\"\\"\\"
+  """Filter by the object’s \`depth\` field."""
   depth: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`descendantId\` field.\\"\\"\\"
+  """Filter by the object’s \`descendantId\` field."""
   descendantId: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: FilterableClosureFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [FilterableClosureFilter!]
 }
 
-\\"\\"\\"A connection to a list of \`FilterableClosure\` values.\\"\\"\\"
+"""A connection to a list of \`FilterableClosure\` values."""
 type FilterableClosuresConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`FilterableClosure\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [FilterableClosuresEdge!]!
 
-  \\"\\"\\"A list of \`FilterableClosure\` objects.\\"\\"\\"
+  """A list of \`FilterableClosure\` objects."""
   nodes: [FilterableClosure]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"
+  """
   The count of *all* \`FilterableClosure\` you could get from the connection.
-  \\"\\"\\"
+  """
   totalCount: Int!
 }
 
-\\"\\"\\"A \`FilterableClosure\` edge in the connection.\\"\\"\\"
+"""A \`FilterableClosure\` edge in the connection."""
 type FilterableClosuresEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`FilterableClosure\` at the end of the edge.\\"\\"\\"
+  """The \`FilterableClosure\` at the end of the edge."""
   node: FilterableClosure
 }
 
-\\"\\"\\"Methods to use when ordering \`FilterableClosure\`.\\"\\"\\"
+"""Methods to use when ordering \`FilterableClosure\`."""
 enum FilterableClosuresOrderBy {
   ANCESTOR_ID_ASC
   ANCESTOR_ID_DESC
@@ -1552,181 +1552,181 @@ enum FilterableClosuresOrderBy {
   PRIMARY_KEY_DESC
 }
 
-\\"\\"\\"A connection to a list of \`Int\` values.\\"\\"\\"
+"""A connection to a list of \`Int\` values."""
 type FilterableComputedSetofIntConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`Int\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [FilterableComputedSetofIntEdge!]!
 
-  \\"\\"\\"A list of \`Int\` objects.\\"\\"\\"
+  """A list of \`Int\` objects."""
   nodes: [Int]!
 
-  \\"\\"\\"The count of *all* \`Int\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`Int\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`Int\` edge in the connection.\\"\\"\\"
+"""A \`Int\` edge in the connection."""
 type FilterableComputedSetofIntEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`Int\` at the end of the edge.\\"\\"\\"
+  """The \`Int\` at the end of the edge."""
   node: Int
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`Filterable\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input FilterableFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [FilterableFilter!]
 
-  \\"\\"\\"Filter by the object’s \`backwardCompound1\` field.\\"\\"\\"
+  """Filter by the object’s \`backwardCompound1\` field."""
   backwardCompound1: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`backwardCompound2\` field.\\"\\"\\"
+  """Filter by the object’s \`backwardCompound2\` field."""
   backwardCompound2: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`bit4\` field.\\"\\"\\"
+  """Filter by the object’s \`bit4\` field."""
   bit4: BitStringFilter
 
-  \\"\\"\\"Filter by the object’s \`bool\` field.\\"\\"\\"
+  """Filter by the object’s \`bool\` field."""
   bool: BooleanFilter
 
-  \\"\\"\\"Filter by the object’s \`bpchar4\` field.\\"\\"\\"
+  """Filter by the object’s \`bpchar4\` field."""
   bpchar4: StringFilter
 
-  \\"\\"\\"Filter by the object’s \`char4\` field.\\"\\"\\"
+  """Filter by the object’s \`char4\` field."""
   char4: StringFilter
 
-  \\"\\"\\"Filter by the object’s \`citext\` field.\\"\\"\\"
+  """Filter by the object’s \`citext\` field."""
   citext: StringFilter
 
-  \\"\\"\\"Filter by the object’s \`compositeColumn\` field.\\"\\"\\"
+  """Filter by the object’s \`compositeColumn\` field."""
   compositeColumn: CompositeFilter
 
-  \\"\\"\\"Filter by the object’s \`computed\` field.\\"\\"\\"
+  """Filter by the object’s \`computed\` field."""
   computed: StringFilter
 
-  \\"\\"\\"Filter by the object’s \`computedIntArray\` field.\\"\\"\\"
+  """Filter by the object’s \`computedIntArray\` field."""
   computedIntArray: IntListFilter
 
-  \\"\\"\\"Filter by the object’s \`computedTaggedFilterable\` field.\\"\\"\\"
+  """Filter by the object’s \`computedTaggedFilterable\` field."""
   computedTaggedFilterable: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`date\` field.\\"\\"\\"
+  """Filter by the object’s \`date\` field."""
   date: DateFilter
 
-  \\"\\"\\"Filter by the object’s \`float4\` field.\\"\\"\\"
+  """Filter by the object’s \`float4\` field."""
   float4: FloatFilter
 
-  \\"\\"\\"Filter by the object’s \`float8\` field.\\"\\"\\"
+  """Filter by the object’s \`float8\` field."""
   float8: FloatFilter
 
-  \\"\\"\\"Filter by the object’s \`forwardCompound1\` field.\\"\\"\\"
+  """Filter by the object’s \`forwardCompound1\` field."""
   forwardCompound1: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`forwardCompound2\` field.\\"\\"\\"
+  """Filter by the object’s \`forwardCompound2\` field."""
   forwardCompound2: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`forwardId\` field.\\"\\"\\"
+  """Filter by the object’s \`forwardId\` field."""
   forwardId: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`hstore\` field.\\"\\"\\"
+  """Filter by the object’s \`hstore\` field."""
   hstore: KeyValueHashFilter
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`inet\` field.\\"\\"\\"
+  """Filter by the object’s \`inet\` field."""
   inet: InternetAddressFilter
 
-  \\"\\"\\"Filter by the object’s \`int2\` field.\\"\\"\\"
+  """Filter by the object’s \`int2\` field."""
   int2: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`int4\` field.\\"\\"\\"
+  """Filter by the object’s \`int4\` field."""
   int4: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`int8\` field.\\"\\"\\"
+  """Filter by the object’s \`int8\` field."""
   int8: BigIntFilter
 
-  \\"\\"\\"Filter by the object’s \`interval\` field.\\"\\"\\"
+  """Filter by the object’s \`interval\` field."""
   interval: IntervalFilter
 
-  \\"\\"\\"Filter by the object’s \`jsonb\` field.\\"\\"\\"
+  """Filter by the object’s \`jsonb\` field."""
   jsonb: JSONFilter
 
-  \\"\\"\\"Filter by the object’s \`money\` field.\\"\\"\\"
+  """Filter by the object’s \`money\` field."""
   money: FloatFilter
 
-  \\"\\"\\"Filter by the object’s \`name\` field.\\"\\"\\"
+  """Filter by the object’s \`name\` field."""
   name: StringFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: FilterableFilter
 
-  \\"\\"\\"Filter by the object’s \`numeric\` field.\\"\\"\\"
+  """Filter by the object’s \`numeric\` field."""
   numeric: BigFloatFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [FilterableFilter!]
 
-  \\"\\"\\"Filter by the object’s \`parentId\` field.\\"\\"\\"
+  """Filter by the object’s \`parentId\` field."""
   parentId: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`text\` field.\\"\\"\\"
+  """Filter by the object’s \`text\` field."""
   text: StringFilter
 
-  \\"\\"\\"Filter by the object’s \`time\` field.\\"\\"\\"
+  """Filter by the object’s \`time\` field."""
   time: TimeFilter
 
-  \\"\\"\\"Filter by the object’s \`timestamp\` field.\\"\\"\\"
+  """Filter by the object’s \`timestamp\` field."""
   timestamp: DatetimeFilter
 
-  \\"\\"\\"Filter by the object’s \`timestamptz\` field.\\"\\"\\"
+  """Filter by the object’s \`timestamptz\` field."""
   timestamptz: DatetimeFilter
 
-  \\"\\"\\"Filter by the object’s \`timetz\` field.\\"\\"\\"
+  """Filter by the object’s \`timetz\` field."""
   timetz: TimeFilter
 
-  \\"\\"\\"Filter by the object’s \`uuid\` field.\\"\\"\\"
+  """Filter by the object’s \`uuid\` field."""
   uuid: UUIDFilter
 
-  \\"\\"\\"Filter by the object’s \`varbit\` field.\\"\\"\\"
+  """Filter by the object’s \`varbit\` field."""
   varbit: BitStringFilter
 
-  \\"\\"\\"Filter by the object’s \`varchar\` field.\\"\\"\\"
+  """Filter by the object’s \`varchar\` field."""
   varchar: StringFilter
 }
 
-\\"\\"\\"A connection to a list of \`Filterable\` values.\\"\\"\\"
+"""A connection to a list of \`Filterable\` values."""
 type FilterablesConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`Filterable\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [FilterablesEdge!]!
 
-  \\"\\"\\"A list of \`Filterable\` objects.\\"\\"\\"
+  """A list of \`Filterable\` objects."""
   nodes: [Filterable]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`Filterable\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`Filterable\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`Filterable\` edge in the connection.\\"\\"\\"
+"""A \`Filterable\` edge in the connection."""
 type FilterablesEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`Filterable\` at the end of the edge.\\"\\"\\"
+  """The \`Filterable\` at the end of the edge."""
   node: Filterable
 }
 
-\\"\\"\\"Methods to use when ordering \`Filterable\`.\\"\\"\\"
+"""Methods to use when ordering \`Filterable\`."""
 enum FilterablesOrderBy {
   BACKWARD_COMPOUND_1_ASC
   BACKWARD_COMPOUND_1_DESC
@@ -1815,105 +1815,105 @@ enum FilterablesOrderBy {
   XML_DESC
 }
 
-\\"\\"\\"
+"""
 A filter to be used against Float fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input FloatFilter {
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: Float
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: Float
 }
 
-\\"\\"\\"
+"""
 A filter to be used against Float List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input FloatListFilter {
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [Float]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [Float]
 }
 
 type Forward implements Node {
-  \\"\\"\\"Reads a single \`Filterable\` that is related to this \`Forward\`.\\"\\"\\"
+  """Reads a single \`Filterable\` that is related to this \`Forward\`."""
   filterableByForwardId: Filterable
   id: Int!
   name: String!
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
 type ForwardCompound implements Node {
-  \\"\\"\\"Reads a single \`Filterable\` that is related to this \`ForwardCompound\`.\\"\\"\\"
+  """Reads a single \`Filterable\` that is related to this \`ForwardCompound\`."""
   filterableByForwardCompound1AndForwardCompound2: Filterable
   forwardCompound1: Int!
   forwardCompound2: Int!
   name: String
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`ForwardCompound\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input ForwardCompoundFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [ForwardCompoundFilter!]
 
-  \\"\\"\\"Filter by the object’s \`forwardCompound1\` field.\\"\\"\\"
+  """Filter by the object’s \`forwardCompound1\` field."""
   forwardCompound1: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`forwardCompound2\` field.\\"\\"\\"
+  """Filter by the object’s \`forwardCompound2\` field."""
   forwardCompound2: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`name\` field.\\"\\"\\"
+  """Filter by the object’s \`name\` field."""
   name: StringFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: ForwardCompoundFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [ForwardCompoundFilter!]
 }
 
-\\"\\"\\"A connection to a list of \`ForwardCompound\` values.\\"\\"\\"
+"""A connection to a list of \`ForwardCompound\` values."""
 type ForwardCompoundsConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`ForwardCompound\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [ForwardCompoundsEdge!]!
 
-  \\"\\"\\"A list of \`ForwardCompound\` objects.\\"\\"\\"
+  """A list of \`ForwardCompound\` objects."""
   nodes: [ForwardCompound]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"
+  """
   The count of *all* \`ForwardCompound\` you could get from the connection.
-  \\"\\"\\"
+  """
   totalCount: Int!
 }
 
-\\"\\"\\"A \`ForwardCompound\` edge in the connection.\\"\\"\\"
+"""A \`ForwardCompound\` edge in the connection."""
 type ForwardCompoundsEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`ForwardCompound\` at the end of the edge.\\"\\"\\"
+  """The \`ForwardCompound\` at the end of the edge."""
   node: ForwardCompound
 }
 
-\\"\\"\\"Methods to use when ordering \`ForwardCompound\`.\\"\\"\\"
+"""Methods to use when ordering \`ForwardCompound\`."""
 enum ForwardCompoundsOrderBy {
   FORWARD_COMPOUND_1_ASC
   FORWARD_COMPOUND_1_DESC
@@ -1926,53 +1926,53 @@ enum ForwardCompoundsOrderBy {
   PRIMARY_KEY_DESC
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`Forward\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input ForwardFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [ForwardFilter!]
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`name\` field.\\"\\"\\"
+  """Filter by the object’s \`name\` field."""
   name: StringFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: ForwardFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [ForwardFilter!]
 }
 
-\\"\\"\\"A connection to a list of \`Forward\` values.\\"\\"\\"
+"""A connection to a list of \`Forward\` values."""
 type ForwardsConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`Forward\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [ForwardsEdge!]!
 
-  \\"\\"\\"A list of \`Forward\` objects.\\"\\"\\"
+  """A list of \`Forward\` objects."""
   nodes: [Forward]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`Forward\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`Forward\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`Forward\` edge in the connection.\\"\\"\\"
+"""A \`Forward\` edge in the connection."""
 type ForwardsEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`Forward\` at the end of the edge.\\"\\"\\"
+  """The \`Forward\` at the end of the edge."""
   node: Forward
 }
 
-\\"\\"\\"Methods to use when ordering \`Forward\`.\\"\\"\\"
+"""Methods to use when ordering \`Forward\`."""
 enum ForwardsOrderBy {
   ID_ASC
   ID_DESC
@@ -1986,40 +1986,40 @@ enum ForwardsOrderBy {
 type FullyOmitted implements Node {
   id: Int!
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
   text: String
 }
 
-\\"\\"\\"A connection to a list of \`FullyOmitted\` values.\\"\\"\\"
+"""A connection to a list of \`FullyOmitted\` values."""
 type FullyOmittedsConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`FullyOmitted\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [FullyOmittedsEdge!]!
 
-  \\"\\"\\"A list of \`FullyOmitted\` objects.\\"\\"\\"
+  """A list of \`FullyOmitted\` objects."""
   nodes: [FullyOmitted]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`FullyOmitted\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`FullyOmitted\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`FullyOmitted\` edge in the connection.\\"\\"\\"
+"""A \`FullyOmitted\` edge in the connection."""
 type FullyOmittedsEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`FullyOmitted\` at the end of the edge.\\"\\"\\"
+  """The \`FullyOmitted\` at the end of the edge."""
   node: FullyOmitted
 }
 
-\\"\\"\\"Methods to use when ordering \`FullyOmitted\`.\\"\\"\\"
+"""Methods to use when ordering \`FullyOmitted\`."""
 enum FullyOmittedsOrderBy {
   ID_ASC
   ID_DESC
@@ -2030,341 +2030,341 @@ enum FullyOmittedsOrderBy {
   TEXT_DESC
 }
 
-\\"\\"\\"A connection to a list of \`FuncReturnsTableMultiColRecord\` values.\\"\\"\\"
+"""A connection to a list of \`FuncReturnsTableMultiColRecord\` values."""
 type FuncReturnsTableMultiColConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`FuncReturnsTableMultiColRecord\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [FuncReturnsTableMultiColEdge!]!
 
-  \\"\\"\\"A list of \`FuncReturnsTableMultiColRecord\` objects.\\"\\"\\"
+  """A list of \`FuncReturnsTableMultiColRecord\` objects."""
   nodes: [FuncReturnsTableMultiColRecord]!
 
-  \\"\\"\\"
+  """
   The count of *all* \`FuncReturnsTableMultiColRecord\` you could get from the connection.
-  \\"\\"\\"
+  """
   totalCount: Int!
 }
 
-\\"\\"\\"A \`FuncReturnsTableMultiColRecord\` edge in the connection.\\"\\"\\"
+"""A \`FuncReturnsTableMultiColRecord\` edge in the connection."""
 type FuncReturnsTableMultiColEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`FuncReturnsTableMultiColRecord\` at the end of the edge.\\"\\"\\"
+  """The \`FuncReturnsTableMultiColRecord\` at the end of the edge."""
   node: FuncReturnsTableMultiColRecord
 }
 
-\\"\\"\\"The return type of our \`funcReturnsTableMultiCol\` query.\\"\\"\\"
+"""The return type of our \`funcReturnsTableMultiCol\` query."""
 type FuncReturnsTableMultiColRecord {
   col1: Int
   col2: String
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`FuncReturnsTableMultiColRecord\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input FuncReturnsTableMultiColRecordFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [FuncReturnsTableMultiColRecordFilter!]
 
-  \\"\\"\\"Filter by the object’s \`col1\` field.\\"\\"\\"
+  """Filter by the object’s \`col1\` field."""
   col1: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`col2\` field.\\"\\"\\"
+  """Filter by the object’s \`col2\` field."""
   col2: StringFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: FuncReturnsTableMultiColRecordFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [FuncReturnsTableMultiColRecordFilter!]
 }
 
-\\"\\"\\"A connection to a list of \`Int\` values.\\"\\"\\"
+"""A connection to a list of \`Int\` values."""
 type FuncReturnsTableOneColConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`Int\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [FuncReturnsTableOneColEdge!]!
 
-  \\"\\"\\"A list of \`Int\` objects.\\"\\"\\"
+  """A list of \`Int\` objects."""
   nodes: [Int]!
 
-  \\"\\"\\"The count of *all* \`Int\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`Int\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`Int\` edge in the connection.\\"\\"\\"
+"""A \`Int\` edge in the connection."""
 type FuncReturnsTableOneColEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`Int\` at the end of the edge.\\"\\"\\"
+  """The \`Int\` at the end of the edge."""
   node: Int
 }
 
-\\"\\"\\"
+"""
 A connection to a list of \`FuncTaggedFilterableReturnsTableMultiColRecord\` values.
-\\"\\"\\"
+"""
 type FuncTaggedFilterableReturnsTableMultiColConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`FuncTaggedFilterableReturnsTableMultiColRecord\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [FuncTaggedFilterableReturnsTableMultiColEdge!]!
 
-  \\"\\"\\"A list of \`FuncTaggedFilterableReturnsTableMultiColRecord\` objects.\\"\\"\\"
+  """A list of \`FuncTaggedFilterableReturnsTableMultiColRecord\` objects."""
   nodes: [FuncTaggedFilterableReturnsTableMultiColRecord]!
 
-  \\"\\"\\"
+  """
   The count of *all* \`FuncTaggedFilterableReturnsTableMultiColRecord\` you could get from the connection.
-  \\"\\"\\"
+  """
   totalCount: Int!
 }
 
-\\"\\"\\"
+"""
 A \`FuncTaggedFilterableReturnsTableMultiColRecord\` edge in the connection.
-\\"\\"\\"
+"""
 type FuncTaggedFilterableReturnsTableMultiColEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"
+  """
   The \`FuncTaggedFilterableReturnsTableMultiColRecord\` at the end of the edge.
-  \\"\\"\\"
+  """
   node: FuncTaggedFilterableReturnsTableMultiColRecord
 }
 
-\\"\\"\\"
+"""
 The return type of our \`funcTaggedFilterableReturnsTableMultiCol\` query.
-\\"\\"\\"
+"""
 type FuncTaggedFilterableReturnsTableMultiColRecord {
   col1: Int
   col2: String
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`FuncTaggedFilterableReturnsTableMultiColRecord\`
 object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input FuncTaggedFilterableReturnsTableMultiColRecordFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [FuncTaggedFilterableReturnsTableMultiColRecordFilter!]
 
-  \\"\\"\\"Filter by the object’s \`col1\` field.\\"\\"\\"
+  """Filter by the object’s \`col1\` field."""
   col1: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`col2\` field.\\"\\"\\"
+  """Filter by the object’s \`col2\` field."""
   col2: StringFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: FuncTaggedFilterableReturnsTableMultiColRecordFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [FuncTaggedFilterableReturnsTableMultiColRecordFilter!]
 }
 
 scalar Int4Domain
 
-\\"\\"\\"
+"""
 A filter to be used against Int4Domain fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input Int4DomainFilter {
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: Int4Domain
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: Int4Domain
 }
 
-\\"\\"\\"An IPv4 or IPv6 host address, and optionally its subnet.\\"\\"\\"
+"""An IPv4 or IPv6 host address, and optionally its subnet."""
 scalar InternetAddress
 
-\\"\\"\\"
+"""
 A filter to be used against InternetAddress fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input InternetAddressFilter {
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: InternetAddress
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: InternetAddress
 }
 
-\\"\\"\\"
+"""
 A filter to be used against InternetAddress List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input InternetAddressListFilter {
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [InternetAddress]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [InternetAddress]
 }
 
-\\"\\"\\"
+"""
 An interval of time that has passed where the smallest distinct unit is a second.
-\\"\\"\\"
+"""
 type Interval {
-  \\"\\"\\"A quantity of days.\\"\\"\\"
+  """A quantity of days."""
   days: Int
 
-  \\"\\"\\"A quantity of hours.\\"\\"\\"
+  """A quantity of hours."""
   hours: Int
 
-  \\"\\"\\"A quantity of minutes.\\"\\"\\"
+  """A quantity of minutes."""
   minutes: Int
 
-  \\"\\"\\"A quantity of months.\\"\\"\\"
+  """A quantity of months."""
   months: Int
 
-  \\"\\"\\"
+  """
   A quantity of seconds. This is the only non-integer field, as all the other
   fields will dump their overflow into a smaller unit of time. Intervals don’t
   have a smaller unit than seconds.
-  \\"\\"\\"
+  """
   seconds: Float
 
-  \\"\\"\\"A quantity of years.\\"\\"\\"
+  """A quantity of years."""
   years: Int
 }
 
-\\"\\"\\"
+"""
 A filter to be used against Interval fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input IntervalFilter {
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: IntervalInput
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: IntervalInput
 }
 
-\\"\\"\\"
+"""
 An interval of time that has passed where the smallest distinct unit is a second.
-\\"\\"\\"
+"""
 input IntervalInput {
-  \\"\\"\\"A quantity of days.\\"\\"\\"
+  """A quantity of days."""
   days: Int
 
-  \\"\\"\\"A quantity of hours.\\"\\"\\"
+  """A quantity of hours."""
   hours: Int
 
-  \\"\\"\\"A quantity of minutes.\\"\\"\\"
+  """A quantity of minutes."""
   minutes: Int
 
-  \\"\\"\\"A quantity of months.\\"\\"\\"
+  """A quantity of months."""
   months: Int
 
-  \\"\\"\\"
+  """
   A quantity of seconds. This is the only non-integer field, as all the other
   fields will dump their overflow into a smaller unit of time. Intervals don’t
   have a smaller unit than seconds.
-  \\"\\"\\"
+  """
   seconds: Float
 
-  \\"\\"\\"A quantity of years.\\"\\"\\"
+  """A quantity of years."""
   years: Int
 }
 
-\\"\\"\\"
+"""
 A filter to be used against Interval List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input IntervalListFilter {
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [IntervalInput]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [IntervalInput]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against Int fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input IntFilter {
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: Int
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: Int
 }
 
-\\"\\"\\"
+"""
 A filter to be used against Int List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input IntListFilter {
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [Int]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [Int]
 }
 
-\\"\\"\\"A range of \`Int\`.\\"\\"\\"
+"""A range of \`Int\`."""
 type IntRange {
-  \\"\\"\\"The ending bound of our range.\\"\\"\\"
+  """The ending bound of our range."""
   end: IntRangeBound
 
-  \\"\\"\\"The starting bound of our range.\\"\\"\\"
+  """The starting bound of our range."""
   start: IntRangeBound
 }
 
-\\"\\"\\"
+"""
 The value at one end of a range. A range can either include this value, or not.
-\\"\\"\\"
+"""
 type IntRangeBound {
-  \\"\\"\\"Whether or not the value of this bound is included in the range.\\"\\"\\"
+  """Whether or not the value of this bound is included in the range."""
   inclusive: Boolean!
 
-  \\"\\"\\"The value at one end of our range.\\"\\"\\"
+  """The value at one end of our range."""
   value: Int!
 }
 
-\\"\\"\\"
+"""
 The value at one end of a range. A range can either include this value, or not.
-\\"\\"\\"
+"""
 input IntRangeBoundInput {
-  \\"\\"\\"Whether or not the value of this bound is included in the range.\\"\\"\\"
+  """Whether or not the value of this bound is included in the range."""
   inclusive: Boolean!
 
-  \\"\\"\\"The value at one end of our range.\\"\\"\\"
+  """The value at one end of our range."""
   value: Int!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against IntRange fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input IntRangeFilter {
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: IntRangeInput
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: IntRangeInput
 }
 
-\\"\\"\\"A range of \`Int\`.\\"\\"\\"
+"""A range of \`Int\`."""
 input IntRangeInput {
-  \\"\\"\\"The ending bound of our range.\\"\\"\\"
+  """The ending bound of our range."""
   end: IntRangeBoundInput
 
-  \\"\\"\\"The starting bound of our range.\\"\\"\\"
+  """The starting bound of our range."""
   start: IntRangeBoundInput
 }
 
-\\"\\"\\"
+"""
 A filter to be used against IntRange List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input IntRangeListFilter {
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [IntRangeInput]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [IntRangeInput]
 }
 
-\\"\\"\\"
+"""
 A JavaScript object encoded in the JSON format as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf).
-\\"\\"\\"
+"""
 scalar JSON
 
 type JsonbTest implements Node {
@@ -2372,62 +2372,62 @@ type JsonbTest implements Node {
   jsonbWithArray: JSON
   jsonbWithObject: JSON
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`JsonbTest\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input JsonbTestFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [JsonbTestFilter!]
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`jsonbWithArray\` field.\\"\\"\\"
+  """Filter by the object’s \`jsonbWithArray\` field."""
   jsonbWithArray: JSONFilter
 
-  \\"\\"\\"Filter by the object’s \`jsonbWithObject\` field.\\"\\"\\"
+  """Filter by the object’s \`jsonbWithObject\` field."""
   jsonbWithObject: JSONFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: JsonbTestFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [JsonbTestFilter!]
 }
 
-\\"\\"\\"A connection to a list of \`JsonbTest\` values.\\"\\"\\"
+"""A connection to a list of \`JsonbTest\` values."""
 type JsonbTestsConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`JsonbTest\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [JsonbTestsEdge!]!
 
-  \\"\\"\\"A list of \`JsonbTest\` objects.\\"\\"\\"
+  """A list of \`JsonbTest\` objects."""
   nodes: [JsonbTest]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`JsonbTest\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`JsonbTest\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`JsonbTest\` edge in the connection.\\"\\"\\"
+"""A \`JsonbTest\` edge in the connection."""
 type JsonbTestsEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`JsonbTest\` at the end of the edge.\\"\\"\\"
+  """The \`JsonbTest\` at the end of the edge."""
   node: JsonbTest
 }
 
-\\"\\"\\"Methods to use when ordering \`JsonbTest\`.\\"\\"\\"
+"""Methods to use when ordering \`JsonbTest\`."""
 enum JsonbTestsOrderBy {
   ID_ASC
   ID_DESC
@@ -2440,90 +2440,90 @@ enum JsonbTestsOrderBy {
   PRIMARY_KEY_DESC
 }
 
-\\"\\"\\"
+"""
 A filter to be used against JSON fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input JSONFilter {
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: JSON
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: JSON
 }
 
-\\"\\"\\"
+"""
 A filter to be used against JSON List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input JSONListFilter {
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [JSON]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [JSON]
 }
 
 type Junction implements Node {
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 
-  \\"\\"\\"Reads a single \`SideA\` that is related to this \`Junction\`.\\"\\"\\"
+  """Reads a single \`SideA\` that is related to this \`Junction\`."""
   sideABySideAId: SideA
   sideAId: Int!
 
-  \\"\\"\\"Reads a single \`SideB\` that is related to this \`Junction\`.\\"\\"\\"
+  """Reads a single \`SideB\` that is related to this \`Junction\`."""
   sideBBySideBId: SideB
   sideBId: Int!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`Junction\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input JunctionFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [JunctionFilter!]
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: JunctionFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [JunctionFilter!]
 
-  \\"\\"\\"Filter by the object’s \`sideAId\` field.\\"\\"\\"
+  """Filter by the object’s \`sideAId\` field."""
   sideAId: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`sideBId\` field.\\"\\"\\"
+  """Filter by the object’s \`sideBId\` field."""
   sideBId: IntFilter
 }
 
-\\"\\"\\"A connection to a list of \`Junction\` values.\\"\\"\\"
+"""A connection to a list of \`Junction\` values."""
 type JunctionsConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`Junction\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [JunctionsEdge!]!
 
-  \\"\\"\\"A list of \`Junction\` objects.\\"\\"\\"
+  """A list of \`Junction\` objects."""
   nodes: [Junction]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`Junction\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`Junction\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`Junction\` edge in the connection.\\"\\"\\"
+"""A \`Junction\` edge in the connection."""
 type JunctionsEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`Junction\` at the end of the edge.\\"\\"\\"
+  """The \`Junction\` at the end of the edge."""
   node: Junction
 }
 
-\\"\\"\\"Methods to use when ordering \`Junction\`.\\"\\"\\"
+"""Methods to use when ordering \`Junction\`."""
 enum JunctionsOrderBy {
   NATURAL
   PRIMARY_KEY_ASC
@@ -2534,30 +2534,30 @@ enum JunctionsOrderBy {
   SIDE_B_ID_DESC
 }
 
-\\"\\"\\"
+"""
 A set of key/value pairs, keys are strings, values may be a string or null. Exposed as a JSON object.
-\\"\\"\\"
+"""
 scalar KeyValueHash
 
-\\"\\"\\"
+"""
 A filter to be used against KeyValueHash fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input KeyValueHashFilter {
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: KeyValueHash
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: KeyValueHash
 }
 
-\\"\\"\\"
+"""
 A filter to be used against KeyValueHash List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input KeyValueHashListFilter {
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [KeyValueHash]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [KeyValueHash]
 }
 
@@ -2567,136 +2567,136 @@ enum Mood {
   SAD
 }
 
-\\"\\"\\"
+"""
 A filter to be used against Mood fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input MoodFilter {
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: Mood
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: Mood
 }
 
-\\"\\"\\"
+"""
 A filter to be used against Mood List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input MoodListFilter {
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [Mood]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [Mood]
 }
 
-\\"\\"\\"An object with a globally unique \`ID\`.\\"\\"\\"
+"""An object with a globally unique \`ID\`."""
 interface Node {
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
-\\"\\"\\"Information about pagination in a connection.\\"\\"\\"
+"""Information about pagination in a connection."""
 type PageInfo {
-  \\"\\"\\"When paginating forwards, the cursor to continue.\\"\\"\\"
+  """When paginating forwards, the cursor to continue."""
   endCursor: Cursor
 
-  \\"\\"\\"When paginating forwards, are there more items?\\"\\"\\"
+  """When paginating forwards, are there more items?"""
   hasNextPage: Boolean!
 
-  \\"\\"\\"When paginating backwards, are there more items?\\"\\"\\"
+  """When paginating backwards, are there more items?"""
   hasPreviousPage: Boolean!
 
-  \\"\\"\\"When paginating backwards, the cursor to continue.\\"\\"\\"
+  """When paginating backwards, the cursor to continue."""
   startCursor: Cursor
 }
 
 type Parent implements Node {
-  \\"\\"\\"Reads and enables pagination through a set of \`Filterable\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Filterable\`."""
   filterablesByParentId(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: FilterableFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`Filterable\`.\\"\\"\\"
+    """The method to use when ordering \`Filterable\`."""
     orderBy: [FilterablesOrderBy!] = [PRIMARY_KEY_ASC]
   ): FilterablesConnection!
   id: Int!
   name: String!
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`Parent\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input ParentFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [ParentFilter!]
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`name\` field.\\"\\"\\"
+  """Filter by the object’s \`name\` field."""
   name: StringFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: ParentFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [ParentFilter!]
 }
 
-\\"\\"\\"A connection to a list of \`Parent\` values.\\"\\"\\"
+"""A connection to a list of \`Parent\` values."""
 type ParentsConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`Parent\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [ParentsEdge!]!
 
-  \\"\\"\\"A list of \`Parent\` objects.\\"\\"\\"
+  """A list of \`Parent\` objects."""
   nodes: [Parent]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`Parent\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`Parent\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`Parent\` edge in the connection.\\"\\"\\"
+"""A \`Parent\` edge in the connection."""
 type ParentsEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`Parent\` at the end of the edge.\\"\\"\\"
+  """The \`Parent\` at the end of the edge."""
   node: Parent
 }
 
-\\"\\"\\"Methods to use when ordering \`Parent\`.\\"\\"\\"
+"""Methods to use when ordering \`Parent\`."""
 enum ParentsOrderBy {
   ID_ASC
   ID_DESC
@@ -2711,704 +2711,704 @@ type Protected implements Node {
   id: Int!
   name: String
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
   otherId: Int
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`Protected\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input ProtectedFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [ProtectedFilter!]
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`name\` field.\\"\\"\\"
+  """Filter by the object’s \`name\` field."""
   name: StringFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: ProtectedFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [ProtectedFilter!]
 
-  \\"\\"\\"Filter by the object’s \`otherId\` field.\\"\\"\\"
+  """Filter by the object’s \`otherId\` field."""
   otherId: IntFilter
 }
 
-\\"\\"\\"A connection to a list of \`Protected\` values.\\"\\"\\"
+"""A connection to a list of \`Protected\` values."""
 type ProtectedsConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`Protected\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [ProtectedsEdge!]!
 
-  \\"\\"\\"A list of \`Protected\` objects.\\"\\"\\"
+  """A list of \`Protected\` objects."""
   nodes: [Protected]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`Protected\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`Protected\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`Protected\` edge in the connection.\\"\\"\\"
+"""A \`Protected\` edge in the connection."""
 type ProtectedsEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`Protected\` at the end of the edge.\\"\\"\\"
+  """The \`Protected\` at the end of the edge."""
   node: Protected
 }
 
-\\"\\"\\"The root query type which gives access points into the data universe.\\"\\"\\"
+"""The root query type which gives access points into the data universe."""
 type Query implements Node {
-  \\"\\"\\"Reads and enables pagination through a set of \`ArrayType\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`ArrayType\`."""
   allArrayTypes(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: ArrayTypeFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`ArrayType\`.\\"\\"\\"
+    """The method to use when ordering \`ArrayType\`."""
     orderBy: [ArrayTypesOrderBy!] = [PRIMARY_KEY_ASC]
   ): ArrayTypesConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`BackwardCompound\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`BackwardCompound\`."""
   allBackwardCompounds(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: BackwardCompoundFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`BackwardCompound\`.\\"\\"\\"
+    """The method to use when ordering \`BackwardCompound\`."""
     orderBy: [BackwardCompoundsOrderBy!] = [PRIMARY_KEY_ASC]
   ): BackwardCompoundsConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Backward\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Backward\`."""
   allBackwards(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: BackwardFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`Backward\`.\\"\\"\\"
+    """The method to use when ordering \`Backward\`."""
     orderBy: [BackwardsOrderBy!] = [PRIMARY_KEY_ASC]
   ): BackwardsConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`ChildNoRelatedFilter\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`ChildNoRelatedFilter\`."""
   allChildNoRelatedFilters(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: ChildNoRelatedFilterFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`ChildNoRelatedFilter\`.\\"\\"\\"
+    """The method to use when ordering \`ChildNoRelatedFilter\`."""
     orderBy: [ChildNoRelatedFiltersOrderBy!] = [PRIMARY_KEY_ASC]
   ): ChildNoRelatedFiltersConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Child\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Child\`."""
   allChildren(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: ChildFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`Child\`.\\"\\"\\"
+    """The method to use when ordering \`Child\`."""
     orderBy: [ChildrenOrderBy!] = [PRIMARY_KEY_ASC]
   ): ChildrenConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`DomainType\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`DomainType\`."""
   allDomainTypes(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: DomainTypeFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`DomainType\`.\\"\\"\\"
+    """The method to use when ordering \`DomainType\`."""
     orderBy: [DomainTypesOrderBy!] = [PRIMARY_KEY_ASC]
   ): DomainTypesConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`EnumArrayType\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`EnumArrayType\`."""
   allEnumArrayTypes(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: EnumArrayTypeFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`EnumArrayType\`.\\"\\"\\"
+    """The method to use when ordering \`EnumArrayType\`."""
     orderBy: [EnumArrayTypesOrderBy!] = [PRIMARY_KEY_ASC]
   ): EnumArrayTypesConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`EnumType\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`EnumType\`."""
   allEnumTypes(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: EnumTypeFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`EnumType\`.\\"\\"\\"
+    """The method to use when ordering \`EnumType\`."""
     orderBy: [EnumTypesOrderBy!] = [PRIMARY_KEY_ASC]
   ): EnumTypesConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Filterable\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Filterable\`."""
   allFilterables(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: FilterableFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`Filterable\`.\\"\\"\\"
+    """The method to use when ordering \`Filterable\`."""
     orderBy: [FilterablesOrderBy!] = [PRIMARY_KEY_ASC]
   ): FilterablesConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`ForwardCompound\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`ForwardCompound\`."""
   allForwardCompounds(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: ForwardCompoundFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`ForwardCompound\`.\\"\\"\\"
+    """The method to use when ordering \`ForwardCompound\`."""
     orderBy: [ForwardCompoundsOrderBy!] = [PRIMARY_KEY_ASC]
   ): ForwardCompoundsConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Forward\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Forward\`."""
   allForwards(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: ForwardFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`Forward\`.\\"\\"\\"
+    """The method to use when ordering \`Forward\`."""
     orderBy: [ForwardsOrderBy!] = [PRIMARY_KEY_ASC]
   ): ForwardsConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`FullyOmitted\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`FullyOmitted\`."""
   allFullyOmitteds(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`FullyOmitted\`.\\"\\"\\"
+    """The method to use when ordering \`FullyOmitted\`."""
     orderBy: [FullyOmittedsOrderBy!] = [PRIMARY_KEY_ASC]
   ): FullyOmittedsConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`JsonbTest\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`JsonbTest\`."""
   allJsonbTests(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: JsonbTestFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`JsonbTest\`.\\"\\"\\"
+    """The method to use when ordering \`JsonbTest\`."""
     orderBy: [JsonbTestsOrderBy!] = [PRIMARY_KEY_ASC]
   ): JsonbTestsConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Junction\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Junction\`."""
   allJunctions(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: JunctionFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`Junction\`.\\"\\"\\"
+    """The method to use when ordering \`Junction\`."""
     orderBy: [JunctionsOrderBy!] = [PRIMARY_KEY_ASC]
   ): JunctionsConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Parent\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Parent\`."""
   allParents(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: ParentFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`Parent\`.\\"\\"\\"
+    """The method to use when ordering \`Parent\`."""
     orderBy: [ParentsOrderBy!] = [PRIMARY_KEY_ASC]
   ): ParentsConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`RangeArrayType\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`RangeArrayType\`."""
   allRangeArrayTypes(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: RangeArrayTypeFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`RangeArrayType\`.\\"\\"\\"
+    """The method to use when ordering \`RangeArrayType\`."""
     orderBy: [RangeArrayTypesOrderBy!] = [PRIMARY_KEY_ASC]
   ): RangeArrayTypesConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`RangeType\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`RangeType\`."""
   allRangeTypes(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: RangeTypeFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`RangeType\`.\\"\\"\\"
+    """The method to use when ordering \`RangeType\`."""
     orderBy: [RangeTypesOrderBy!] = [PRIMARY_KEY_ASC]
   ): RangeTypesConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`SideA\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`SideA\`."""
   allSideAs(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: SideAFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`SideA\`.\\"\\"\\"
+    """The method to use when ordering \`SideA\`."""
     orderBy: [SideAsOrderBy!] = [PRIMARY_KEY_ASC]
   ): SideAsConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`SideB\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`SideB\`."""
   allSideBs(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: SideBFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`SideB\`.\\"\\"\\"
+    """The method to use when ordering \`SideB\`."""
     orderBy: [SideBsOrderBy!] = [PRIMARY_KEY_ASC]
   ): SideBsConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Unfilterable\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Unfilterable\`."""
   allUnfilterables(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`Unfilterable\`.\\"\\"\\"
+    """The method to use when ordering \`Unfilterable\`."""
     orderBy: [UnfilterablesOrderBy!] = [PRIMARY_KEY_ASC]
   ): UnfilterablesConnection
 
-  \\"\\"\\"Reads a single \`ArrayType\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`ArrayType\` using its globally unique \`ID\`."""
   arrayType(
-    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`ArrayType\`.\\"\\"\\"
+    """The globally unique \`ID\` to be used in selecting a single \`ArrayType\`."""
     nodeId: ID!
   ): ArrayType
   arrayTypeById(id: Int!): ArrayType
 
-  \\"\\"\\"Reads a single \`Backward\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`Backward\` using its globally unique \`ID\`."""
   backward(
-    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`Backward\`.\\"\\"\\"
+    """The globally unique \`ID\` to be used in selecting a single \`Backward\`."""
     nodeId: ID!
   ): Backward
   backwardByFilterableId(filterableId: Int!): Backward
   backwardById(id: Int!): Backward
 
-  \\"\\"\\"Reads a single \`BackwardCompound\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`BackwardCompound\` using its globally unique \`ID\`."""
   backwardCompound(
-    \\"\\"\\"
+    """
     The globally unique \`ID\` to be used in selecting a single \`BackwardCompound\`.
-    \\"\\"\\"
+    """
     nodeId: ID!
   ): BackwardCompound
   backwardCompoundByBackwardCompound1AndBackwardCompound2(backwardCompound1: Int!, backwardCompound2: Int!): BackwardCompound
 
-  \\"\\"\\"Reads a single \`Child\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`Child\` using its globally unique \`ID\`."""
   child(
-    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`Child\`.\\"\\"\\"
+    """The globally unique \`ID\` to be used in selecting a single \`Child\`."""
     nodeId: ID!
   ): Child
   childById(id: Int!): Child
 
-  \\"\\"\\"Reads a single \`ChildNoRelatedFilter\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`ChildNoRelatedFilter\` using its globally unique \`ID\`."""
   childNoRelatedFilter(
-    \\"\\"\\"
+    """
     The globally unique \`ID\` to be used in selecting a single \`ChildNoRelatedFilter\`.
-    \\"\\"\\"
+    """
     nodeId: ID!
   ): ChildNoRelatedFilter
   childNoRelatedFilterById(id: Int!): ChildNoRelatedFilter
 
-  \\"\\"\\"Reads a single \`DomainType\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`DomainType\` using its globally unique \`ID\`."""
   domainType(
-    \\"\\"\\"
+    """
     The globally unique \`ID\` to be used in selecting a single \`DomainType\`.
-    \\"\\"\\"
+    """
     nodeId: ID!
   ): DomainType
   domainTypeById(id: Int!): DomainType
 
-  \\"\\"\\"Reads a single \`EnumArrayType\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`EnumArrayType\` using its globally unique \`ID\`."""
   enumArrayType(
-    \\"\\"\\"
+    """
     The globally unique \`ID\` to be used in selecting a single \`EnumArrayType\`.
-    \\"\\"\\"
+    """
     nodeId: ID!
   ): EnumArrayType
   enumArrayTypeById(id: Int!): EnumArrayType
 
-  \\"\\"\\"Reads a single \`EnumType\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`EnumType\` using its globally unique \`ID\`."""
   enumType(
-    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`EnumType\`.\\"\\"\\"
+    """The globally unique \`ID\` to be used in selecting a single \`EnumType\`."""
     nodeId: ID!
   ): EnumType
   enumTypeById(id: Int!): EnumType
 
-  \\"\\"\\"Reads a single \`Filterable\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`Filterable\` using its globally unique \`ID\`."""
   filterable(
-    \\"\\"\\"
+    """
     The globally unique \`ID\` to be used in selecting a single \`Filterable\`.
-    \\"\\"\\"
+    """
     nodeId: ID!
   ): Filterable
   filterableByBackwardCompound1AndBackwardCompound2(backwardCompound1: Int!, backwardCompound2: Int!): Filterable
@@ -3416,247 +3416,247 @@ type Query implements Node {
   filterableByForwardId(forwardId: Int!): Filterable
   filterableById(id: Int!): Filterable
 
-  \\"\\"\\"Reads a single \`FilterableClosure\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`FilterableClosure\` using its globally unique \`ID\`."""
   filterableClosure(
-    \\"\\"\\"
+    """
     The globally unique \`ID\` to be used in selecting a single \`FilterableClosure\`.
-    \\"\\"\\"
+    """
     nodeId: ID!
   ): FilterableClosure
   filterableClosureById(id: Int!): FilterableClosure
 
-  \\"\\"\\"Reads a single \`Forward\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`Forward\` using its globally unique \`ID\`."""
   forward(
-    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`Forward\`.\\"\\"\\"
+    """The globally unique \`ID\` to be used in selecting a single \`Forward\`."""
     nodeId: ID!
   ): Forward
   forwardById(id: Int!): Forward
 
-  \\"\\"\\"Reads a single \`ForwardCompound\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`ForwardCompound\` using its globally unique \`ID\`."""
   forwardCompound(
-    \\"\\"\\"
+    """
     The globally unique \`ID\` to be used in selecting a single \`ForwardCompound\`.
-    \\"\\"\\"
+    """
     nodeId: ID!
   ): ForwardCompound
   forwardCompoundByForwardCompound1AndForwardCompound2(forwardCompound1: Int!, forwardCompound2: Int!): ForwardCompound
 
-  \\"\\"\\"Reads a single \`FullyOmitted\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`FullyOmitted\` using its globally unique \`ID\`."""
   fullyOmitted(
-    \\"\\"\\"
+    """
     The globally unique \`ID\` to be used in selecting a single \`FullyOmitted\`.
-    \\"\\"\\"
+    """
     nodeId: ID!
   ): FullyOmitted
   fullyOmittedById(id: Int!): FullyOmitted
   funcReturnsTableMultiCol(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: FuncReturnsTableMultiColRecordFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
     i: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
   ): FuncReturnsTableMultiColConnection!
   funcReturnsTableOneCol(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: IntFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
     i: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
   ): FuncReturnsTableOneColConnection!
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Filterable\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Filterable\`."""
   funcTaggedFilterableReturnsSetofFilterable(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: FilterableFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
   ): FilterablesConnection!
   funcTaggedFilterableReturnsTableMultiCol(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: FuncTaggedFilterableReturnsTableMultiColRecordFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
   ): FuncTaggedFilterableReturnsTableMultiColConnection!
 
-  \\"\\"\\"Reads a single \`JsonbTest\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`JsonbTest\` using its globally unique \`ID\`."""
   jsonbTest(
-    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`JsonbTest\`.\\"\\"\\"
+    """The globally unique \`ID\` to be used in selecting a single \`JsonbTest\`."""
     nodeId: ID!
   ): JsonbTest
   jsonbTestById(id: Int!): JsonbTest
 
-  \\"\\"\\"Reads a single \`Junction\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`Junction\` using its globally unique \`ID\`."""
   junction(
-    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`Junction\`.\\"\\"\\"
+    """The globally unique \`ID\` to be used in selecting a single \`Junction\`."""
     nodeId: ID!
   ): Junction
   junctionBySideAIdAndSideBId(sideAId: Int!, sideBId: Int!): Junction
 
-  \\"\\"\\"Fetches an object given its globally unique \`ID\`.\\"\\"\\"
+  """Fetches an object given its globally unique \`ID\`."""
   node(
-    \\"\\"\\"The globally unique \`ID\`.\\"\\"\\"
+    """The globally unique \`ID\`."""
     nodeId: ID!
   ): Node
 
-  \\"\\"\\"
+  """
   The root query type must be a \`Node\` to work well with Relay 1 mutations. This just resolves to \`query\`.
-  \\"\\"\\"
+  """
   nodeId: ID!
 
-  \\"\\"\\"Reads a single \`Parent\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`Parent\` using its globally unique \`ID\`."""
   parent(
-    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`Parent\`.\\"\\"\\"
+    """The globally unique \`ID\` to be used in selecting a single \`Parent\`."""
     nodeId: ID!
   ): Parent
   parentById(id: Int!): Parent
 
-  \\"\\"\\"Reads a single \`Protected\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`Protected\` using its globally unique \`ID\`."""
   protected(
-    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`Protected\`.\\"\\"\\"
+    """The globally unique \`ID\` to be used in selecting a single \`Protected\`."""
     nodeId: ID!
   ): Protected
   protectedById(id: Int!): Protected
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Protected\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Protected\`."""
   protectedsByOtherId(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: ProtectedFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
     otherId: Int
   ): ProtectedsConnection!
 
-  \\"\\"\\"
+  """
   Exposes the root query type nested one level down. This is helpful for Relay 1
   which can only query top level fields if they are in a particular form.
-  \\"\\"\\"
+  """
   query: Query!
 
-  \\"\\"\\"Reads a single \`RangeArrayType\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`RangeArrayType\` using its globally unique \`ID\`."""
   rangeArrayType(
-    \\"\\"\\"
+    """
     The globally unique \`ID\` to be used in selecting a single \`RangeArrayType\`.
-    \\"\\"\\"
+    """
     nodeId: ID!
   ): RangeArrayType
   rangeArrayTypeById(id: Int!): RangeArrayType
 
-  \\"\\"\\"Reads a single \`RangeType\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`RangeType\` using its globally unique \`ID\`."""
   rangeType(
-    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`RangeType\`.\\"\\"\\"
+    """The globally unique \`ID\` to be used in selecting a single \`RangeType\`."""
     nodeId: ID!
   ): RangeType
   rangeTypeById(id: Int!): RangeType
 
-  \\"\\"\\"Reads a single \`SideA\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`SideA\` using its globally unique \`ID\`."""
   sideA(
-    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`SideA\`.\\"\\"\\"
+    """The globally unique \`ID\` to be used in selecting a single \`SideA\`."""
     nodeId: ID!
   ): SideA
   sideAByAId(aId: Int!): SideA
 
-  \\"\\"\\"Reads a single \`SideB\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`SideB\` using its globally unique \`ID\`."""
   sideB(
-    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`SideB\`.\\"\\"\\"
+    """The globally unique \`ID\` to be used in selecting a single \`SideB\`."""
     nodeId: ID!
   ): SideB
   sideBByBId(bId: Int!): SideB
 
-  \\"\\"\\"Reads a single \`Unfilterable\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`Unfilterable\` using its globally unique \`ID\`."""
   unfilterable(
-    \\"\\"\\"
+    """
     The globally unique \`ID\` to be used in selecting a single \`Unfilterable\`.
-    \\"\\"\\"
+    """
     nodeId: ID!
   ): Unfilterable
   unfilterableById(id: Int!): Unfilterable
@@ -3668,77 +3668,77 @@ type RangeArrayType implements Node {
   int4RangeArray: [IntRange]
   int8RangeArray: [BigIntRange]
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
   numericRangeArray: [BigFloatRange]
   timestampRangeArray: [DatetimeRange]
   timestamptzRangeArray: [DatetimeRange]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`RangeArrayType\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input RangeArrayTypeFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [RangeArrayTypeFilter!]
 
-  \\"\\"\\"Filter by the object’s \`dateRangeArray\` field.\\"\\"\\"
+  """Filter by the object’s \`dateRangeArray\` field."""
   dateRangeArray: DateRangeListFilter
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`int4RangeArray\` field.\\"\\"\\"
+  """Filter by the object’s \`int4RangeArray\` field."""
   int4RangeArray: IntRangeListFilter
 
-  \\"\\"\\"Filter by the object’s \`int8RangeArray\` field.\\"\\"\\"
+  """Filter by the object’s \`int8RangeArray\` field."""
   int8RangeArray: BigIntRangeListFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: RangeArrayTypeFilter
 
-  \\"\\"\\"Filter by the object’s \`numericRangeArray\` field.\\"\\"\\"
+  """Filter by the object’s \`numericRangeArray\` field."""
   numericRangeArray: BigFloatRangeListFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [RangeArrayTypeFilter!]
 
-  \\"\\"\\"Filter by the object’s \`timestampRangeArray\` field.\\"\\"\\"
+  """Filter by the object’s \`timestampRangeArray\` field."""
   timestampRangeArray: DatetimeRangeListFilter
 
-  \\"\\"\\"Filter by the object’s \`timestamptzRangeArray\` field.\\"\\"\\"
+  """Filter by the object’s \`timestamptzRangeArray\` field."""
   timestamptzRangeArray: DatetimeRangeListFilter
 }
 
-\\"\\"\\"A connection to a list of \`RangeArrayType\` values.\\"\\"\\"
+"""A connection to a list of \`RangeArrayType\` values."""
 type RangeArrayTypesConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`RangeArrayType\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [RangeArrayTypesEdge!]!
 
-  \\"\\"\\"A list of \`RangeArrayType\` objects.\\"\\"\\"
+  """A list of \`RangeArrayType\` objects."""
   nodes: [RangeArrayType]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`RangeArrayType\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`RangeArrayType\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`RangeArrayType\` edge in the connection.\\"\\"\\"
+"""A \`RangeArrayType\` edge in the connection."""
 type RangeArrayTypesEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`RangeArrayType\` at the end of the edge.\\"\\"\\"
+  """The \`RangeArrayType\` at the end of the edge."""
   node: RangeArrayType
 }
 
-\\"\\"\\"Methods to use when ordering \`RangeArrayType\`.\\"\\"\\"
+"""Methods to use when ordering \`RangeArrayType\`."""
 enum RangeArrayTypesOrderBy {
   DATE_RANGE_ARRAY_ASC
   DATE_RANGE_ARRAY_DESC
@@ -3765,77 +3765,77 @@ type RangeType implements Node {
   int4Range: IntRange
   int8Range: BigIntRange
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
   numericRange: BigFloatRange
   timestampRange: DatetimeRange
   timestamptzRange: DatetimeRange
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`RangeType\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input RangeTypeFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [RangeTypeFilter!]
 
-  \\"\\"\\"Filter by the object’s \`dateRange\` field.\\"\\"\\"
+  """Filter by the object’s \`dateRange\` field."""
   dateRange: DateRangeFilter
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`int4Range\` field.\\"\\"\\"
+  """Filter by the object’s \`int4Range\` field."""
   int4Range: IntRangeFilter
 
-  \\"\\"\\"Filter by the object’s \`int8Range\` field.\\"\\"\\"
+  """Filter by the object’s \`int8Range\` field."""
   int8Range: BigIntRangeFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: RangeTypeFilter
 
-  \\"\\"\\"Filter by the object’s \`numericRange\` field.\\"\\"\\"
+  """Filter by the object’s \`numericRange\` field."""
   numericRange: BigFloatRangeFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [RangeTypeFilter!]
 
-  \\"\\"\\"Filter by the object’s \`timestampRange\` field.\\"\\"\\"
+  """Filter by the object’s \`timestampRange\` field."""
   timestampRange: DatetimeRangeFilter
 
-  \\"\\"\\"Filter by the object’s \`timestamptzRange\` field.\\"\\"\\"
+  """Filter by the object’s \`timestamptzRange\` field."""
   timestamptzRange: DatetimeRangeFilter
 }
 
-\\"\\"\\"A connection to a list of \`RangeType\` values.\\"\\"\\"
+"""A connection to a list of \`RangeType\` values."""
 type RangeTypesConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`RangeType\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [RangeTypesEdge!]!
 
-  \\"\\"\\"A list of \`RangeType\` objects.\\"\\"\\"
+  """A list of \`RangeType\` objects."""
   nodes: [RangeType]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`RangeType\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`RangeType\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`RangeType\` edge in the connection.\\"\\"\\"
+"""A \`RangeType\` edge in the connection."""
 type RangeTypesEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`RangeType\` at the end of the edge.\\"\\"\\"
+  """The \`RangeType\` at the end of the edge."""
   node: RangeType
 }
 
-\\"\\"\\"Methods to use when ordering \`RangeType\`.\\"\\"\\"
+"""Methods to use when ordering \`RangeType\`."""
 enum RangeTypesOrderBy {
   DATE_RANGE_ASC
   DATE_RANGE_DESC
@@ -3859,89 +3859,89 @@ enum RangeTypesOrderBy {
 type SideA implements Node {
   aId: Int!
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Junction\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Junction\`."""
   junctionsBySideAId(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: JunctionFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`Junction\`.\\"\\"\\"
+    """The method to use when ordering \`Junction\`."""
     orderBy: [JunctionsOrderBy!] = [PRIMARY_KEY_ASC]
   ): JunctionsConnection!
   name: String!
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`SideA\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input SideAFilter {
-  \\"\\"\\"Filter by the object’s \`aId\` field.\\"\\"\\"
+  """Filter by the object’s \`aId\` field."""
   aId: IntFilter
 
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [SideAFilter!]
 
-  \\"\\"\\"Filter by the object’s \`name\` field.\\"\\"\\"
+  """Filter by the object’s \`name\` field."""
   name: StringFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: SideAFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [SideAFilter!]
 }
 
-\\"\\"\\"A connection to a list of \`SideA\` values.\\"\\"\\"
+"""A connection to a list of \`SideA\` values."""
 type SideAsConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`SideA\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [SideAsEdge!]!
 
-  \\"\\"\\"A list of \`SideA\` objects.\\"\\"\\"
+  """A list of \`SideA\` objects."""
   nodes: [SideA]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`SideA\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`SideA\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`SideA\` edge in the connection.\\"\\"\\"
+"""A \`SideA\` edge in the connection."""
 type SideAsEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`SideA\` at the end of the edge.\\"\\"\\"
+  """The \`SideA\` at the end of the edge."""
   node: SideA
 }
 
-\\"\\"\\"Methods to use when ordering \`SideA\`.\\"\\"\\"
+"""Methods to use when ordering \`SideA\`."""
 enum SideAsOrderBy {
   A_ID_ASC
   A_ID_DESC
@@ -3955,89 +3955,89 @@ enum SideAsOrderBy {
 type SideB implements Node {
   bId: Int!
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Junction\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Junction\`."""
   junctionsBySideBId(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: JunctionFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`Junction\`.\\"\\"\\"
+    """The method to use when ordering \`Junction\`."""
     orderBy: [JunctionsOrderBy!] = [PRIMARY_KEY_ASC]
   ): JunctionsConnection!
   name: String!
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`SideB\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input SideBFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [SideBFilter!]
 
-  \\"\\"\\"Filter by the object’s \`bId\` field.\\"\\"\\"
+  """Filter by the object’s \`bId\` field."""
   bId: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`name\` field.\\"\\"\\"
+  """Filter by the object’s \`name\` field."""
   name: StringFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: SideBFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [SideBFilter!]
 }
 
-\\"\\"\\"A connection to a list of \`SideB\` values.\\"\\"\\"
+"""A connection to a list of \`SideB\` values."""
 type SideBsConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`SideB\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [SideBsEdge!]!
 
-  \\"\\"\\"A list of \`SideB\` objects.\\"\\"\\"
+  """A list of \`SideB\` objects."""
   nodes: [SideB]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`SideB\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`SideB\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`SideB\` edge in the connection.\\"\\"\\"
+"""A \`SideB\` edge in the connection."""
 type SideBsEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`SideB\` at the end of the edge.\\"\\"\\"
+  """The \`SideB\` at the end of the edge."""
   node: SideB
 }
 
-\\"\\"\\"Methods to use when ordering \`SideB\`.\\"\\"\\"
+"""Methods to use when ordering \`SideB\`."""
 enum SideBsOrderBy {
   B_ID_ASC
   B_ID_DESC
@@ -4048,120 +4048,120 @@ enum SideBsOrderBy {
   PRIMARY_KEY_DESC
 }
 
-\\"\\"\\"
+"""
 A filter to be used against String fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input StringFilter {
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: String
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: String
 }
 
-\\"\\"\\"
+"""
 A filter to be used against String List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input StringListFilter {
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [String]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [String]
 }
 
-\\"\\"\\"
+"""
 The exact time of day, does not include the date. May or may not have a timezone offset.
-\\"\\"\\"
+"""
 scalar Time
 
-\\"\\"\\"
+"""
 A filter to be used against Time fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input TimeFilter {
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: Time
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: Time
 }
 
-\\"\\"\\"
+"""
 A filter to be used against Time List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input TimeListFilter {
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [Time]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [Time]
 }
 
 type Unfilterable implements Node {
-  \\"\\"\\"Reads and enables pagination through a set of \`ChildNoRelatedFilter\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`ChildNoRelatedFilter\`."""
   childNoRelatedFiltersByUnfilterableId(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: ChildNoRelatedFilterFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`ChildNoRelatedFilter\`.\\"\\"\\"
+    """The method to use when ordering \`ChildNoRelatedFilter\`."""
     orderBy: [ChildNoRelatedFiltersOrderBy!] = [PRIMARY_KEY_ASC]
   ): ChildNoRelatedFiltersConnection!
   id: Int!
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
   text: String
 }
 
-\\"\\"\\"A connection to a list of \`Unfilterable\` values.\\"\\"\\"
+"""A connection to a list of \`Unfilterable\` values."""
 type UnfilterablesConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`Unfilterable\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [UnfilterablesEdge!]!
 
-  \\"\\"\\"A list of \`Unfilterable\` objects.\\"\\"\\"
+  """A list of \`Unfilterable\` objects."""
   nodes: [Unfilterable]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`Unfilterable\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`Unfilterable\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`Unfilterable\` edge in the connection.\\"\\"\\"
+"""A \`Unfilterable\` edge in the connection."""
 type UnfilterablesEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`Unfilterable\` at the end of the edge.\\"\\"\\"
+  """The \`Unfilterable\` at the end of the edge."""
   node: Unfilterable
 }
 
-\\"\\"\\"Methods to use when ordering \`Unfilterable\`.\\"\\"\\"
+"""Methods to use when ordering \`Unfilterable\`."""
 enum UnfilterablesOrderBy {
   ID_ASC
   ID_DESC
@@ -4172,31 +4172,31 @@ enum UnfilterablesOrderBy {
   TEXT_DESC
 }
 
-\\"\\"\\"
+"""
 A universally unique identifier as defined by [RFC 4122](https://tools.ietf.org/html/rfc4122).
-\\"\\"\\"
+"""
 scalar UUID
 
-\\"\\"\\"
+"""
 A filter to be used against UUID fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input UUIDFilter {
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: UUID
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: UUID
 }
 
-\\"\\"\\"
+"""
 A filter to be used against UUID List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input UUIDListFilter {
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [UUID]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [UUID]
 }
-"
+
 `;

--- a/__tests__/integration/schema/__snapshots__/arraysFalse.test.ts.snap
+++ b/__tests__/integration/schema/__snapshots__/arraysFalse.test.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`prints a schema with the filter plugin and the \`connectionFilterArrays: false\` option 1`] = `
-"type ArrayType implements Node {
+type ArrayType implements Node {
   bit4Array: [BitString]
   boolArray: [Boolean]
   bpchar4Array: [String]
@@ -25,9 +25,9 @@ exports[`prints a schema with the filter plugin and the \`connectionFilterArrays
   moneyArray: [Float]
   nameArray: [String]
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
   numericArray: [BigFloat]
   textArray: [String]
@@ -41,50 +41,50 @@ exports[`prints a schema with the filter plugin and the \`connectionFilterArrays
   xmlArray: [String]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`ArrayType\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input ArrayTypeFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [ArrayTypeFilter!]
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: ArrayTypeFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [ArrayTypeFilter!]
 }
 
-\\"\\"\\"A connection to a list of \`ArrayType\` values.\\"\\"\\"
+"""A connection to a list of \`ArrayType\` values."""
 type ArrayTypesConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`ArrayType\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [ArrayTypesEdge!]!
 
-  \\"\\"\\"A list of \`ArrayType\` objects.\\"\\"\\"
+  """A list of \`ArrayType\` objects."""
   nodes: [ArrayType]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`ArrayType\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`ArrayType\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`ArrayType\` edge in the connection.\\"\\"\\"
+"""A \`ArrayType\` edge in the connection."""
 type ArrayTypesEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`ArrayType\` at the end of the edge.\\"\\"\\"
+  """The \`ArrayType\` at the end of the edge."""
   node: ArrayType
 }
 
-\\"\\"\\"Methods to use when ordering \`ArrayType\`.\\"\\"\\"
+"""Methods to use when ordering \`ArrayType\`."""
 enum ArrayTypesOrderBy {
   BIT4_ARRAY_ASC
   BIT4_ARRAY_DESC
@@ -156,15 +156,15 @@ enum ArrayTypesOrderBy {
 }
 
 type Backward implements Node {
-  \\"\\"\\"Reads a single \`Filterable\` that is related to this \`Backward\`.\\"\\"\\"
+  """Reads a single \`Filterable\` that is related to this \`Backward\`."""
   filterableByFilterableId: Filterable
   filterableId: Int
   id: Int!
   name: String!
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
@@ -172,70 +172,70 @@ type BackwardCompound implements Node {
   backwardCompound1: Int!
   backwardCompound2: Int!
 
-  \\"\\"\\"
+  """
   Reads a single \`Filterable\` that is related to this \`BackwardCompound\`.
-  \\"\\"\\"
+  """
   filterableByBackwardCompound1AndBackwardCompound2: Filterable
   name: String
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`BackwardCompound\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input BackwardCompoundFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [BackwardCompoundFilter!]
 
-  \\"\\"\\"Filter by the object’s \`backwardCompound1\` field.\\"\\"\\"
+  """Filter by the object’s \`backwardCompound1\` field."""
   backwardCompound1: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`backwardCompound2\` field.\\"\\"\\"
+  """Filter by the object’s \`backwardCompound2\` field."""
   backwardCompound2: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`name\` field.\\"\\"\\"
+  """Filter by the object’s \`name\` field."""
   name: StringFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: BackwardCompoundFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [BackwardCompoundFilter!]
 }
 
-\\"\\"\\"A connection to a list of \`BackwardCompound\` values.\\"\\"\\"
+"""A connection to a list of \`BackwardCompound\` values."""
 type BackwardCompoundsConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`BackwardCompound\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [BackwardCompoundsEdge!]!
 
-  \\"\\"\\"A list of \`BackwardCompound\` objects.\\"\\"\\"
+  """A list of \`BackwardCompound\` objects."""
   nodes: [BackwardCompound]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"
+  """
   The count of *all* \`BackwardCompound\` you could get from the connection.
-  \\"\\"\\"
+  """
   totalCount: Int!
 }
 
-\\"\\"\\"A \`BackwardCompound\` edge in the connection.\\"\\"\\"
+"""A \`BackwardCompound\` edge in the connection."""
 type BackwardCompoundsEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`BackwardCompound\` at the end of the edge.\\"\\"\\"
+  """The \`BackwardCompound\` at the end of the edge."""
   node: BackwardCompound
 }
 
-\\"\\"\\"Methods to use when ordering \`BackwardCompound\`.\\"\\"\\"
+"""Methods to use when ordering \`BackwardCompound\`."""
 enum BackwardCompoundsOrderBy {
   BACKWARD_COMPOUND_1_ASC
   BACKWARD_COMPOUND_1_DESC
@@ -248,56 +248,56 @@ enum BackwardCompoundsOrderBy {
   PRIMARY_KEY_DESC
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`Backward\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input BackwardFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [BackwardFilter!]
 
-  \\"\\"\\"Filter by the object’s \`filterableId\` field.\\"\\"\\"
+  """Filter by the object’s \`filterableId\` field."""
   filterableId: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`name\` field.\\"\\"\\"
+  """Filter by the object’s \`name\` field."""
   name: StringFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: BackwardFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [BackwardFilter!]
 }
 
-\\"\\"\\"A connection to a list of \`Backward\` values.\\"\\"\\"
+"""A connection to a list of \`Backward\` values."""
 type BackwardsConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`Backward\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [BackwardsEdge!]!
 
-  \\"\\"\\"A list of \`Backward\` objects.\\"\\"\\"
+  """A list of \`Backward\` objects."""
   nodes: [Backward]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`Backward\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`Backward\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`Backward\` edge in the connection.\\"\\"\\"
+"""A \`Backward\` edge in the connection."""
 type BackwardsEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`Backward\` at the end of the edge.\\"\\"\\"
+  """The \`Backward\` at the end of the edge."""
   node: Backward
 }
 
-\\"\\"\\"Methods to use when ordering \`Backward\`.\\"\\"\\"
+"""Methods to use when ordering \`Backward\`."""
 enum BackwardsOrderBy {
   FILTERABLE_ID_ASC
   FILTERABLE_ID_DESC
@@ -310,659 +310,659 @@ enum BackwardsOrderBy {
   PRIMARY_KEY_DESC
 }
 
-\\"\\"\\"
+"""
 A floating point number that requires more precision than IEEE 754 binary 64
-\\"\\"\\"
+"""
 scalar BigFloat
 
-\\"\\"\\"
+"""
 A filter to be used against BigFloat fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input BigFloatFilter {
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: BigFloat
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: BigFloat
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: BigFloat
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: BigFloat
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [BigFloat!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: BigFloat
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: BigFloat
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: BigFloat
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: BigFloat
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [BigFloat!]
 }
 
-\\"\\"\\"A range of \`BigFloat\`.\\"\\"\\"
+"""A range of \`BigFloat\`."""
 type BigFloatRange {
-  \\"\\"\\"The ending bound of our range.\\"\\"\\"
+  """The ending bound of our range."""
   end: BigFloatRangeBound
 
-  \\"\\"\\"The starting bound of our range.\\"\\"\\"
+  """The starting bound of our range."""
   start: BigFloatRangeBound
 }
 
-\\"\\"\\"
+"""
 The value at one end of a range. A range can either include this value, or not.
-\\"\\"\\"
+"""
 type BigFloatRangeBound {
-  \\"\\"\\"Whether or not the value of this bound is included in the range.\\"\\"\\"
+  """Whether or not the value of this bound is included in the range."""
   inclusive: Boolean!
 
-  \\"\\"\\"The value at one end of our range.\\"\\"\\"
+  """The value at one end of our range."""
   value: BigFloat!
 }
 
-\\"\\"\\"
+"""
 The value at one end of a range. A range can either include this value, or not.
-\\"\\"\\"
+"""
 input BigFloatRangeBoundInput {
-  \\"\\"\\"Whether or not the value of this bound is included in the range.\\"\\"\\"
+  """Whether or not the value of this bound is included in the range."""
   inclusive: Boolean!
 
-  \\"\\"\\"The value at one end of our range.\\"\\"\\"
+  """The value at one end of our range."""
   value: BigFloat!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against BigFloatRange fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input BigFloatRangeFilter {
-  \\"\\"\\"Adjacent to the specified range.\\"\\"\\"
+  """Adjacent to the specified range."""
   adjacentTo: BigFloatRangeInput
 
-  \\"\\"\\"Contained by the specified range.\\"\\"\\"
+  """Contained by the specified range."""
   containedBy: BigFloatRangeInput
 
-  \\"\\"\\"Contains the specified range.\\"\\"\\"
+  """Contains the specified range."""
   contains: BigFloatRangeInput
 
-  \\"\\"\\"Contains the specified value.\\"\\"\\"
+  """Contains the specified value."""
   containsElement: BigFloat
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: BigFloatRangeInput
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: BigFloatRangeInput
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: BigFloatRangeInput
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: BigFloatRangeInput
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [BigFloatRangeInput!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: BigFloatRangeInput
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: BigFloatRangeInput
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: BigFloatRangeInput
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: BigFloatRangeInput
 
-  \\"\\"\\"Does not extend left of the specified range.\\"\\"\\"
+  """Does not extend left of the specified range."""
   notExtendsLeftOf: BigFloatRangeInput
 
-  \\"\\"\\"Does not extend right of the specified range.\\"\\"\\"
+  """Does not extend right of the specified range."""
   notExtendsRightOf: BigFloatRangeInput
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [BigFloatRangeInput!]
 
-  \\"\\"\\"Overlaps the specified range.\\"\\"\\"
+  """Overlaps the specified range."""
   overlaps: BigFloatRangeInput
 
-  \\"\\"\\"Strictly left of the specified range.\\"\\"\\"
+  """Strictly left of the specified range."""
   strictlyLeftOf: BigFloatRangeInput
 
-  \\"\\"\\"Strictly right of the specified range.\\"\\"\\"
+  """Strictly right of the specified range."""
   strictlyRightOf: BigFloatRangeInput
 }
 
-\\"\\"\\"A range of \`BigFloat\`.\\"\\"\\"
+"""A range of \`BigFloat\`."""
 input BigFloatRangeInput {
-  \\"\\"\\"The ending bound of our range.\\"\\"\\"
+  """The ending bound of our range."""
   end: BigFloatRangeBoundInput
 
-  \\"\\"\\"The starting bound of our range.\\"\\"\\"
+  """The starting bound of our range."""
   start: BigFloatRangeBoundInput
 }
 
-\\"\\"\\"
+"""
 A signed eight-byte integer. The upper big integer values are greater than the
 max value for a JavaScript number. Therefore all big integers will be output as
 strings and not numbers.
-\\"\\"\\"
+"""
 scalar BigInt
 
-\\"\\"\\"
+"""
 A filter to be used against BigInt fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input BigIntFilter {
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: BigInt
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: BigInt
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: BigInt
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: BigInt
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [BigInt!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: BigInt
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: BigInt
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: BigInt
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: BigInt
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [BigInt!]
 }
 
-\\"\\"\\"A range of \`BigInt\`.\\"\\"\\"
+"""A range of \`BigInt\`."""
 type BigIntRange {
-  \\"\\"\\"The ending bound of our range.\\"\\"\\"
+  """The ending bound of our range."""
   end: BigIntRangeBound
 
-  \\"\\"\\"The starting bound of our range.\\"\\"\\"
+  """The starting bound of our range."""
   start: BigIntRangeBound
 }
 
-\\"\\"\\"
+"""
 The value at one end of a range. A range can either include this value, or not.
-\\"\\"\\"
+"""
 type BigIntRangeBound {
-  \\"\\"\\"Whether or not the value of this bound is included in the range.\\"\\"\\"
+  """Whether or not the value of this bound is included in the range."""
   inclusive: Boolean!
 
-  \\"\\"\\"The value at one end of our range.\\"\\"\\"
+  """The value at one end of our range."""
   value: BigInt!
 }
 
-\\"\\"\\"
+"""
 The value at one end of a range. A range can either include this value, or not.
-\\"\\"\\"
+"""
 input BigIntRangeBoundInput {
-  \\"\\"\\"Whether or not the value of this bound is included in the range.\\"\\"\\"
+  """Whether or not the value of this bound is included in the range."""
   inclusive: Boolean!
 
-  \\"\\"\\"The value at one end of our range.\\"\\"\\"
+  """The value at one end of our range."""
   value: BigInt!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against BigIntRange fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input BigIntRangeFilter {
-  \\"\\"\\"Adjacent to the specified range.\\"\\"\\"
+  """Adjacent to the specified range."""
   adjacentTo: BigIntRangeInput
 
-  \\"\\"\\"Contained by the specified range.\\"\\"\\"
+  """Contained by the specified range."""
   containedBy: BigIntRangeInput
 
-  \\"\\"\\"Contains the specified range.\\"\\"\\"
+  """Contains the specified range."""
   contains: BigIntRangeInput
 
-  \\"\\"\\"Contains the specified value.\\"\\"\\"
+  """Contains the specified value."""
   containsElement: BigInt
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: BigIntRangeInput
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: BigIntRangeInput
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: BigIntRangeInput
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: BigIntRangeInput
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [BigIntRangeInput!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: BigIntRangeInput
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: BigIntRangeInput
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: BigIntRangeInput
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: BigIntRangeInput
 
-  \\"\\"\\"Does not extend left of the specified range.\\"\\"\\"
+  """Does not extend left of the specified range."""
   notExtendsLeftOf: BigIntRangeInput
 
-  \\"\\"\\"Does not extend right of the specified range.\\"\\"\\"
+  """Does not extend right of the specified range."""
   notExtendsRightOf: BigIntRangeInput
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [BigIntRangeInput!]
 
-  \\"\\"\\"Overlaps the specified range.\\"\\"\\"
+  """Overlaps the specified range."""
   overlaps: BigIntRangeInput
 
-  \\"\\"\\"Strictly left of the specified range.\\"\\"\\"
+  """Strictly left of the specified range."""
   strictlyLeftOf: BigIntRangeInput
 
-  \\"\\"\\"Strictly right of the specified range.\\"\\"\\"
+  """Strictly right of the specified range."""
   strictlyRightOf: BigIntRangeInput
 }
 
-\\"\\"\\"A range of \`BigInt\`.\\"\\"\\"
+"""A range of \`BigInt\`."""
 input BigIntRangeInput {
-  \\"\\"\\"The ending bound of our range.\\"\\"\\"
+  """The ending bound of our range."""
   end: BigIntRangeBoundInput
 
-  \\"\\"\\"The starting bound of our range.\\"\\"\\"
+  """The starting bound of our range."""
   start: BigIntRangeBoundInput
 }
 
-\\"\\"\\"A string representing a series of binary bits\\"\\"\\"
+"""A string representing a series of binary bits"""
 scalar BitString
 
-\\"\\"\\"
+"""
 A filter to be used against BitString fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input BitStringFilter {
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: BitString
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: BitString
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: BitString
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: BitString
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [BitString!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: BitString
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: BitString
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: BitString
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: BitString
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [BitString!]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against Boolean fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input BooleanFilter {
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: Boolean
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: Boolean
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: Boolean
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: Boolean
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [Boolean!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: Boolean
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: Boolean
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: Boolean
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: Boolean
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [Boolean!]
 }
 
 scalar Char4Domain
 
-\\"\\"\\"
+"""
 A filter to be used against Char4Domain fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input Char4DomainFilter {
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: Char4Domain
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value (case-insensitive).
-  \\"\\"\\"
+  """
   distinctFromInsensitive: Char4Domain
 
-  \\"\\"\\"Ends with the specified string (case-sensitive).\\"\\"\\"
+  """Ends with the specified string (case-sensitive)."""
   endsWith: Char4Domain
 
-  \\"\\"\\"Ends with the specified string (case-insensitive).\\"\\"\\"
+  """Ends with the specified string (case-insensitive)."""
   endsWithInsensitive: Char4Domain
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: Char4Domain
 
-  \\"\\"\\"Equal to the specified value (case-insensitive).\\"\\"\\"
+  """Equal to the specified value (case-insensitive)."""
   equalToInsensitive: Char4Domain
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: Char4Domain
 
-  \\"\\"\\"Greater than the specified value (case-insensitive).\\"\\"\\"
+  """Greater than the specified value (case-insensitive)."""
   greaterThanInsensitive: Char4Domain
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: Char4Domain
 
-  \\"\\"\\"Greater than or equal to the specified value (case-insensitive).\\"\\"\\"
+  """Greater than or equal to the specified value (case-insensitive)."""
   greaterThanOrEqualToInsensitive: Char4Domain
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [Char4Domain!]
 
-  \\"\\"\\"Included in the specified list (case-insensitive).\\"\\"\\"
-  inInsensitive: [Char4Domain!]
-
-  \\"\\"\\"Contains the specified string (case-sensitive).\\"\\"\\"
+  """Contains the specified string (case-sensitive)."""
   includes: Char4Domain
 
-  \\"\\"\\"Contains the specified string (case-insensitive).\\"\\"\\"
+  """Contains the specified string (case-insensitive)."""
   includesInsensitive: Char4Domain
 
-  \\"\\"\\"
+  """Included in the specified list (case-insensitive)."""
+  inInsensitive: [Char4Domain!]
+
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: Char4Domain
 
-  \\"\\"\\"Less than the specified value (case-insensitive).\\"\\"\\"
+  """Less than the specified value (case-insensitive)."""
   lessThanInsensitive: Char4Domain
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: Char4Domain
 
-  \\"\\"\\"Less than or equal to the specified value (case-insensitive).\\"\\"\\"
+  """Less than or equal to the specified value (case-insensitive)."""
   lessThanOrEqualToInsensitive: Char4Domain
 
-  \\"\\"\\"
+  """
   Matches the specified pattern (case-sensitive). An underscore (_) matches any
   single character; a percent sign (%) matches any sequence of zero or more characters.
-  \\"\\"\\"
+  """
   like: Char4Domain
 
-  \\"\\"\\"
+  """
   Matches the specified pattern (case-insensitive). An underscore (_) matches
   any single character; a percent sign (%) matches any sequence of zero or more characters.
-  \\"\\"\\"
+  """
   likeInsensitive: Char4Domain
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: Char4Domain
 
-  \\"\\"\\"
+  """
   Equal to the specified value, treating null like an ordinary value (case-insensitive).
-  \\"\\"\\"
+  """
   notDistinctFromInsensitive: Char4Domain
 
-  \\"\\"\\"Does not end with the specified string (case-sensitive).\\"\\"\\"
+  """Does not end with the specified string (case-sensitive)."""
   notEndsWith: Char4Domain
 
-  \\"\\"\\"Does not end with the specified string (case-insensitive).\\"\\"\\"
+  """Does not end with the specified string (case-insensitive)."""
   notEndsWithInsensitive: Char4Domain
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: Char4Domain
 
-  \\"\\"\\"Not equal to the specified value (case-insensitive).\\"\\"\\"
+  """Not equal to the specified value (case-insensitive)."""
   notEqualToInsensitive: Char4Domain
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [Char4Domain!]
 
-  \\"\\"\\"Not included in the specified list (case-insensitive).\\"\\"\\"
-  notInInsensitive: [Char4Domain!]
-
-  \\"\\"\\"Does not contain the specified string (case-sensitive).\\"\\"\\"
+  """Does not contain the specified string (case-sensitive)."""
   notIncludes: Char4Domain
 
-  \\"\\"\\"Does not contain the specified string (case-insensitive).\\"\\"\\"
+  """Does not contain the specified string (case-insensitive)."""
   notIncludesInsensitive: Char4Domain
 
-  \\"\\"\\"
+  """Not included in the specified list (case-insensitive)."""
+  notInInsensitive: [Char4Domain!]
+
+  """
   Does not match the specified pattern (case-sensitive). An underscore (_)
   matches any single character; a percent sign (%) matches any sequence of zero
   or more characters.
-  \\"\\"\\"
+  """
   notLike: Char4Domain
 
-  \\"\\"\\"
+  """
   Does not match the specified pattern (case-insensitive). An underscore (_)
   matches any single character; a percent sign (%) matches any sequence of zero
   or more characters.
-  \\"\\"\\"
+  """
   notLikeInsensitive: Char4Domain
 
-  \\"\\"\\"Does not start with the specified string (case-sensitive).\\"\\"\\"
+  """Does not start with the specified string (case-sensitive)."""
   notStartsWith: Char4Domain
 
-  \\"\\"\\"Does not start with the specified string (case-insensitive).\\"\\"\\"
+  """Does not start with the specified string (case-insensitive)."""
   notStartsWithInsensitive: Char4Domain
 
-  \\"\\"\\"Starts with the specified string (case-sensitive).\\"\\"\\"
+  """Starts with the specified string (case-sensitive)."""
   startsWith: Char4Domain
 
-  \\"\\"\\"Starts with the specified string (case-insensitive).\\"\\"\\"
+  """Starts with the specified string (case-insensitive)."""
   startsWithInsensitive: Char4Domain
 }
 
 type Child implements Node {
-  \\"\\"\\"Reads a single \`Filterable\` that is related to this \`Child\`.\\"\\"\\"
+  """Reads a single \`Filterable\` that is related to this \`Child\`."""
   filterableByFilterableId: Filterable
   filterableId: Int
   id: Int!
   name: String!
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`Child\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input ChildFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [ChildFilter!]
 
-  \\"\\"\\"Filter by the object’s \`filterableId\` field.\\"\\"\\"
+  """Filter by the object’s \`filterableId\` field."""
   filterableId: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`name\` field.\\"\\"\\"
+  """Filter by the object’s \`name\` field."""
   name: StringFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: ChildFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [ChildFilter!]
 }
 
 type ChildNoRelatedFilter implements Node {
-  \\"\\"\\"
+  """
   Reads a single \`Filterable\` that is related to this \`ChildNoRelatedFilter\`.
-  \\"\\"\\"
+  """
   filterableByFilterableId: Filterable
   filterableId: Int
   id: Int!
   name: String!
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 
-  \\"\\"\\"
+  """
   Reads a single \`Unfilterable\` that is related to this \`ChildNoRelatedFilter\`.
-  \\"\\"\\"
+  """
   unfilterableByUnfilterableId: Unfilterable
   unfilterableId: Int
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`ChildNoRelatedFilter\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input ChildNoRelatedFilterFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [ChildNoRelatedFilterFilter!]
 
-  \\"\\"\\"Filter by the object’s \`filterableId\` field.\\"\\"\\"
+  """Filter by the object’s \`filterableId\` field."""
   filterableId: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`name\` field.\\"\\"\\"
+  """Filter by the object’s \`name\` field."""
   name: StringFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: ChildNoRelatedFilterFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [ChildNoRelatedFilterFilter!]
 
-  \\"\\"\\"Filter by the object’s \`unfilterableId\` field.\\"\\"\\"
+  """Filter by the object’s \`unfilterableId\` field."""
   unfilterableId: IntFilter
 }
 
-\\"\\"\\"A connection to a list of \`ChildNoRelatedFilter\` values.\\"\\"\\"
+"""A connection to a list of \`ChildNoRelatedFilter\` values."""
 type ChildNoRelatedFiltersConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`ChildNoRelatedFilter\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [ChildNoRelatedFiltersEdge!]!
 
-  \\"\\"\\"A list of \`ChildNoRelatedFilter\` objects.\\"\\"\\"
+  """A list of \`ChildNoRelatedFilter\` objects."""
   nodes: [ChildNoRelatedFilter]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"
+  """
   The count of *all* \`ChildNoRelatedFilter\` you could get from the connection.
-  \\"\\"\\"
+  """
   totalCount: Int!
 }
 
-\\"\\"\\"A \`ChildNoRelatedFilter\` edge in the connection.\\"\\"\\"
+"""A \`ChildNoRelatedFilter\` edge in the connection."""
 type ChildNoRelatedFiltersEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`ChildNoRelatedFilter\` at the end of the edge.\\"\\"\\"
+  """The \`ChildNoRelatedFilter\` at the end of the edge."""
   node: ChildNoRelatedFilter
 }
 
-\\"\\"\\"Methods to use when ordering \`ChildNoRelatedFilter\`.\\"\\"\\"
+"""Methods to use when ordering \`ChildNoRelatedFilter\`."""
 enum ChildNoRelatedFiltersOrderBy {
   FILTERABLE_ID_ASC
   FILTERABLE_ID_DESC
@@ -977,33 +977,33 @@ enum ChildNoRelatedFiltersOrderBy {
   UNFILTERABLE_ID_DESC
 }
 
-\\"\\"\\"A connection to a list of \`Child\` values.\\"\\"\\"
+"""A connection to a list of \`Child\` values."""
 type ChildrenConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`Child\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [ChildrenEdge!]!
 
-  \\"\\"\\"A list of \`Child\` objects.\\"\\"\\"
+  """A list of \`Child\` objects."""
   nodes: [Child]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`Child\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`Child\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`Child\` edge in the connection.\\"\\"\\"
+"""A \`Child\` edge in the connection."""
 type ChildrenEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`Child\` at the end of the edge.\\"\\"\\"
+  """The \`Child\` at the end of the edge."""
   node: Child
 }
 
-\\"\\"\\"Methods to use when ordering \`Child\`.\\"\\"\\"
+"""Methods to use when ordering \`Child\`."""
 enum ChildrenOrderBy {
   FILTERABLE_ID_ASC
   FILTERABLE_ID_DESC
@@ -1021,381 +1021,381 @@ type Composite {
   b: String
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`Composite\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input CompositeFilter {
-  \\"\\"\\"Filter by the object’s \`a\` field.\\"\\"\\"
+  """Filter by the object’s \`a\` field."""
   a: IntFilter
 
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [CompositeFilter!]
 
-  \\"\\"\\"Filter by the object’s \`b\` field.\\"\\"\\"
+  """Filter by the object’s \`b\` field."""
   b: StringFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: CompositeFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [CompositeFilter!]
 }
 
-\\"\\"\\"A location in a connection that can be used for resuming pagination.\\"\\"\\"
+"""A location in a connection that can be used for resuming pagination."""
 scalar Cursor
 
-\\"\\"\\"The day, does not include a time.\\"\\"\\"
+"""The day, does not include a time."""
 scalar Date
 
 scalar DateDomain
 
-\\"\\"\\"
+"""
 A filter to be used against DateDomain fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input DateDomainFilter {
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: DateDomain
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: DateDomain
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: DateDomain
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: DateDomain
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [DateDomain!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: DateDomain
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: DateDomain
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: DateDomain
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: DateDomain
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [DateDomain!]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against Date fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input DateFilter {
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: Date
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: Date
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: Date
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: Date
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [Date!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: Date
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: Date
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: Date
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: Date
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [Date!]
 }
 
-\\"\\"\\"A range of \`Date\`.\\"\\"\\"
+"""A range of \`Date\`."""
 type DateRange {
-  \\"\\"\\"The ending bound of our range.\\"\\"\\"
+  """The ending bound of our range."""
   end: DateRangeBound
 
-  \\"\\"\\"The starting bound of our range.\\"\\"\\"
+  """The starting bound of our range."""
   start: DateRangeBound
 }
 
-\\"\\"\\"
+"""
 The value at one end of a range. A range can either include this value, or not.
-\\"\\"\\"
+"""
 type DateRangeBound {
-  \\"\\"\\"Whether or not the value of this bound is included in the range.\\"\\"\\"
+  """Whether or not the value of this bound is included in the range."""
   inclusive: Boolean!
 
-  \\"\\"\\"The value at one end of our range.\\"\\"\\"
+  """The value at one end of our range."""
   value: Date!
 }
 
-\\"\\"\\"
+"""
 The value at one end of a range. A range can either include this value, or not.
-\\"\\"\\"
+"""
 input DateRangeBoundInput {
-  \\"\\"\\"Whether or not the value of this bound is included in the range.\\"\\"\\"
+  """Whether or not the value of this bound is included in the range."""
   inclusive: Boolean!
 
-  \\"\\"\\"The value at one end of our range.\\"\\"\\"
+  """The value at one end of our range."""
   value: Date!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against DateRange fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input DateRangeFilter {
-  \\"\\"\\"Adjacent to the specified range.\\"\\"\\"
+  """Adjacent to the specified range."""
   adjacentTo: DateRangeInput
 
-  \\"\\"\\"Contained by the specified range.\\"\\"\\"
+  """Contained by the specified range."""
   containedBy: DateRangeInput
 
-  \\"\\"\\"Contains the specified range.\\"\\"\\"
+  """Contains the specified range."""
   contains: DateRangeInput
 
-  \\"\\"\\"Contains the specified value.\\"\\"\\"
+  """Contains the specified value."""
   containsElement: Date
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: DateRangeInput
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: DateRangeInput
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: DateRangeInput
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: DateRangeInput
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [DateRangeInput!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: DateRangeInput
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: DateRangeInput
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: DateRangeInput
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: DateRangeInput
 
-  \\"\\"\\"Does not extend left of the specified range.\\"\\"\\"
+  """Does not extend left of the specified range."""
   notExtendsLeftOf: DateRangeInput
 
-  \\"\\"\\"Does not extend right of the specified range.\\"\\"\\"
+  """Does not extend right of the specified range."""
   notExtendsRightOf: DateRangeInput
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [DateRangeInput!]
 
-  \\"\\"\\"Overlaps the specified range.\\"\\"\\"
+  """Overlaps the specified range."""
   overlaps: DateRangeInput
 
-  \\"\\"\\"Strictly left of the specified range.\\"\\"\\"
+  """Strictly left of the specified range."""
   strictlyLeftOf: DateRangeInput
 
-  \\"\\"\\"Strictly right of the specified range.\\"\\"\\"
+  """Strictly right of the specified range."""
   strictlyRightOf: DateRangeInput
 }
 
-\\"\\"\\"A range of \`Date\`.\\"\\"\\"
+"""A range of \`Date\`."""
 input DateRangeInput {
-  \\"\\"\\"The ending bound of our range.\\"\\"\\"
+  """The ending bound of our range."""
   end: DateRangeBoundInput
 
-  \\"\\"\\"The starting bound of our range.\\"\\"\\"
+  """The starting bound of our range."""
   start: DateRangeBoundInput
 }
 
-\\"\\"\\"
+"""
 A point in time as described by the [ISO
 8601](https://en.wikipedia.org/wiki/ISO_8601) standard. May or may not include a timezone.
-\\"\\"\\"
+"""
 scalar Datetime
 
-\\"\\"\\"
+"""
 A filter to be used against Datetime fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input DatetimeFilter {
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: Datetime
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: Datetime
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: Datetime
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: Datetime
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [Datetime!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: Datetime
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: Datetime
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: Datetime
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: Datetime
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [Datetime!]
 }
 
-\\"\\"\\"A range of \`Datetime\`.\\"\\"\\"
+"""A range of \`Datetime\`."""
 type DatetimeRange {
-  \\"\\"\\"The ending bound of our range.\\"\\"\\"
+  """The ending bound of our range."""
   end: DatetimeRangeBound
 
-  \\"\\"\\"The starting bound of our range.\\"\\"\\"
+  """The starting bound of our range."""
   start: DatetimeRangeBound
 }
 
-\\"\\"\\"
+"""
 The value at one end of a range. A range can either include this value, or not.
-\\"\\"\\"
+"""
 type DatetimeRangeBound {
-  \\"\\"\\"Whether or not the value of this bound is included in the range.\\"\\"\\"
+  """Whether or not the value of this bound is included in the range."""
   inclusive: Boolean!
 
-  \\"\\"\\"The value at one end of our range.\\"\\"\\"
+  """The value at one end of our range."""
   value: Datetime!
 }
 
-\\"\\"\\"
+"""
 The value at one end of a range. A range can either include this value, or not.
-\\"\\"\\"
+"""
 input DatetimeRangeBoundInput {
-  \\"\\"\\"Whether or not the value of this bound is included in the range.\\"\\"\\"
+  """Whether or not the value of this bound is included in the range."""
   inclusive: Boolean!
 
-  \\"\\"\\"The value at one end of our range.\\"\\"\\"
+  """The value at one end of our range."""
   value: Datetime!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against DatetimeRange fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input DatetimeRangeFilter {
-  \\"\\"\\"Adjacent to the specified range.\\"\\"\\"
+  """Adjacent to the specified range."""
   adjacentTo: DatetimeRangeInput
 
-  \\"\\"\\"Contained by the specified range.\\"\\"\\"
+  """Contained by the specified range."""
   containedBy: DatetimeRangeInput
 
-  \\"\\"\\"Contains the specified range.\\"\\"\\"
+  """Contains the specified range."""
   contains: DatetimeRangeInput
 
-  \\"\\"\\"Contains the specified value.\\"\\"\\"
+  """Contains the specified value."""
   containsElement: Datetime
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: DatetimeRangeInput
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: DatetimeRangeInput
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: DatetimeRangeInput
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: DatetimeRangeInput
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [DatetimeRangeInput!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: DatetimeRangeInput
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: DatetimeRangeInput
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: DatetimeRangeInput
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: DatetimeRangeInput
 
-  \\"\\"\\"Does not extend left of the specified range.\\"\\"\\"
+  """Does not extend left of the specified range."""
   notExtendsLeftOf: DatetimeRangeInput
 
-  \\"\\"\\"Does not extend right of the specified range.\\"\\"\\"
+  """Does not extend right of the specified range."""
   notExtendsRightOf: DatetimeRangeInput
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [DatetimeRangeInput!]
 
-  \\"\\"\\"Overlaps the specified range.\\"\\"\\"
+  """Overlaps the specified range."""
   overlaps: DatetimeRangeInput
 
-  \\"\\"\\"Strictly left of the specified range.\\"\\"\\"
+  """Strictly left of the specified range."""
   strictlyLeftOf: DatetimeRangeInput
 
-  \\"\\"\\"Strictly right of the specified range.\\"\\"\\"
+  """Strictly right of the specified range."""
   strictlyRightOf: DatetimeRangeInput
 }
 
-\\"\\"\\"A range of \`Datetime\`.\\"\\"\\"
+"""A range of \`Datetime\`."""
 input DatetimeRangeInput {
-  \\"\\"\\"The ending bound of our range.\\"\\"\\"
+  """The ending bound of our range."""
   end: DatetimeRangeBoundInput
 
-  \\"\\"\\"The starting bound of our range.\\"\\"\\"
+  """The starting bound of our range."""
   start: DatetimeRangeBoundInput
 }
 
@@ -1405,65 +1405,65 @@ type DomainType implements Node {
   id: Int!
   int4Domain: Int4Domain
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`DomainType\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input DomainTypeFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [DomainTypeFilter!]
 
-  \\"\\"\\"Filter by the object’s \`char4Domain\` field.\\"\\"\\"
+  """Filter by the object’s \`char4Domain\` field."""
   char4Domain: Char4DomainFilter
 
-  \\"\\"\\"Filter by the object’s \`dateDomain\` field.\\"\\"\\"
+  """Filter by the object’s \`dateDomain\` field."""
   dateDomain: DateDomainFilter
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`int4Domain\` field.\\"\\"\\"
+  """Filter by the object’s \`int4Domain\` field."""
   int4Domain: Int4DomainFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: DomainTypeFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [DomainTypeFilter!]
 }
 
-\\"\\"\\"A connection to a list of \`DomainType\` values.\\"\\"\\"
+"""A connection to a list of \`DomainType\` values."""
 type DomainTypesConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`DomainType\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [DomainTypesEdge!]!
 
-  \\"\\"\\"A list of \`DomainType\` objects.\\"\\"\\"
+  """A list of \`DomainType\` objects."""
   nodes: [DomainType]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`DomainType\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`DomainType\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`DomainType\` edge in the connection.\\"\\"\\"
+"""A \`DomainType\` edge in the connection."""
 type DomainTypesEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`DomainType\` at the end of the edge.\\"\\"\\"
+  """The \`DomainType\` at the end of the edge."""
   node: DomainType
 }
 
-\\"\\"\\"Methods to use when ordering \`DomainType\`.\\"\\"\\"
+"""Methods to use when ordering \`DomainType\`."""
 enum DomainTypesOrderBy {
   CHAR4_DOMAIN_ASC
   CHAR4_DOMAIN_DESC
@@ -1482,56 +1482,56 @@ type EnumArrayType implements Node {
   enumArray: [Mood]
   id: Int!
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`EnumArrayType\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input EnumArrayTypeFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [EnumArrayTypeFilter!]
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: EnumArrayTypeFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [EnumArrayTypeFilter!]
 }
 
-\\"\\"\\"A connection to a list of \`EnumArrayType\` values.\\"\\"\\"
+"""A connection to a list of \`EnumArrayType\` values."""
 type EnumArrayTypesConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`EnumArrayType\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [EnumArrayTypesEdge!]!
 
-  \\"\\"\\"A list of \`EnumArrayType\` objects.\\"\\"\\"
+  """A list of \`EnumArrayType\` objects."""
   nodes: [EnumArrayType]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`EnumArrayType\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`EnumArrayType\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`EnumArrayType\` edge in the connection.\\"\\"\\"
+"""A \`EnumArrayType\` edge in the connection."""
 type EnumArrayTypesEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`EnumArrayType\` at the end of the edge.\\"\\"\\"
+  """The \`EnumArrayType\` at the end of the edge."""
   node: EnumArrayType
 }
 
-\\"\\"\\"Methods to use when ordering \`EnumArrayType\`.\\"\\"\\"
+"""Methods to use when ordering \`EnumArrayType\`."""
 enum EnumArrayTypesOrderBy {
   ENUM_ARRAY_ASC
   ENUM_ARRAY_DESC
@@ -1546,59 +1546,59 @@ type EnumType implements Node {
   enum: Mood
   id: Int!
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`EnumType\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input EnumTypeFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [EnumTypeFilter!]
 
-  \\"\\"\\"Filter by the object’s \`enum\` field.\\"\\"\\"
+  """Filter by the object’s \`enum\` field."""
   enum: MoodFilter
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: EnumTypeFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [EnumTypeFilter!]
 }
 
-\\"\\"\\"A connection to a list of \`EnumType\` values.\\"\\"\\"
+"""A connection to a list of \`EnumType\` values."""
 type EnumTypesConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`EnumType\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [EnumTypesEdge!]!
 
-  \\"\\"\\"A list of \`EnumType\` objects.\\"\\"\\"
+  """A list of \`EnumType\` objects."""
   nodes: [EnumType]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`EnumType\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`EnumType\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`EnumType\` edge in the connection.\\"\\"\\"
+"""A \`EnumType\` edge in the connection."""
 type EnumTypesEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`EnumType\` at the end of the edge.\\"\\"\\"
+  """The \`EnumType\` at the end of the edge."""
   node: EnumType
 }
 
-\\"\\"\\"Methods to use when ordering \`EnumType\`.\\"\\"\\"
+"""Methods to use when ordering \`EnumType\`."""
 enum EnumTypesOrderBy {
   ENUM_ASC
   ENUM_DESC
@@ -1610,14 +1610,14 @@ enum EnumTypesOrderBy {
 }
 
 type Filterable implements Node {
-  \\"\\"\\"Reads a single \`Backward\` that is related to this \`Filterable\`.\\"\\"\\"
+  """Reads a single \`Backward\` that is related to this \`Filterable\`."""
   backwardByFilterableId: Backward
   backwardCompound1: Int
   backwardCompound2: Int
 
-  \\"\\"\\"
+  """
   Reads a single \`BackwardCompound\` that is related to this \`Filterable\`.
-  \\"\\"\\"
+  """
   backwardCompoundByBackwardCompound1AndBackwardCompound2: BackwardCompound
   bit4: BitString
   bool: Boolean
@@ -1625,61 +1625,61 @@ type Filterable implements Node {
   bytea: String
   char4: String
 
-  \\"\\"\\"Reads and enables pagination through a set of \`ChildNoRelatedFilter\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`ChildNoRelatedFilter\`."""
   childNoRelatedFiltersByFilterableId(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: ChildNoRelatedFilterFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`ChildNoRelatedFilter\`.\\"\\"\\"
+    """The method to use when ordering \`ChildNoRelatedFilter\`."""
     orderBy: [ChildNoRelatedFiltersOrderBy!] = [PRIMARY_KEY_ASC]
   ): ChildNoRelatedFiltersConnection!
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Child\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Child\`."""
   childrenByFilterableId(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: ChildFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`Child\`.\\"\\"\\"
+    """The method to use when ordering \`Child\`."""
     orderBy: [ChildrenOrderBy!] = [PRIMARY_KEY_ASC]
   ): ChildrenConnection!
   cidr: String
@@ -1690,126 +1690,126 @@ type Filterable implements Node {
   computedChild: Child
   computedIntArray: [Int]
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Child\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Child\`."""
   computedSetofChild(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: ChildFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
   ): ChildrenConnection!
   computedSetofInt(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: IntFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
   ): FilterableComputedSetofIntConnection!
   computedTaggedFilterable: Int
   computedWithRequiredArg(i: Int!): Int
   date: Date
 
-  \\"\\"\\"Reads and enables pagination through a set of \`FilterableClosure\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`FilterableClosure\`."""
   filterableClosuresByAncestorId(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: FilterableClosureFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`FilterableClosure\`.\\"\\"\\"
+    """The method to use when ordering \`FilterableClosure\`."""
     orderBy: [FilterableClosuresOrderBy!] = [PRIMARY_KEY_ASC]
   ): FilterableClosuresConnection!
 
-  \\"\\"\\"Reads and enables pagination through a set of \`FilterableClosure\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`FilterableClosure\`."""
   filterableClosuresByDescendantId(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: FilterableClosureFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`FilterableClosure\`.\\"\\"\\"
+    """The method to use when ordering \`FilterableClosure\`."""
     orderBy: [FilterableClosuresOrderBy!] = [PRIMARY_KEY_ASC]
   ): FilterableClosuresConnection!
   float4: Float
   float8: Float
 
-  \\"\\"\\"Reads a single \`Forward\` that is related to this \`Filterable\`.\\"\\"\\"
+  """Reads a single \`Forward\` that is related to this \`Filterable\`."""
   forwardByForwardId: Forward
   forwardColumn: Forward
   forwardCompound1: Int
   forwardCompound2: Int
 
-  \\"\\"\\"Reads a single \`ForwardCompound\` that is related to this \`Filterable\`.\\"\\"\\"
+  """Reads a single \`ForwardCompound\` that is related to this \`Filterable\`."""
   forwardCompoundByForwardCompound1AndForwardCompound2: ForwardCompound
   forwardId: Int
   hstore: KeyValueHash
@@ -1825,13 +1825,13 @@ type Filterable implements Node {
   money: Float
   name: String
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
   numeric: BigFloat
 
-  \\"\\"\\"Reads a single \`Parent\` that is related to this \`Filterable\`.\\"\\"\\"
+  """Reads a single \`Parent\` that is related to this \`Filterable\`."""
   parentByParentId: Parent
   parentId: Int
   text: String
@@ -1851,78 +1851,78 @@ type FilterableClosure implements Node {
   depth: Int!
   descendantId: Int!
 
-  \\"\\"\\"
+  """
   Reads a single \`Filterable\` that is related to this \`FilterableClosure\`.
-  \\"\\"\\"
+  """
   filterableByAncestorId: Filterable
 
-  \\"\\"\\"
+  """
   Reads a single \`Filterable\` that is related to this \`FilterableClosure\`.
-  \\"\\"\\"
+  """
   filterableByDescendantId: Filterable
   id: Int!
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`FilterableClosure\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input FilterableClosureFilter {
-  \\"\\"\\"Filter by the object’s \`ancestorId\` field.\\"\\"\\"
+  """Filter by the object’s \`ancestorId\` field."""
   ancestorId: IntFilter
 
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [FilterableClosureFilter!]
 
-  \\"\\"\\"Filter by the object’s \`depth\` field.\\"\\"\\"
+  """Filter by the object’s \`depth\` field."""
   depth: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`descendantId\` field.\\"\\"\\"
+  """Filter by the object’s \`descendantId\` field."""
   descendantId: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: FilterableClosureFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [FilterableClosureFilter!]
 }
 
-\\"\\"\\"A connection to a list of \`FilterableClosure\` values.\\"\\"\\"
+"""A connection to a list of \`FilterableClosure\` values."""
 type FilterableClosuresConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`FilterableClosure\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [FilterableClosuresEdge!]!
 
-  \\"\\"\\"A list of \`FilterableClosure\` objects.\\"\\"\\"
+  """A list of \`FilterableClosure\` objects."""
   nodes: [FilterableClosure]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"
+  """
   The count of *all* \`FilterableClosure\` you could get from the connection.
-  \\"\\"\\"
+  """
   totalCount: Int!
 }
 
-\\"\\"\\"A \`FilterableClosure\` edge in the connection.\\"\\"\\"
+"""A \`FilterableClosure\` edge in the connection."""
 type FilterableClosuresEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`FilterableClosure\` at the end of the edge.\\"\\"\\"
+  """The \`FilterableClosure\` at the end of the edge."""
   node: FilterableClosure
 }
 
-\\"\\"\\"Methods to use when ordering \`FilterableClosure\`.\\"\\"\\"
+"""Methods to use when ordering \`FilterableClosure\`."""
 enum FilterableClosuresOrderBy {
   ANCESTOR_ID_ASC
   ANCESTOR_ID_DESC
@@ -1937,178 +1937,178 @@ enum FilterableClosuresOrderBy {
   PRIMARY_KEY_DESC
 }
 
-\\"\\"\\"A connection to a list of \`Int\` values.\\"\\"\\"
+"""A connection to a list of \`Int\` values."""
 type FilterableComputedSetofIntConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`Int\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [FilterableComputedSetofIntEdge!]!
 
-  \\"\\"\\"A list of \`Int\` objects.\\"\\"\\"
+  """A list of \`Int\` objects."""
   nodes: [Int]!
 
-  \\"\\"\\"The count of *all* \`Int\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`Int\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`Int\` edge in the connection.\\"\\"\\"
+"""A \`Int\` edge in the connection."""
 type FilterableComputedSetofIntEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`Int\` at the end of the edge.\\"\\"\\"
+  """The \`Int\` at the end of the edge."""
   node: Int
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`Filterable\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input FilterableFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [FilterableFilter!]
 
-  \\"\\"\\"Filter by the object’s \`backwardCompound1\` field.\\"\\"\\"
+  """Filter by the object’s \`backwardCompound1\` field."""
   backwardCompound1: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`backwardCompound2\` field.\\"\\"\\"
+  """Filter by the object’s \`backwardCompound2\` field."""
   backwardCompound2: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`bit4\` field.\\"\\"\\"
+  """Filter by the object’s \`bit4\` field."""
   bit4: BitStringFilter
 
-  \\"\\"\\"Filter by the object’s \`bool\` field.\\"\\"\\"
+  """Filter by the object’s \`bool\` field."""
   bool: BooleanFilter
 
-  \\"\\"\\"Filter by the object’s \`bpchar4\` field.\\"\\"\\"
+  """Filter by the object’s \`bpchar4\` field."""
   bpchar4: StringFilter
 
-  \\"\\"\\"Filter by the object’s \`char4\` field.\\"\\"\\"
+  """Filter by the object’s \`char4\` field."""
   char4: StringFilter
 
-  \\"\\"\\"Filter by the object’s \`citext\` field.\\"\\"\\"
+  """Filter by the object’s \`citext\` field."""
   citext: StringFilter
 
-  \\"\\"\\"Filter by the object’s \`compositeColumn\` field.\\"\\"\\"
+  """Filter by the object’s \`compositeColumn\` field."""
   compositeColumn: CompositeFilter
 
-  \\"\\"\\"Filter by the object’s \`computed\` field.\\"\\"\\"
+  """Filter by the object’s \`computed\` field."""
   computed: StringFilter
 
-  \\"\\"\\"Filter by the object’s \`computedTaggedFilterable\` field.\\"\\"\\"
+  """Filter by the object’s \`computedTaggedFilterable\` field."""
   computedTaggedFilterable: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`date\` field.\\"\\"\\"
+  """Filter by the object’s \`date\` field."""
   date: DateFilter
 
-  \\"\\"\\"Filter by the object’s \`float4\` field.\\"\\"\\"
+  """Filter by the object’s \`float4\` field."""
   float4: FloatFilter
 
-  \\"\\"\\"Filter by the object’s \`float8\` field.\\"\\"\\"
+  """Filter by the object’s \`float8\` field."""
   float8: FloatFilter
 
-  \\"\\"\\"Filter by the object’s \`forwardCompound1\` field.\\"\\"\\"
+  """Filter by the object’s \`forwardCompound1\` field."""
   forwardCompound1: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`forwardCompound2\` field.\\"\\"\\"
+  """Filter by the object’s \`forwardCompound2\` field."""
   forwardCompound2: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`forwardId\` field.\\"\\"\\"
+  """Filter by the object’s \`forwardId\` field."""
   forwardId: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`hstore\` field.\\"\\"\\"
+  """Filter by the object’s \`hstore\` field."""
   hstore: KeyValueHashFilter
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`inet\` field.\\"\\"\\"
+  """Filter by the object’s \`inet\` field."""
   inet: InternetAddressFilter
 
-  \\"\\"\\"Filter by the object’s \`int2\` field.\\"\\"\\"
+  """Filter by the object’s \`int2\` field."""
   int2: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`int4\` field.\\"\\"\\"
+  """Filter by the object’s \`int4\` field."""
   int4: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`int8\` field.\\"\\"\\"
+  """Filter by the object’s \`int8\` field."""
   int8: BigIntFilter
 
-  \\"\\"\\"Filter by the object’s \`interval\` field.\\"\\"\\"
+  """Filter by the object’s \`interval\` field."""
   interval: IntervalFilter
 
-  \\"\\"\\"Filter by the object’s \`jsonb\` field.\\"\\"\\"
+  """Filter by the object’s \`jsonb\` field."""
   jsonb: JSONFilter
 
-  \\"\\"\\"Filter by the object’s \`money\` field.\\"\\"\\"
+  """Filter by the object’s \`money\` field."""
   money: FloatFilter
 
-  \\"\\"\\"Filter by the object’s \`name\` field.\\"\\"\\"
+  """Filter by the object’s \`name\` field."""
   name: StringFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: FilterableFilter
 
-  \\"\\"\\"Filter by the object’s \`numeric\` field.\\"\\"\\"
+  """Filter by the object’s \`numeric\` field."""
   numeric: BigFloatFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [FilterableFilter!]
 
-  \\"\\"\\"Filter by the object’s \`parentId\` field.\\"\\"\\"
+  """Filter by the object’s \`parentId\` field."""
   parentId: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`text\` field.\\"\\"\\"
+  """Filter by the object’s \`text\` field."""
   text: StringFilter
 
-  \\"\\"\\"Filter by the object’s \`time\` field.\\"\\"\\"
+  """Filter by the object’s \`time\` field."""
   time: TimeFilter
 
-  \\"\\"\\"Filter by the object’s \`timestamp\` field.\\"\\"\\"
+  """Filter by the object’s \`timestamp\` field."""
   timestamp: DatetimeFilter
 
-  \\"\\"\\"Filter by the object’s \`timestamptz\` field.\\"\\"\\"
+  """Filter by the object’s \`timestamptz\` field."""
   timestamptz: DatetimeFilter
 
-  \\"\\"\\"Filter by the object’s \`timetz\` field.\\"\\"\\"
+  """Filter by the object’s \`timetz\` field."""
   timetz: TimeFilter
 
-  \\"\\"\\"Filter by the object’s \`uuid\` field.\\"\\"\\"
+  """Filter by the object’s \`uuid\` field."""
   uuid: UUIDFilter
 
-  \\"\\"\\"Filter by the object’s \`varbit\` field.\\"\\"\\"
+  """Filter by the object’s \`varbit\` field."""
   varbit: BitStringFilter
 
-  \\"\\"\\"Filter by the object’s \`varchar\` field.\\"\\"\\"
+  """Filter by the object’s \`varchar\` field."""
   varchar: StringFilter
 }
 
-\\"\\"\\"A connection to a list of \`Filterable\` values.\\"\\"\\"
+"""A connection to a list of \`Filterable\` values."""
 type FilterablesConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`Filterable\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [FilterablesEdge!]!
 
-  \\"\\"\\"A list of \`Filterable\` objects.\\"\\"\\"
+  """A list of \`Filterable\` objects."""
   nodes: [Filterable]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`Filterable\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`Filterable\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`Filterable\` edge in the connection.\\"\\"\\"
+"""A \`Filterable\` edge in the connection."""
 type FilterablesEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`Filterable\` at the end of the edge.\\"\\"\\"
+  """The \`Filterable\` at the end of the edge."""
   node: Filterable
 }
 
-\\"\\"\\"Methods to use when ordering \`Filterable\`.\\"\\"\\"
+"""Methods to use when ordering \`Filterable\`."""
 enum FilterablesOrderBy {
   BACKWARD_COMPOUND_1_ASC
   BACKWARD_COMPOUND_1_DESC
@@ -2197,125 +2197,125 @@ enum FilterablesOrderBy {
   XML_DESC
 }
 
-\\"\\"\\"
+"""
 A filter to be used against Float fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input FloatFilter {
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: Float
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: Float
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: Float
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: Float
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [Float!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: Float
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: Float
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: Float
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: Float
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [Float!]
 }
 
 type Forward implements Node {
-  \\"\\"\\"Reads a single \`Filterable\` that is related to this \`Forward\`.\\"\\"\\"
+  """Reads a single \`Filterable\` that is related to this \`Forward\`."""
   filterableByForwardId: Filterable
   id: Int!
   name: String!
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
 type ForwardCompound implements Node {
-  \\"\\"\\"Reads a single \`Filterable\` that is related to this \`ForwardCompound\`.\\"\\"\\"
+  """Reads a single \`Filterable\` that is related to this \`ForwardCompound\`."""
   filterableByForwardCompound1AndForwardCompound2: Filterable
   forwardCompound1: Int!
   forwardCompound2: Int!
   name: String
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`ForwardCompound\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input ForwardCompoundFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [ForwardCompoundFilter!]
 
-  \\"\\"\\"Filter by the object’s \`forwardCompound1\` field.\\"\\"\\"
+  """Filter by the object’s \`forwardCompound1\` field."""
   forwardCompound1: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`forwardCompound2\` field.\\"\\"\\"
+  """Filter by the object’s \`forwardCompound2\` field."""
   forwardCompound2: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`name\` field.\\"\\"\\"
+  """Filter by the object’s \`name\` field."""
   name: StringFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: ForwardCompoundFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [ForwardCompoundFilter!]
 }
 
-\\"\\"\\"A connection to a list of \`ForwardCompound\` values.\\"\\"\\"
+"""A connection to a list of \`ForwardCompound\` values."""
 type ForwardCompoundsConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`ForwardCompound\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [ForwardCompoundsEdge!]!
 
-  \\"\\"\\"A list of \`ForwardCompound\` objects.\\"\\"\\"
+  """A list of \`ForwardCompound\` objects."""
   nodes: [ForwardCompound]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"
+  """
   The count of *all* \`ForwardCompound\` you could get from the connection.
-  \\"\\"\\"
+  """
   totalCount: Int!
 }
 
-\\"\\"\\"A \`ForwardCompound\` edge in the connection.\\"\\"\\"
+"""A \`ForwardCompound\` edge in the connection."""
 type ForwardCompoundsEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`ForwardCompound\` at the end of the edge.\\"\\"\\"
+  """The \`ForwardCompound\` at the end of the edge."""
   node: ForwardCompound
 }
 
-\\"\\"\\"Methods to use when ordering \`ForwardCompound\`.\\"\\"\\"
+"""Methods to use when ordering \`ForwardCompound\`."""
 enum ForwardCompoundsOrderBy {
   FORWARD_COMPOUND_1_ASC
   FORWARD_COMPOUND_1_DESC
@@ -2328,53 +2328,53 @@ enum ForwardCompoundsOrderBy {
   PRIMARY_KEY_DESC
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`Forward\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input ForwardFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [ForwardFilter!]
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`name\` field.\\"\\"\\"
+  """Filter by the object’s \`name\` field."""
   name: StringFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: ForwardFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [ForwardFilter!]
 }
 
-\\"\\"\\"A connection to a list of \`Forward\` values.\\"\\"\\"
+"""A connection to a list of \`Forward\` values."""
 type ForwardsConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`Forward\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [ForwardsEdge!]!
 
-  \\"\\"\\"A list of \`Forward\` objects.\\"\\"\\"
+  """A list of \`Forward\` objects."""
   nodes: [Forward]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`Forward\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`Forward\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`Forward\` edge in the connection.\\"\\"\\"
+"""A \`Forward\` edge in the connection."""
 type ForwardsEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`Forward\` at the end of the edge.\\"\\"\\"
+  """The \`Forward\` at the end of the edge."""
   node: Forward
 }
 
-\\"\\"\\"Methods to use when ordering \`Forward\`.\\"\\"\\"
+"""Methods to use when ordering \`Forward\`."""
 enum ForwardsOrderBy {
   ID_ASC
   ID_DESC
@@ -2388,40 +2388,40 @@ enum ForwardsOrderBy {
 type FullyOmitted implements Node {
   id: Int!
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
   text: String
 }
 
-\\"\\"\\"A connection to a list of \`FullyOmitted\` values.\\"\\"\\"
+"""A connection to a list of \`FullyOmitted\` values."""
 type FullyOmittedsConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`FullyOmitted\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [FullyOmittedsEdge!]!
 
-  \\"\\"\\"A list of \`FullyOmitted\` objects.\\"\\"\\"
+  """A list of \`FullyOmitted\` objects."""
   nodes: [FullyOmitted]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`FullyOmitted\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`FullyOmitted\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`FullyOmitted\` edge in the connection.\\"\\"\\"
+"""A \`FullyOmitted\` edge in the connection."""
 type FullyOmittedsEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`FullyOmitted\` at the end of the edge.\\"\\"\\"
+  """The \`FullyOmitted\` at the end of the edge."""
   node: FullyOmitted
 }
 
-\\"\\"\\"Methods to use when ordering \`FullyOmitted\`.\\"\\"\\"
+"""Methods to use when ordering \`FullyOmitted\`."""
 enum FullyOmittedsOrderBy {
   ID_ASC
   ID_DESC
@@ -2432,494 +2432,494 @@ enum FullyOmittedsOrderBy {
   TEXT_DESC
 }
 
-\\"\\"\\"A connection to a list of \`FuncReturnsTableMultiColRecord\` values.\\"\\"\\"
+"""A connection to a list of \`FuncReturnsTableMultiColRecord\` values."""
 type FuncReturnsTableMultiColConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`FuncReturnsTableMultiColRecord\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [FuncReturnsTableMultiColEdge!]!
 
-  \\"\\"\\"A list of \`FuncReturnsTableMultiColRecord\` objects.\\"\\"\\"
+  """A list of \`FuncReturnsTableMultiColRecord\` objects."""
   nodes: [FuncReturnsTableMultiColRecord]!
 
-  \\"\\"\\"
+  """
   The count of *all* \`FuncReturnsTableMultiColRecord\` you could get from the connection.
-  \\"\\"\\"
+  """
   totalCount: Int!
 }
 
-\\"\\"\\"A \`FuncReturnsTableMultiColRecord\` edge in the connection.\\"\\"\\"
+"""A \`FuncReturnsTableMultiColRecord\` edge in the connection."""
 type FuncReturnsTableMultiColEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`FuncReturnsTableMultiColRecord\` at the end of the edge.\\"\\"\\"
+  """The \`FuncReturnsTableMultiColRecord\` at the end of the edge."""
   node: FuncReturnsTableMultiColRecord
 }
 
-\\"\\"\\"The return type of our \`funcReturnsTableMultiCol\` query.\\"\\"\\"
+"""The return type of our \`funcReturnsTableMultiCol\` query."""
 type FuncReturnsTableMultiColRecord {
   col1: Int
   col2: String
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`FuncReturnsTableMultiColRecord\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input FuncReturnsTableMultiColRecordFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [FuncReturnsTableMultiColRecordFilter!]
 
-  \\"\\"\\"Filter by the object’s \`col1\` field.\\"\\"\\"
+  """Filter by the object’s \`col1\` field."""
   col1: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`col2\` field.\\"\\"\\"
+  """Filter by the object’s \`col2\` field."""
   col2: StringFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: FuncReturnsTableMultiColRecordFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [FuncReturnsTableMultiColRecordFilter!]
 }
 
-\\"\\"\\"A connection to a list of \`Int\` values.\\"\\"\\"
+"""A connection to a list of \`Int\` values."""
 type FuncReturnsTableOneColConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`Int\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [FuncReturnsTableOneColEdge!]!
 
-  \\"\\"\\"A list of \`Int\` objects.\\"\\"\\"
+  """A list of \`Int\` objects."""
   nodes: [Int]!
 
-  \\"\\"\\"The count of *all* \`Int\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`Int\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`Int\` edge in the connection.\\"\\"\\"
+"""A \`Int\` edge in the connection."""
 type FuncReturnsTableOneColEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`Int\` at the end of the edge.\\"\\"\\"
+  """The \`Int\` at the end of the edge."""
   node: Int
 }
 
-\\"\\"\\"
+"""
 A connection to a list of \`FuncTaggedFilterableReturnsTableMultiColRecord\` values.
-\\"\\"\\"
+"""
 type FuncTaggedFilterableReturnsTableMultiColConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`FuncTaggedFilterableReturnsTableMultiColRecord\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [FuncTaggedFilterableReturnsTableMultiColEdge!]!
 
-  \\"\\"\\"A list of \`FuncTaggedFilterableReturnsTableMultiColRecord\` objects.\\"\\"\\"
+  """A list of \`FuncTaggedFilterableReturnsTableMultiColRecord\` objects."""
   nodes: [FuncTaggedFilterableReturnsTableMultiColRecord]!
 
-  \\"\\"\\"
+  """
   The count of *all* \`FuncTaggedFilterableReturnsTableMultiColRecord\` you could get from the connection.
-  \\"\\"\\"
+  """
   totalCount: Int!
 }
 
-\\"\\"\\"
+"""
 A \`FuncTaggedFilterableReturnsTableMultiColRecord\` edge in the connection.
-\\"\\"\\"
+"""
 type FuncTaggedFilterableReturnsTableMultiColEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"
+  """
   The \`FuncTaggedFilterableReturnsTableMultiColRecord\` at the end of the edge.
-  \\"\\"\\"
+  """
   node: FuncTaggedFilterableReturnsTableMultiColRecord
 }
 
-\\"\\"\\"
+"""
 The return type of our \`funcTaggedFilterableReturnsTableMultiCol\` query.
-\\"\\"\\"
+"""
 type FuncTaggedFilterableReturnsTableMultiColRecord {
   col1: Int
   col2: String
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`FuncTaggedFilterableReturnsTableMultiColRecord\`
 object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input FuncTaggedFilterableReturnsTableMultiColRecordFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [FuncTaggedFilterableReturnsTableMultiColRecordFilter!]
 
-  \\"\\"\\"Filter by the object’s \`col1\` field.\\"\\"\\"
+  """Filter by the object’s \`col1\` field."""
   col1: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`col2\` field.\\"\\"\\"
+  """Filter by the object’s \`col2\` field."""
   col2: StringFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: FuncTaggedFilterableReturnsTableMultiColRecordFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [FuncTaggedFilterableReturnsTableMultiColRecordFilter!]
 }
 
 scalar Int4Domain
 
-\\"\\"\\"
+"""
 A filter to be used against Int4Domain fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input Int4DomainFilter {
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: Int4Domain
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: Int4Domain
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: Int4Domain
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: Int4Domain
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [Int4Domain!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: Int4Domain
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: Int4Domain
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: Int4Domain
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: Int4Domain
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [Int4Domain!]
 }
 
-\\"\\"\\"An IPv4 or IPv6 host address, and optionally its subnet.\\"\\"\\"
+"""An IPv4 or IPv6 host address, and optionally its subnet."""
 scalar InternetAddress
 
-\\"\\"\\"
+"""
 A filter to be used against InternetAddress fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input InternetAddressFilter {
-  \\"\\"\\"Contained by the specified internet address.\\"\\"\\"
+  """Contained by the specified internet address."""
   containedBy: InternetAddress
 
-  \\"\\"\\"Contained by or equal to the specified internet address.\\"\\"\\"
+  """Contained by or equal to the specified internet address."""
   containedByOrEqualTo: InternetAddress
 
-  \\"\\"\\"Contains the specified internet address.\\"\\"\\"
+  """Contains the specified internet address."""
   contains: InternetAddress
 
-  \\"\\"\\"Contains or contained by the specified internet address.\\"\\"\\"
+  """Contains or contained by the specified internet address."""
   containsOrContainedBy: InternetAddress
 
-  \\"\\"\\"Contains or equal to the specified internet address.\\"\\"\\"
+  """Contains or equal to the specified internet address."""
   containsOrEqualTo: InternetAddress
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: InternetAddress
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: InternetAddress
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: InternetAddress
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: InternetAddress
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [InternetAddress!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: InternetAddress
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: InternetAddress
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: InternetAddress
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: InternetAddress
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [InternetAddress!]
 }
 
-\\"\\"\\"
+"""
 An interval of time that has passed where the smallest distinct unit is a second.
-\\"\\"\\"
+"""
 type Interval {
-  \\"\\"\\"A quantity of days.\\"\\"\\"
+  """A quantity of days."""
   days: Int
 
-  \\"\\"\\"A quantity of hours.\\"\\"\\"
+  """A quantity of hours."""
   hours: Int
 
-  \\"\\"\\"A quantity of minutes.\\"\\"\\"
+  """A quantity of minutes."""
   minutes: Int
 
-  \\"\\"\\"A quantity of months.\\"\\"\\"
+  """A quantity of months."""
   months: Int
 
-  \\"\\"\\"
+  """
   A quantity of seconds. This is the only non-integer field, as all the other
   fields will dump their overflow into a smaller unit of time. Intervals don’t
   have a smaller unit than seconds.
-  \\"\\"\\"
+  """
   seconds: Float
 
-  \\"\\"\\"A quantity of years.\\"\\"\\"
+  """A quantity of years."""
   years: Int
 }
 
-\\"\\"\\"
+"""
 A filter to be used against Interval fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input IntervalFilter {
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: IntervalInput
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: IntervalInput
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: IntervalInput
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: IntervalInput
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [IntervalInput!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: IntervalInput
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: IntervalInput
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: IntervalInput
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: IntervalInput
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [IntervalInput!]
 }
 
-\\"\\"\\"
+"""
 An interval of time that has passed where the smallest distinct unit is a second.
-\\"\\"\\"
+"""
 input IntervalInput {
-  \\"\\"\\"A quantity of days.\\"\\"\\"
+  """A quantity of days."""
   days: Int
 
-  \\"\\"\\"A quantity of hours.\\"\\"\\"
+  """A quantity of hours."""
   hours: Int
 
-  \\"\\"\\"A quantity of minutes.\\"\\"\\"
+  """A quantity of minutes."""
   minutes: Int
 
-  \\"\\"\\"A quantity of months.\\"\\"\\"
+  """A quantity of months."""
   months: Int
 
-  \\"\\"\\"
+  """
   A quantity of seconds. This is the only non-integer field, as all the other
   fields will dump their overflow into a smaller unit of time. Intervals don’t
   have a smaller unit than seconds.
-  \\"\\"\\"
+  """
   seconds: Float
 
-  \\"\\"\\"A quantity of years.\\"\\"\\"
+  """A quantity of years."""
   years: Int
 }
 
-\\"\\"\\"
+"""
 A filter to be used against Int fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input IntFilter {
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: Int
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: Int
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: Int
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: Int
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [Int!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: Int
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: Int
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: Int
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: Int
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [Int!]
 }
 
-\\"\\"\\"A range of \`Int\`.\\"\\"\\"
+"""A range of \`Int\`."""
 type IntRange {
-  \\"\\"\\"The ending bound of our range.\\"\\"\\"
+  """The ending bound of our range."""
   end: IntRangeBound
 
-  \\"\\"\\"The starting bound of our range.\\"\\"\\"
+  """The starting bound of our range."""
   start: IntRangeBound
 }
 
-\\"\\"\\"
+"""
 The value at one end of a range. A range can either include this value, or not.
-\\"\\"\\"
+"""
 type IntRangeBound {
-  \\"\\"\\"Whether or not the value of this bound is included in the range.\\"\\"\\"
+  """Whether or not the value of this bound is included in the range."""
   inclusive: Boolean!
 
-  \\"\\"\\"The value at one end of our range.\\"\\"\\"
+  """The value at one end of our range."""
   value: Int!
 }
 
-\\"\\"\\"
+"""
 The value at one end of a range. A range can either include this value, or not.
-\\"\\"\\"
+"""
 input IntRangeBoundInput {
-  \\"\\"\\"Whether or not the value of this bound is included in the range.\\"\\"\\"
+  """Whether or not the value of this bound is included in the range."""
   inclusive: Boolean!
 
-  \\"\\"\\"The value at one end of our range.\\"\\"\\"
+  """The value at one end of our range."""
   value: Int!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against IntRange fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input IntRangeFilter {
-  \\"\\"\\"Adjacent to the specified range.\\"\\"\\"
+  """Adjacent to the specified range."""
   adjacentTo: IntRangeInput
 
-  \\"\\"\\"Contained by the specified range.\\"\\"\\"
+  """Contained by the specified range."""
   containedBy: IntRangeInput
 
-  \\"\\"\\"Contains the specified range.\\"\\"\\"
+  """Contains the specified range."""
   contains: IntRangeInput
 
-  \\"\\"\\"Contains the specified value.\\"\\"\\"
+  """Contains the specified value."""
   containsElement: Int
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: IntRangeInput
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: IntRangeInput
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: IntRangeInput
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: IntRangeInput
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [IntRangeInput!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: IntRangeInput
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: IntRangeInput
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: IntRangeInput
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: IntRangeInput
 
-  \\"\\"\\"Does not extend left of the specified range.\\"\\"\\"
+  """Does not extend left of the specified range."""
   notExtendsLeftOf: IntRangeInput
 
-  \\"\\"\\"Does not extend right of the specified range.\\"\\"\\"
+  """Does not extend right of the specified range."""
   notExtendsRightOf: IntRangeInput
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [IntRangeInput!]
 
-  \\"\\"\\"Overlaps the specified range.\\"\\"\\"
+  """Overlaps the specified range."""
   overlaps: IntRangeInput
 
-  \\"\\"\\"Strictly left of the specified range.\\"\\"\\"
+  """Strictly left of the specified range."""
   strictlyLeftOf: IntRangeInput
 
-  \\"\\"\\"Strictly right of the specified range.\\"\\"\\"
+  """Strictly right of the specified range."""
   strictlyRightOf: IntRangeInput
 }
 
-\\"\\"\\"A range of \`Int\`.\\"\\"\\"
+"""A range of \`Int\`."""
 input IntRangeInput {
-  \\"\\"\\"The ending bound of our range.\\"\\"\\"
+  """The ending bound of our range."""
   end: IntRangeBoundInput
 
-  \\"\\"\\"The starting bound of our range.\\"\\"\\"
+  """The starting bound of our range."""
   start: IntRangeBoundInput
 }
 
-\\"\\"\\"
+"""
 A JavaScript object encoded in the JSON format as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf).
-\\"\\"\\"
+"""
 scalar JSON
 
 type JsonbTest implements Node {
@@ -2927,62 +2927,62 @@ type JsonbTest implements Node {
   jsonbWithArray: JSON
   jsonbWithObject: JSON
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`JsonbTest\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input JsonbTestFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [JsonbTestFilter!]
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`jsonbWithArray\` field.\\"\\"\\"
+  """Filter by the object’s \`jsonbWithArray\` field."""
   jsonbWithArray: JSONFilter
 
-  \\"\\"\\"Filter by the object’s \`jsonbWithObject\` field.\\"\\"\\"
+  """Filter by the object’s \`jsonbWithObject\` field."""
   jsonbWithObject: JSONFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: JsonbTestFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [JsonbTestFilter!]
 }
 
-\\"\\"\\"A connection to a list of \`JsonbTest\` values.\\"\\"\\"
+"""A connection to a list of \`JsonbTest\` values."""
 type JsonbTestsConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`JsonbTest\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [JsonbTestsEdge!]!
 
-  \\"\\"\\"A list of \`JsonbTest\` objects.\\"\\"\\"
+  """A list of \`JsonbTest\` objects."""
   nodes: [JsonbTest]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`JsonbTest\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`JsonbTest\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`JsonbTest\` edge in the connection.\\"\\"\\"
+"""A \`JsonbTest\` edge in the connection."""
 type JsonbTestsEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`JsonbTest\` at the end of the edge.\\"\\"\\"
+  """The \`JsonbTest\` at the end of the edge."""
   node: JsonbTest
 }
 
-\\"\\"\\"Methods to use when ordering \`JsonbTest\`.\\"\\"\\"
+"""Methods to use when ordering \`JsonbTest\`."""
 enum JsonbTestsOrderBy {
   ID_ASC
   ID_DESC
@@ -2995,125 +2995,125 @@ enum JsonbTestsOrderBy {
   PRIMARY_KEY_DESC
 }
 
-\\"\\"\\"
+"""
 A filter to be used against JSON fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input JSONFilter {
-  \\"\\"\\"Contained by the specified JSON.\\"\\"\\"
+  """Contained by the specified JSON."""
   containedBy: JSON
 
-  \\"\\"\\"Contains the specified JSON.\\"\\"\\"
+  """Contains the specified JSON."""
   contains: JSON
 
-  \\"\\"\\"Contains all of the specified keys.\\"\\"\\"
+  """Contains all of the specified keys."""
   containsAllKeys: [String!]
 
-  \\"\\"\\"Contains any of the specified keys.\\"\\"\\"
+  """Contains any of the specified keys."""
   containsAnyKeys: [String!]
 
-  \\"\\"\\"Contains the specified key.\\"\\"\\"
+  """Contains the specified key."""
   containsKey: String
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: JSON
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: JSON
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: JSON
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: JSON
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [JSON!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: JSON
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: JSON
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: JSON
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: JSON
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [JSON!]
 }
 
 type Junction implements Node {
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 
-  \\"\\"\\"Reads a single \`SideA\` that is related to this \`Junction\`.\\"\\"\\"
+  """Reads a single \`SideA\` that is related to this \`Junction\`."""
   sideABySideAId: SideA
   sideAId: Int!
 
-  \\"\\"\\"Reads a single \`SideB\` that is related to this \`Junction\`.\\"\\"\\"
+  """Reads a single \`SideB\` that is related to this \`Junction\`."""
   sideBBySideBId: SideB
   sideBId: Int!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`Junction\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input JunctionFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [JunctionFilter!]
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: JunctionFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [JunctionFilter!]
 
-  \\"\\"\\"Filter by the object’s \`sideAId\` field.\\"\\"\\"
+  """Filter by the object’s \`sideAId\` field."""
   sideAId: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`sideBId\` field.\\"\\"\\"
+  """Filter by the object’s \`sideBId\` field."""
   sideBId: IntFilter
 }
 
-\\"\\"\\"A connection to a list of \`Junction\` values.\\"\\"\\"
+"""A connection to a list of \`Junction\` values."""
 type JunctionsConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`Junction\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [JunctionsEdge!]!
 
-  \\"\\"\\"A list of \`Junction\` objects.\\"\\"\\"
+  """A list of \`Junction\` objects."""
   nodes: [Junction]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`Junction\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`Junction\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`Junction\` edge in the connection.\\"\\"\\"
+"""A \`Junction\` edge in the connection."""
 type JunctionsEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`Junction\` at the end of the edge.\\"\\"\\"
+  """The \`Junction\` at the end of the edge."""
   node: Junction
 }
 
-\\"\\"\\"Methods to use when ordering \`Junction\`.\\"\\"\\"
+"""Methods to use when ordering \`Junction\`."""
 enum JunctionsOrderBy {
   NATURAL
   PRIMARY_KEY_ASC
@@ -3124,53 +3124,53 @@ enum JunctionsOrderBy {
   SIDE_B_ID_DESC
 }
 
-\\"\\"\\"
+"""
 A set of key/value pairs, keys are strings, values may be a string or null. Exposed as a JSON object.
-\\"\\"\\"
+"""
 scalar KeyValueHash
 
-\\"\\"\\"
+"""
 A filter to be used against KeyValueHash fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input KeyValueHashFilter {
-  \\"\\"\\"Contained by the specified KeyValueHash.\\"\\"\\"
+  """Contained by the specified KeyValueHash."""
   containedBy: KeyValueHash
 
-  \\"\\"\\"Contains the specified KeyValueHash.\\"\\"\\"
+  """Contains the specified KeyValueHash."""
   contains: KeyValueHash
 
-  \\"\\"\\"Contains all of the specified keys.\\"\\"\\"
+  """Contains all of the specified keys."""
   containsAllKeys: [String!]
 
-  \\"\\"\\"Contains any of the specified keys.\\"\\"\\"
+  """Contains any of the specified keys."""
   containsAnyKeys: [String!]
 
-  \\"\\"\\"Contains the specified key.\\"\\"\\"
+  """Contains the specified key."""
   containsKey: String
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: KeyValueHash
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: KeyValueHash
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [KeyValueHash!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: KeyValueHash
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: KeyValueHash
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [KeyValueHash!]
 }
 
@@ -3180,156 +3180,156 @@ enum Mood {
   SAD
 }
 
-\\"\\"\\"
+"""
 A filter to be used against Mood fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input MoodFilter {
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: Mood
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: Mood
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: Mood
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: Mood
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [Mood!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: Mood
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: Mood
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: Mood
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: Mood
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [Mood!]
 }
 
-\\"\\"\\"An object with a globally unique \`ID\`.\\"\\"\\"
+"""An object with a globally unique \`ID\`."""
 interface Node {
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
-\\"\\"\\"Information about pagination in a connection.\\"\\"\\"
+"""Information about pagination in a connection."""
 type PageInfo {
-  \\"\\"\\"When paginating forwards, the cursor to continue.\\"\\"\\"
+  """When paginating forwards, the cursor to continue."""
   endCursor: Cursor
 
-  \\"\\"\\"When paginating forwards, are there more items?\\"\\"\\"
+  """When paginating forwards, are there more items?"""
   hasNextPage: Boolean!
 
-  \\"\\"\\"When paginating backwards, are there more items?\\"\\"\\"
+  """When paginating backwards, are there more items?"""
   hasPreviousPage: Boolean!
 
-  \\"\\"\\"When paginating backwards, the cursor to continue.\\"\\"\\"
+  """When paginating backwards, the cursor to continue."""
   startCursor: Cursor
 }
 
 type Parent implements Node {
-  \\"\\"\\"Reads and enables pagination through a set of \`Filterable\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Filterable\`."""
   filterablesByParentId(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: FilterableFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`Filterable\`.\\"\\"\\"
+    """The method to use when ordering \`Filterable\`."""
     orderBy: [FilterablesOrderBy!] = [PRIMARY_KEY_ASC]
   ): FilterablesConnection!
   id: Int!
   name: String!
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`Parent\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input ParentFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [ParentFilter!]
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`name\` field.\\"\\"\\"
+  """Filter by the object’s \`name\` field."""
   name: StringFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: ParentFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [ParentFilter!]
 }
 
-\\"\\"\\"A connection to a list of \`Parent\` values.\\"\\"\\"
+"""A connection to a list of \`Parent\` values."""
 type ParentsConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`Parent\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [ParentsEdge!]!
 
-  \\"\\"\\"A list of \`Parent\` objects.\\"\\"\\"
+  """A list of \`Parent\` objects."""
   nodes: [Parent]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`Parent\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`Parent\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`Parent\` edge in the connection.\\"\\"\\"
+"""A \`Parent\` edge in the connection."""
 type ParentsEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`Parent\` at the end of the edge.\\"\\"\\"
+  """The \`Parent\` at the end of the edge."""
   node: Parent
 }
 
-\\"\\"\\"Methods to use when ordering \`Parent\`.\\"\\"\\"
+"""Methods to use when ordering \`Parent\`."""
 enum ParentsOrderBy {
   ID_ASC
   ID_DESC
@@ -3344,704 +3344,704 @@ type Protected implements Node {
   id: Int!
   name: String
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
   otherId: Int
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`Protected\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input ProtectedFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [ProtectedFilter!]
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`name\` field.\\"\\"\\"
+  """Filter by the object’s \`name\` field."""
   name: StringFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: ProtectedFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [ProtectedFilter!]
 
-  \\"\\"\\"Filter by the object’s \`otherId\` field.\\"\\"\\"
+  """Filter by the object’s \`otherId\` field."""
   otherId: IntFilter
 }
 
-\\"\\"\\"A connection to a list of \`Protected\` values.\\"\\"\\"
+"""A connection to a list of \`Protected\` values."""
 type ProtectedsConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`Protected\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [ProtectedsEdge!]!
 
-  \\"\\"\\"A list of \`Protected\` objects.\\"\\"\\"
+  """A list of \`Protected\` objects."""
   nodes: [Protected]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`Protected\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`Protected\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`Protected\` edge in the connection.\\"\\"\\"
+"""A \`Protected\` edge in the connection."""
 type ProtectedsEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`Protected\` at the end of the edge.\\"\\"\\"
+  """The \`Protected\` at the end of the edge."""
   node: Protected
 }
 
-\\"\\"\\"The root query type which gives access points into the data universe.\\"\\"\\"
+"""The root query type which gives access points into the data universe."""
 type Query implements Node {
-  \\"\\"\\"Reads and enables pagination through a set of \`ArrayType\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`ArrayType\`."""
   allArrayTypes(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: ArrayTypeFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`ArrayType\`.\\"\\"\\"
+    """The method to use when ordering \`ArrayType\`."""
     orderBy: [ArrayTypesOrderBy!] = [PRIMARY_KEY_ASC]
   ): ArrayTypesConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`BackwardCompound\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`BackwardCompound\`."""
   allBackwardCompounds(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: BackwardCompoundFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`BackwardCompound\`.\\"\\"\\"
+    """The method to use when ordering \`BackwardCompound\`."""
     orderBy: [BackwardCompoundsOrderBy!] = [PRIMARY_KEY_ASC]
   ): BackwardCompoundsConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Backward\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Backward\`."""
   allBackwards(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: BackwardFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`Backward\`.\\"\\"\\"
+    """The method to use when ordering \`Backward\`."""
     orderBy: [BackwardsOrderBy!] = [PRIMARY_KEY_ASC]
   ): BackwardsConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`ChildNoRelatedFilter\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`ChildNoRelatedFilter\`."""
   allChildNoRelatedFilters(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: ChildNoRelatedFilterFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`ChildNoRelatedFilter\`.\\"\\"\\"
+    """The method to use when ordering \`ChildNoRelatedFilter\`."""
     orderBy: [ChildNoRelatedFiltersOrderBy!] = [PRIMARY_KEY_ASC]
   ): ChildNoRelatedFiltersConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Child\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Child\`."""
   allChildren(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: ChildFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`Child\`.\\"\\"\\"
+    """The method to use when ordering \`Child\`."""
     orderBy: [ChildrenOrderBy!] = [PRIMARY_KEY_ASC]
   ): ChildrenConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`DomainType\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`DomainType\`."""
   allDomainTypes(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: DomainTypeFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`DomainType\`.\\"\\"\\"
+    """The method to use when ordering \`DomainType\`."""
     orderBy: [DomainTypesOrderBy!] = [PRIMARY_KEY_ASC]
   ): DomainTypesConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`EnumArrayType\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`EnumArrayType\`."""
   allEnumArrayTypes(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: EnumArrayTypeFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`EnumArrayType\`.\\"\\"\\"
+    """The method to use when ordering \`EnumArrayType\`."""
     orderBy: [EnumArrayTypesOrderBy!] = [PRIMARY_KEY_ASC]
   ): EnumArrayTypesConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`EnumType\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`EnumType\`."""
   allEnumTypes(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: EnumTypeFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`EnumType\`.\\"\\"\\"
+    """The method to use when ordering \`EnumType\`."""
     orderBy: [EnumTypesOrderBy!] = [PRIMARY_KEY_ASC]
   ): EnumTypesConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Filterable\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Filterable\`."""
   allFilterables(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: FilterableFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`Filterable\`.\\"\\"\\"
+    """The method to use when ordering \`Filterable\`."""
     orderBy: [FilterablesOrderBy!] = [PRIMARY_KEY_ASC]
   ): FilterablesConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`ForwardCompound\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`ForwardCompound\`."""
   allForwardCompounds(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: ForwardCompoundFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`ForwardCompound\`.\\"\\"\\"
+    """The method to use when ordering \`ForwardCompound\`."""
     orderBy: [ForwardCompoundsOrderBy!] = [PRIMARY_KEY_ASC]
   ): ForwardCompoundsConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Forward\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Forward\`."""
   allForwards(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: ForwardFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`Forward\`.\\"\\"\\"
+    """The method to use when ordering \`Forward\`."""
     orderBy: [ForwardsOrderBy!] = [PRIMARY_KEY_ASC]
   ): ForwardsConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`FullyOmitted\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`FullyOmitted\`."""
   allFullyOmitteds(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`FullyOmitted\`.\\"\\"\\"
+    """The method to use when ordering \`FullyOmitted\`."""
     orderBy: [FullyOmittedsOrderBy!] = [PRIMARY_KEY_ASC]
   ): FullyOmittedsConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`JsonbTest\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`JsonbTest\`."""
   allJsonbTests(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: JsonbTestFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`JsonbTest\`.\\"\\"\\"
+    """The method to use when ordering \`JsonbTest\`."""
     orderBy: [JsonbTestsOrderBy!] = [PRIMARY_KEY_ASC]
   ): JsonbTestsConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Junction\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Junction\`."""
   allJunctions(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: JunctionFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`Junction\`.\\"\\"\\"
+    """The method to use when ordering \`Junction\`."""
     orderBy: [JunctionsOrderBy!] = [PRIMARY_KEY_ASC]
   ): JunctionsConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Parent\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Parent\`."""
   allParents(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: ParentFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`Parent\`.\\"\\"\\"
+    """The method to use when ordering \`Parent\`."""
     orderBy: [ParentsOrderBy!] = [PRIMARY_KEY_ASC]
   ): ParentsConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`RangeArrayType\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`RangeArrayType\`."""
   allRangeArrayTypes(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: RangeArrayTypeFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`RangeArrayType\`.\\"\\"\\"
+    """The method to use when ordering \`RangeArrayType\`."""
     orderBy: [RangeArrayTypesOrderBy!] = [PRIMARY_KEY_ASC]
   ): RangeArrayTypesConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`RangeType\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`RangeType\`."""
   allRangeTypes(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: RangeTypeFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`RangeType\`.\\"\\"\\"
+    """The method to use when ordering \`RangeType\`."""
     orderBy: [RangeTypesOrderBy!] = [PRIMARY_KEY_ASC]
   ): RangeTypesConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`SideA\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`SideA\`."""
   allSideAs(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: SideAFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`SideA\`.\\"\\"\\"
+    """The method to use when ordering \`SideA\`."""
     orderBy: [SideAsOrderBy!] = [PRIMARY_KEY_ASC]
   ): SideAsConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`SideB\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`SideB\`."""
   allSideBs(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: SideBFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`SideB\`.\\"\\"\\"
+    """The method to use when ordering \`SideB\`."""
     orderBy: [SideBsOrderBy!] = [PRIMARY_KEY_ASC]
   ): SideBsConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Unfilterable\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Unfilterable\`."""
   allUnfilterables(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`Unfilterable\`.\\"\\"\\"
+    """The method to use when ordering \`Unfilterable\`."""
     orderBy: [UnfilterablesOrderBy!] = [PRIMARY_KEY_ASC]
   ): UnfilterablesConnection
 
-  \\"\\"\\"Reads a single \`ArrayType\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`ArrayType\` using its globally unique \`ID\`."""
   arrayType(
-    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`ArrayType\`.\\"\\"\\"
+    """The globally unique \`ID\` to be used in selecting a single \`ArrayType\`."""
     nodeId: ID!
   ): ArrayType
   arrayTypeById(id: Int!): ArrayType
 
-  \\"\\"\\"Reads a single \`Backward\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`Backward\` using its globally unique \`ID\`."""
   backward(
-    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`Backward\`.\\"\\"\\"
+    """The globally unique \`ID\` to be used in selecting a single \`Backward\`."""
     nodeId: ID!
   ): Backward
   backwardByFilterableId(filterableId: Int!): Backward
   backwardById(id: Int!): Backward
 
-  \\"\\"\\"Reads a single \`BackwardCompound\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`BackwardCompound\` using its globally unique \`ID\`."""
   backwardCompound(
-    \\"\\"\\"
+    """
     The globally unique \`ID\` to be used in selecting a single \`BackwardCompound\`.
-    \\"\\"\\"
+    """
     nodeId: ID!
   ): BackwardCompound
   backwardCompoundByBackwardCompound1AndBackwardCompound2(backwardCompound1: Int!, backwardCompound2: Int!): BackwardCompound
 
-  \\"\\"\\"Reads a single \`Child\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`Child\` using its globally unique \`ID\`."""
   child(
-    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`Child\`.\\"\\"\\"
+    """The globally unique \`ID\` to be used in selecting a single \`Child\`."""
     nodeId: ID!
   ): Child
   childById(id: Int!): Child
 
-  \\"\\"\\"Reads a single \`ChildNoRelatedFilter\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`ChildNoRelatedFilter\` using its globally unique \`ID\`."""
   childNoRelatedFilter(
-    \\"\\"\\"
+    """
     The globally unique \`ID\` to be used in selecting a single \`ChildNoRelatedFilter\`.
-    \\"\\"\\"
+    """
     nodeId: ID!
   ): ChildNoRelatedFilter
   childNoRelatedFilterById(id: Int!): ChildNoRelatedFilter
 
-  \\"\\"\\"Reads a single \`DomainType\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`DomainType\` using its globally unique \`ID\`."""
   domainType(
-    \\"\\"\\"
+    """
     The globally unique \`ID\` to be used in selecting a single \`DomainType\`.
-    \\"\\"\\"
+    """
     nodeId: ID!
   ): DomainType
   domainTypeById(id: Int!): DomainType
 
-  \\"\\"\\"Reads a single \`EnumArrayType\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`EnumArrayType\` using its globally unique \`ID\`."""
   enumArrayType(
-    \\"\\"\\"
+    """
     The globally unique \`ID\` to be used in selecting a single \`EnumArrayType\`.
-    \\"\\"\\"
+    """
     nodeId: ID!
   ): EnumArrayType
   enumArrayTypeById(id: Int!): EnumArrayType
 
-  \\"\\"\\"Reads a single \`EnumType\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`EnumType\` using its globally unique \`ID\`."""
   enumType(
-    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`EnumType\`.\\"\\"\\"
+    """The globally unique \`ID\` to be used in selecting a single \`EnumType\`."""
     nodeId: ID!
   ): EnumType
   enumTypeById(id: Int!): EnumType
 
-  \\"\\"\\"Reads a single \`Filterable\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`Filterable\` using its globally unique \`ID\`."""
   filterable(
-    \\"\\"\\"
+    """
     The globally unique \`ID\` to be used in selecting a single \`Filterable\`.
-    \\"\\"\\"
+    """
     nodeId: ID!
   ): Filterable
   filterableByBackwardCompound1AndBackwardCompound2(backwardCompound1: Int!, backwardCompound2: Int!): Filterable
@@ -4049,247 +4049,247 @@ type Query implements Node {
   filterableByForwardId(forwardId: Int!): Filterable
   filterableById(id: Int!): Filterable
 
-  \\"\\"\\"Reads a single \`FilterableClosure\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`FilterableClosure\` using its globally unique \`ID\`."""
   filterableClosure(
-    \\"\\"\\"
+    """
     The globally unique \`ID\` to be used in selecting a single \`FilterableClosure\`.
-    \\"\\"\\"
+    """
     nodeId: ID!
   ): FilterableClosure
   filterableClosureById(id: Int!): FilterableClosure
 
-  \\"\\"\\"Reads a single \`Forward\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`Forward\` using its globally unique \`ID\`."""
   forward(
-    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`Forward\`.\\"\\"\\"
+    """The globally unique \`ID\` to be used in selecting a single \`Forward\`."""
     nodeId: ID!
   ): Forward
   forwardById(id: Int!): Forward
 
-  \\"\\"\\"Reads a single \`ForwardCompound\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`ForwardCompound\` using its globally unique \`ID\`."""
   forwardCompound(
-    \\"\\"\\"
+    """
     The globally unique \`ID\` to be used in selecting a single \`ForwardCompound\`.
-    \\"\\"\\"
+    """
     nodeId: ID!
   ): ForwardCompound
   forwardCompoundByForwardCompound1AndForwardCompound2(forwardCompound1: Int!, forwardCompound2: Int!): ForwardCompound
 
-  \\"\\"\\"Reads a single \`FullyOmitted\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`FullyOmitted\` using its globally unique \`ID\`."""
   fullyOmitted(
-    \\"\\"\\"
+    """
     The globally unique \`ID\` to be used in selecting a single \`FullyOmitted\`.
-    \\"\\"\\"
+    """
     nodeId: ID!
   ): FullyOmitted
   fullyOmittedById(id: Int!): FullyOmitted
   funcReturnsTableMultiCol(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: FuncReturnsTableMultiColRecordFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
     i: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
   ): FuncReturnsTableMultiColConnection!
   funcReturnsTableOneCol(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: IntFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
     i: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
   ): FuncReturnsTableOneColConnection!
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Filterable\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Filterable\`."""
   funcTaggedFilterableReturnsSetofFilterable(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: FilterableFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
   ): FilterablesConnection!
   funcTaggedFilterableReturnsTableMultiCol(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: FuncTaggedFilterableReturnsTableMultiColRecordFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
   ): FuncTaggedFilterableReturnsTableMultiColConnection!
 
-  \\"\\"\\"Reads a single \`JsonbTest\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`JsonbTest\` using its globally unique \`ID\`."""
   jsonbTest(
-    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`JsonbTest\`.\\"\\"\\"
+    """The globally unique \`ID\` to be used in selecting a single \`JsonbTest\`."""
     nodeId: ID!
   ): JsonbTest
   jsonbTestById(id: Int!): JsonbTest
 
-  \\"\\"\\"Reads a single \`Junction\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`Junction\` using its globally unique \`ID\`."""
   junction(
-    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`Junction\`.\\"\\"\\"
+    """The globally unique \`ID\` to be used in selecting a single \`Junction\`."""
     nodeId: ID!
   ): Junction
   junctionBySideAIdAndSideBId(sideAId: Int!, sideBId: Int!): Junction
 
-  \\"\\"\\"Fetches an object given its globally unique \`ID\`.\\"\\"\\"
+  """Fetches an object given its globally unique \`ID\`."""
   node(
-    \\"\\"\\"The globally unique \`ID\`.\\"\\"\\"
+    """The globally unique \`ID\`."""
     nodeId: ID!
   ): Node
 
-  \\"\\"\\"
+  """
   The root query type must be a \`Node\` to work well with Relay 1 mutations. This just resolves to \`query\`.
-  \\"\\"\\"
+  """
   nodeId: ID!
 
-  \\"\\"\\"Reads a single \`Parent\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`Parent\` using its globally unique \`ID\`."""
   parent(
-    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`Parent\`.\\"\\"\\"
+    """The globally unique \`ID\` to be used in selecting a single \`Parent\`."""
     nodeId: ID!
   ): Parent
   parentById(id: Int!): Parent
 
-  \\"\\"\\"Reads a single \`Protected\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`Protected\` using its globally unique \`ID\`."""
   protected(
-    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`Protected\`.\\"\\"\\"
+    """The globally unique \`ID\` to be used in selecting a single \`Protected\`."""
     nodeId: ID!
   ): Protected
   protectedById(id: Int!): Protected
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Protected\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Protected\`."""
   protectedsByOtherId(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: ProtectedFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
     otherId: Int
   ): ProtectedsConnection!
 
-  \\"\\"\\"
+  """
   Exposes the root query type nested one level down. This is helpful for Relay 1
   which can only query top level fields if they are in a particular form.
-  \\"\\"\\"
+  """
   query: Query!
 
-  \\"\\"\\"Reads a single \`RangeArrayType\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`RangeArrayType\` using its globally unique \`ID\`."""
   rangeArrayType(
-    \\"\\"\\"
+    """
     The globally unique \`ID\` to be used in selecting a single \`RangeArrayType\`.
-    \\"\\"\\"
+    """
     nodeId: ID!
   ): RangeArrayType
   rangeArrayTypeById(id: Int!): RangeArrayType
 
-  \\"\\"\\"Reads a single \`RangeType\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`RangeType\` using its globally unique \`ID\`."""
   rangeType(
-    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`RangeType\`.\\"\\"\\"
+    """The globally unique \`ID\` to be used in selecting a single \`RangeType\`."""
     nodeId: ID!
   ): RangeType
   rangeTypeById(id: Int!): RangeType
 
-  \\"\\"\\"Reads a single \`SideA\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`SideA\` using its globally unique \`ID\`."""
   sideA(
-    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`SideA\`.\\"\\"\\"
+    """The globally unique \`ID\` to be used in selecting a single \`SideA\`."""
     nodeId: ID!
   ): SideA
   sideAByAId(aId: Int!): SideA
 
-  \\"\\"\\"Reads a single \`SideB\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`SideB\` using its globally unique \`ID\`."""
   sideB(
-    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`SideB\`.\\"\\"\\"
+    """The globally unique \`ID\` to be used in selecting a single \`SideB\`."""
     nodeId: ID!
   ): SideB
   sideBByBId(bId: Int!): SideB
 
-  \\"\\"\\"Reads a single \`Unfilterable\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`Unfilterable\` using its globally unique \`ID\`."""
   unfilterable(
-    \\"\\"\\"
+    """
     The globally unique \`ID\` to be used in selecting a single \`Unfilterable\`.
-    \\"\\"\\"
+    """
     nodeId: ID!
   ): Unfilterable
   unfilterableById(id: Int!): Unfilterable
@@ -4301,59 +4301,59 @@ type RangeArrayType implements Node {
   int4RangeArray: [IntRange]
   int8RangeArray: [BigIntRange]
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
   numericRangeArray: [BigFloatRange]
   timestampRangeArray: [DatetimeRange]
   timestamptzRangeArray: [DatetimeRange]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`RangeArrayType\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input RangeArrayTypeFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [RangeArrayTypeFilter!]
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: RangeArrayTypeFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [RangeArrayTypeFilter!]
 }
 
-\\"\\"\\"A connection to a list of \`RangeArrayType\` values.\\"\\"\\"
+"""A connection to a list of \`RangeArrayType\` values."""
 type RangeArrayTypesConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`RangeArrayType\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [RangeArrayTypesEdge!]!
 
-  \\"\\"\\"A list of \`RangeArrayType\` objects.\\"\\"\\"
+  """A list of \`RangeArrayType\` objects."""
   nodes: [RangeArrayType]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`RangeArrayType\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`RangeArrayType\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`RangeArrayType\` edge in the connection.\\"\\"\\"
+"""A \`RangeArrayType\` edge in the connection."""
 type RangeArrayTypesEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`RangeArrayType\` at the end of the edge.\\"\\"\\"
+  """The \`RangeArrayType\` at the end of the edge."""
   node: RangeArrayType
 }
 
-\\"\\"\\"Methods to use when ordering \`RangeArrayType\`.\\"\\"\\"
+"""Methods to use when ordering \`RangeArrayType\`."""
 enum RangeArrayTypesOrderBy {
   DATE_RANGE_ARRAY_ASC
   DATE_RANGE_ARRAY_DESC
@@ -4380,77 +4380,77 @@ type RangeType implements Node {
   int4Range: IntRange
   int8Range: BigIntRange
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
   numericRange: BigFloatRange
   timestampRange: DatetimeRange
   timestamptzRange: DatetimeRange
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`RangeType\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input RangeTypeFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [RangeTypeFilter!]
 
-  \\"\\"\\"Filter by the object’s \`dateRange\` field.\\"\\"\\"
+  """Filter by the object’s \`dateRange\` field."""
   dateRange: DateRangeFilter
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`int4Range\` field.\\"\\"\\"
+  """Filter by the object’s \`int4Range\` field."""
   int4Range: IntRangeFilter
 
-  \\"\\"\\"Filter by the object’s \`int8Range\` field.\\"\\"\\"
+  """Filter by the object’s \`int8Range\` field."""
   int8Range: BigIntRangeFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: RangeTypeFilter
 
-  \\"\\"\\"Filter by the object’s \`numericRange\` field.\\"\\"\\"
+  """Filter by the object’s \`numericRange\` field."""
   numericRange: BigFloatRangeFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [RangeTypeFilter!]
 
-  \\"\\"\\"Filter by the object’s \`timestampRange\` field.\\"\\"\\"
+  """Filter by the object’s \`timestampRange\` field."""
   timestampRange: DatetimeRangeFilter
 
-  \\"\\"\\"Filter by the object’s \`timestamptzRange\` field.\\"\\"\\"
+  """Filter by the object’s \`timestamptzRange\` field."""
   timestamptzRange: DatetimeRangeFilter
 }
 
-\\"\\"\\"A connection to a list of \`RangeType\` values.\\"\\"\\"
+"""A connection to a list of \`RangeType\` values."""
 type RangeTypesConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`RangeType\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [RangeTypesEdge!]!
 
-  \\"\\"\\"A list of \`RangeType\` objects.\\"\\"\\"
+  """A list of \`RangeType\` objects."""
   nodes: [RangeType]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`RangeType\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`RangeType\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`RangeType\` edge in the connection.\\"\\"\\"
+"""A \`RangeType\` edge in the connection."""
 type RangeTypesEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`RangeType\` at the end of the edge.\\"\\"\\"
+  """The \`RangeType\` at the end of the edge."""
   node: RangeType
 }
 
-\\"\\"\\"Methods to use when ordering \`RangeType\`.\\"\\"\\"
+"""Methods to use when ordering \`RangeType\`."""
 enum RangeTypesOrderBy {
   DATE_RANGE_ASC
   DATE_RANGE_DESC
@@ -4474,89 +4474,89 @@ enum RangeTypesOrderBy {
 type SideA implements Node {
   aId: Int!
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Junction\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Junction\`."""
   junctionsBySideAId(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: JunctionFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`Junction\`.\\"\\"\\"
+    """The method to use when ordering \`Junction\`."""
     orderBy: [JunctionsOrderBy!] = [PRIMARY_KEY_ASC]
   ): JunctionsConnection!
   name: String!
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`SideA\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input SideAFilter {
-  \\"\\"\\"Filter by the object’s \`aId\` field.\\"\\"\\"
+  """Filter by the object’s \`aId\` field."""
   aId: IntFilter
 
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [SideAFilter!]
 
-  \\"\\"\\"Filter by the object’s \`name\` field.\\"\\"\\"
+  """Filter by the object’s \`name\` field."""
   name: StringFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: SideAFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [SideAFilter!]
 }
 
-\\"\\"\\"A connection to a list of \`SideA\` values.\\"\\"\\"
+"""A connection to a list of \`SideA\` values."""
 type SideAsConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`SideA\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [SideAsEdge!]!
 
-  \\"\\"\\"A list of \`SideA\` objects.\\"\\"\\"
+  """A list of \`SideA\` objects."""
   nodes: [SideA]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`SideA\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`SideA\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`SideA\` edge in the connection.\\"\\"\\"
+"""A \`SideA\` edge in the connection."""
 type SideAsEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`SideA\` at the end of the edge.\\"\\"\\"
+  """The \`SideA\` at the end of the edge."""
   node: SideA
 }
 
-\\"\\"\\"Methods to use when ordering \`SideA\`.\\"\\"\\"
+"""Methods to use when ordering \`SideA\`."""
 enum SideAsOrderBy {
   A_ID_ASC
   A_ID_DESC
@@ -4570,89 +4570,89 @@ enum SideAsOrderBy {
 type SideB implements Node {
   bId: Int!
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Junction\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Junction\`."""
   junctionsBySideBId(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: JunctionFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`Junction\`.\\"\\"\\"
+    """The method to use when ordering \`Junction\`."""
     orderBy: [JunctionsOrderBy!] = [PRIMARY_KEY_ASC]
   ): JunctionsConnection!
   name: String!
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`SideB\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input SideBFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [SideBFilter!]
 
-  \\"\\"\\"Filter by the object’s \`bId\` field.\\"\\"\\"
+  """Filter by the object’s \`bId\` field."""
   bId: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`name\` field.\\"\\"\\"
+  """Filter by the object’s \`name\` field."""
   name: StringFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: SideBFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [SideBFilter!]
 }
 
-\\"\\"\\"A connection to a list of \`SideB\` values.\\"\\"\\"
+"""A connection to a list of \`SideB\` values."""
 type SideBsConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`SideB\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [SideBsEdge!]!
 
-  \\"\\"\\"A list of \`SideB\` objects.\\"\\"\\"
+  """A list of \`SideB\` objects."""
   nodes: [SideB]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`SideB\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`SideB\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`SideB\` edge in the connection.\\"\\"\\"
+"""A \`SideB\` edge in the connection."""
 type SideBsEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`SideB\` at the end of the edge.\\"\\"\\"
+  """The \`SideB\` at the end of the edge."""
   node: SideB
 }
 
-\\"\\"\\"Methods to use when ordering \`SideB\`.\\"\\"\\"
+"""Methods to use when ordering \`SideB\`."""
 enum SideBsOrderBy {
   B_ID_ASC
   B_ID_DESC
@@ -4663,256 +4663,256 @@ enum SideBsOrderBy {
   PRIMARY_KEY_DESC
 }
 
-\\"\\"\\"
+"""
 A filter to be used against String fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input StringFilter {
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: String
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value (case-insensitive).
-  \\"\\"\\"
+  """
   distinctFromInsensitive: String
 
-  \\"\\"\\"Ends with the specified string (case-sensitive).\\"\\"\\"
+  """Ends with the specified string (case-sensitive)."""
   endsWith: String
 
-  \\"\\"\\"Ends with the specified string (case-insensitive).\\"\\"\\"
+  """Ends with the specified string (case-insensitive)."""
   endsWithInsensitive: String
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: String
 
-  \\"\\"\\"Equal to the specified value (case-insensitive).\\"\\"\\"
+  """Equal to the specified value (case-insensitive)."""
   equalToInsensitive: String
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: String
 
-  \\"\\"\\"Greater than the specified value (case-insensitive).\\"\\"\\"
+  """Greater than the specified value (case-insensitive)."""
   greaterThanInsensitive: String
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: String
 
-  \\"\\"\\"Greater than or equal to the specified value (case-insensitive).\\"\\"\\"
+  """Greater than or equal to the specified value (case-insensitive)."""
   greaterThanOrEqualToInsensitive: String
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [String!]
 
-  \\"\\"\\"Included in the specified list (case-insensitive).\\"\\"\\"
-  inInsensitive: [String!]
-
-  \\"\\"\\"Contains the specified string (case-sensitive).\\"\\"\\"
+  """Contains the specified string (case-sensitive)."""
   includes: String
 
-  \\"\\"\\"Contains the specified string (case-insensitive).\\"\\"\\"
+  """Contains the specified string (case-insensitive)."""
   includesInsensitive: String
 
-  \\"\\"\\"
+  """Included in the specified list (case-insensitive)."""
+  inInsensitive: [String!]
+
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: String
 
-  \\"\\"\\"Less than the specified value (case-insensitive).\\"\\"\\"
+  """Less than the specified value (case-insensitive)."""
   lessThanInsensitive: String
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: String
 
-  \\"\\"\\"Less than or equal to the specified value (case-insensitive).\\"\\"\\"
+  """Less than or equal to the specified value (case-insensitive)."""
   lessThanOrEqualToInsensitive: String
 
-  \\"\\"\\"
+  """
   Matches the specified pattern (case-sensitive). An underscore (_) matches any
   single character; a percent sign (%) matches any sequence of zero or more characters.
-  \\"\\"\\"
+  """
   like: String
 
-  \\"\\"\\"
+  """
   Matches the specified pattern (case-insensitive). An underscore (_) matches
   any single character; a percent sign (%) matches any sequence of zero or more characters.
-  \\"\\"\\"
+  """
   likeInsensitive: String
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: String
 
-  \\"\\"\\"
+  """
   Equal to the specified value, treating null like an ordinary value (case-insensitive).
-  \\"\\"\\"
+  """
   notDistinctFromInsensitive: String
 
-  \\"\\"\\"Does not end with the specified string (case-sensitive).\\"\\"\\"
+  """Does not end with the specified string (case-sensitive)."""
   notEndsWith: String
 
-  \\"\\"\\"Does not end with the specified string (case-insensitive).\\"\\"\\"
+  """Does not end with the specified string (case-insensitive)."""
   notEndsWithInsensitive: String
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: String
 
-  \\"\\"\\"Not equal to the specified value (case-insensitive).\\"\\"\\"
+  """Not equal to the specified value (case-insensitive)."""
   notEqualToInsensitive: String
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [String!]
 
-  \\"\\"\\"Not included in the specified list (case-insensitive).\\"\\"\\"
-  notInInsensitive: [String!]
-
-  \\"\\"\\"Does not contain the specified string (case-sensitive).\\"\\"\\"
+  """Does not contain the specified string (case-sensitive)."""
   notIncludes: String
 
-  \\"\\"\\"Does not contain the specified string (case-insensitive).\\"\\"\\"
+  """Does not contain the specified string (case-insensitive)."""
   notIncludesInsensitive: String
 
-  \\"\\"\\"
+  """Not included in the specified list (case-insensitive)."""
+  notInInsensitive: [String!]
+
+  """
   Does not match the specified pattern (case-sensitive). An underscore (_)
   matches any single character; a percent sign (%) matches any sequence of zero
   or more characters.
-  \\"\\"\\"
+  """
   notLike: String
 
-  \\"\\"\\"
+  """
   Does not match the specified pattern (case-insensitive). An underscore (_)
   matches any single character; a percent sign (%) matches any sequence of zero
   or more characters.
-  \\"\\"\\"
+  """
   notLikeInsensitive: String
 
-  \\"\\"\\"Does not start with the specified string (case-sensitive).\\"\\"\\"
+  """Does not start with the specified string (case-sensitive)."""
   notStartsWith: String
 
-  \\"\\"\\"Does not start with the specified string (case-insensitive).\\"\\"\\"
+  """Does not start with the specified string (case-insensitive)."""
   notStartsWithInsensitive: String
 
-  \\"\\"\\"Starts with the specified string (case-sensitive).\\"\\"\\"
+  """Starts with the specified string (case-sensitive)."""
   startsWith: String
 
-  \\"\\"\\"Starts with the specified string (case-insensitive).\\"\\"\\"
+  """Starts with the specified string (case-insensitive)."""
   startsWithInsensitive: String
 }
 
-\\"\\"\\"
+"""
 The exact time of day, does not include the date. May or may not have a timezone offset.
-\\"\\"\\"
+"""
 scalar Time
 
-\\"\\"\\"
+"""
 A filter to be used against Time fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input TimeFilter {
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: Time
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: Time
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: Time
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: Time
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [Time!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: Time
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: Time
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: Time
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: Time
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [Time!]
 }
 
 type Unfilterable implements Node {
-  \\"\\"\\"Reads and enables pagination through a set of \`ChildNoRelatedFilter\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`ChildNoRelatedFilter\`."""
   childNoRelatedFiltersByUnfilterableId(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: ChildNoRelatedFilterFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`ChildNoRelatedFilter\`.\\"\\"\\"
+    """The method to use when ordering \`ChildNoRelatedFilter\`."""
     orderBy: [ChildNoRelatedFiltersOrderBy!] = [PRIMARY_KEY_ASC]
   ): ChildNoRelatedFiltersConnection!
   id: Int!
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
   text: String
 }
 
-\\"\\"\\"A connection to a list of \`Unfilterable\` values.\\"\\"\\"
+"""A connection to a list of \`Unfilterable\` values."""
 type UnfilterablesConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`Unfilterable\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [UnfilterablesEdge!]!
 
-  \\"\\"\\"A list of \`Unfilterable\` objects.\\"\\"\\"
+  """A list of \`Unfilterable\` objects."""
   nodes: [Unfilterable]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`Unfilterable\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`Unfilterable\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`Unfilterable\` edge in the connection.\\"\\"\\"
+"""A \`Unfilterable\` edge in the connection."""
 type UnfilterablesEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`Unfilterable\` at the end of the edge.\\"\\"\\"
+  """The \`Unfilterable\` at the end of the edge."""
   node: Unfilterable
 }
 
-\\"\\"\\"Methods to use when ordering \`Unfilterable\`.\\"\\"\\"
+"""Methods to use when ordering \`Unfilterable\`."""
 enum UnfilterablesOrderBy {
   ID_ASC
   ID_DESC
@@ -4923,51 +4923,51 @@ enum UnfilterablesOrderBy {
   TEXT_DESC
 }
 
-\\"\\"\\"
+"""
 A universally unique identifier as defined by [RFC 4122](https://tools.ietf.org/html/rfc4122).
-\\"\\"\\"
+"""
 scalar UUID
 
-\\"\\"\\"
+"""
 A filter to be used against UUID fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input UUIDFilter {
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: UUID
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: UUID
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: UUID
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: UUID
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [UUID!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: UUID
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: UUID
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: UUID
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: UUID
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [UUID!]
 }
-"
+
 `;

--- a/__tests__/integration/schema/__snapshots__/computedColumnsFalse.test.ts.snap
+++ b/__tests__/integration/schema/__snapshots__/computedColumnsFalse.test.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`prints a schema with the filter plugin and the \`connectionFilterComputedColumns: false\` option 1`] = `
-"type ArrayType implements Node {
+type ArrayType implements Node {
   bit4Array: [BitString]
   boolArray: [Boolean]
   bpchar4Array: [String]
@@ -25,9 +25,9 @@ exports[`prints a schema with the filter plugin and the \`connectionFilterComput
   moneyArray: [Float]
   nameArray: [String]
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
   numericArray: [BigFloat]
   textArray: [String]
@@ -41,128 +41,128 @@ exports[`prints a schema with the filter plugin and the \`connectionFilterComput
   xmlArray: [String]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`ArrayType\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input ArrayTypeFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [ArrayTypeFilter!]
 
-  \\"\\"\\"Filter by the object’s \`bit4Array\` field.\\"\\"\\"
+  """Filter by the object’s \`bit4Array\` field."""
   bit4Array: BitStringListFilter
 
-  \\"\\"\\"Filter by the object’s \`boolArray\` field.\\"\\"\\"
+  """Filter by the object’s \`boolArray\` field."""
   boolArray: BooleanListFilter
 
-  \\"\\"\\"Filter by the object’s \`bpchar4Array\` field.\\"\\"\\"
+  """Filter by the object’s \`bpchar4Array\` field."""
   bpchar4Array: StringListFilter
 
-  \\"\\"\\"Filter by the object’s \`char4Array\` field.\\"\\"\\"
+  """Filter by the object’s \`char4Array\` field."""
   char4Array: StringListFilter
 
-  \\"\\"\\"Filter by the object’s \`citextArray\` field.\\"\\"\\"
+  """Filter by the object’s \`citextArray\` field."""
   citextArray: StringListFilter
 
-  \\"\\"\\"Filter by the object’s \`dateArray\` field.\\"\\"\\"
+  """Filter by the object’s \`dateArray\` field."""
   dateArray: DateListFilter
 
-  \\"\\"\\"Filter by the object’s \`float4Array\` field.\\"\\"\\"
+  """Filter by the object’s \`float4Array\` field."""
   float4Array: FloatListFilter
 
-  \\"\\"\\"Filter by the object’s \`float8Array\` field.\\"\\"\\"
+  """Filter by the object’s \`float8Array\` field."""
   float8Array: FloatListFilter
 
-  \\"\\"\\"Filter by the object’s \`hstoreArray\` field.\\"\\"\\"
+  """Filter by the object’s \`hstoreArray\` field."""
   hstoreArray: KeyValueHashListFilter
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`inetArray\` field.\\"\\"\\"
+  """Filter by the object’s \`inetArray\` field."""
   inetArray: InternetAddressListFilter
 
-  \\"\\"\\"Filter by the object’s \`int2Array\` field.\\"\\"\\"
+  """Filter by the object’s \`int2Array\` field."""
   int2Array: IntListFilter
 
-  \\"\\"\\"Filter by the object’s \`int4Array\` field.\\"\\"\\"
+  """Filter by the object’s \`int4Array\` field."""
   int4Array: IntListFilter
 
-  \\"\\"\\"Filter by the object’s \`int8Array\` field.\\"\\"\\"
+  """Filter by the object’s \`int8Array\` field."""
   int8Array: BigIntListFilter
 
-  \\"\\"\\"Filter by the object’s \`intervalArray\` field.\\"\\"\\"
+  """Filter by the object’s \`intervalArray\` field."""
   intervalArray: IntervalListFilter
 
-  \\"\\"\\"Filter by the object’s \`jsonbArray\` field.\\"\\"\\"
+  """Filter by the object’s \`jsonbArray\` field."""
   jsonbArray: JSONListFilter
 
-  \\"\\"\\"Filter by the object’s \`moneyArray\` field.\\"\\"\\"
+  """Filter by the object’s \`moneyArray\` field."""
   moneyArray: FloatListFilter
 
-  \\"\\"\\"Filter by the object’s \`nameArray\` field.\\"\\"\\"
+  """Filter by the object’s \`nameArray\` field."""
   nameArray: StringListFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: ArrayTypeFilter
 
-  \\"\\"\\"Filter by the object’s \`numericArray\` field.\\"\\"\\"
+  """Filter by the object’s \`numericArray\` field."""
   numericArray: BigFloatListFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [ArrayTypeFilter!]
 
-  \\"\\"\\"Filter by the object’s \`textArray\` field.\\"\\"\\"
+  """Filter by the object’s \`textArray\` field."""
   textArray: StringListFilter
 
-  \\"\\"\\"Filter by the object’s \`timeArray\` field.\\"\\"\\"
+  """Filter by the object’s \`timeArray\` field."""
   timeArray: TimeListFilter
 
-  \\"\\"\\"Filter by the object’s \`timestampArray\` field.\\"\\"\\"
+  """Filter by the object’s \`timestampArray\` field."""
   timestampArray: DatetimeListFilter
 
-  \\"\\"\\"Filter by the object’s \`timestamptzArray\` field.\\"\\"\\"
+  """Filter by the object’s \`timestamptzArray\` field."""
   timestamptzArray: DatetimeListFilter
 
-  \\"\\"\\"Filter by the object’s \`timetzArray\` field.\\"\\"\\"
+  """Filter by the object’s \`timetzArray\` field."""
   timetzArray: TimeListFilter
 
-  \\"\\"\\"Filter by the object’s \`uuidArray\` field.\\"\\"\\"
+  """Filter by the object’s \`uuidArray\` field."""
   uuidArray: UUIDListFilter
 
-  \\"\\"\\"Filter by the object’s \`varbitArray\` field.\\"\\"\\"
+  """Filter by the object’s \`varbitArray\` field."""
   varbitArray: BitStringListFilter
 
-  \\"\\"\\"Filter by the object’s \`varcharArray\` field.\\"\\"\\"
+  """Filter by the object’s \`varcharArray\` field."""
   varcharArray: StringListFilter
 }
 
-\\"\\"\\"A connection to a list of \`ArrayType\` values.\\"\\"\\"
+"""A connection to a list of \`ArrayType\` values."""
 type ArrayTypesConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`ArrayType\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [ArrayTypesEdge!]!
 
-  \\"\\"\\"A list of \`ArrayType\` objects.\\"\\"\\"
+  """A list of \`ArrayType\` objects."""
   nodes: [ArrayType]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`ArrayType\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`ArrayType\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`ArrayType\` edge in the connection.\\"\\"\\"
+"""A \`ArrayType\` edge in the connection."""
 type ArrayTypesEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`ArrayType\` at the end of the edge.\\"\\"\\"
+  """The \`ArrayType\` at the end of the edge."""
   node: ArrayType
 }
 
-\\"\\"\\"Methods to use when ordering \`ArrayType\`.\\"\\"\\"
+"""Methods to use when ordering \`ArrayType\`."""
 enum ArrayTypesOrderBy {
   BIT4_ARRAY_ASC
   BIT4_ARRAY_DESC
@@ -234,15 +234,15 @@ enum ArrayTypesOrderBy {
 }
 
 type Backward implements Node {
-  \\"\\"\\"Reads a single \`Filterable\` that is related to this \`Backward\`.\\"\\"\\"
+  """Reads a single \`Filterable\` that is related to this \`Backward\`."""
   filterableByFilterableId: Filterable
   filterableId: Int
   id: Int!
   name: String!
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
@@ -250,70 +250,70 @@ type BackwardCompound implements Node {
   backwardCompound1: Int!
   backwardCompound2: Int!
 
-  \\"\\"\\"
+  """
   Reads a single \`Filterable\` that is related to this \`BackwardCompound\`.
-  \\"\\"\\"
+  """
   filterableByBackwardCompound1AndBackwardCompound2: Filterable
   name: String
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`BackwardCompound\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input BackwardCompoundFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [BackwardCompoundFilter!]
 
-  \\"\\"\\"Filter by the object’s \`backwardCompound1\` field.\\"\\"\\"
+  """Filter by the object’s \`backwardCompound1\` field."""
   backwardCompound1: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`backwardCompound2\` field.\\"\\"\\"
+  """Filter by the object’s \`backwardCompound2\` field."""
   backwardCompound2: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`name\` field.\\"\\"\\"
+  """Filter by the object’s \`name\` field."""
   name: StringFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: BackwardCompoundFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [BackwardCompoundFilter!]
 }
 
-\\"\\"\\"A connection to a list of \`BackwardCompound\` values.\\"\\"\\"
+"""A connection to a list of \`BackwardCompound\` values."""
 type BackwardCompoundsConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`BackwardCompound\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [BackwardCompoundsEdge!]!
 
-  \\"\\"\\"A list of \`BackwardCompound\` objects.\\"\\"\\"
+  """A list of \`BackwardCompound\` objects."""
   nodes: [BackwardCompound]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"
+  """
   The count of *all* \`BackwardCompound\` you could get from the connection.
-  \\"\\"\\"
+  """
   totalCount: Int!
 }
 
-\\"\\"\\"A \`BackwardCompound\` edge in the connection.\\"\\"\\"
+"""A \`BackwardCompound\` edge in the connection."""
 type BackwardCompoundsEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`BackwardCompound\` at the end of the edge.\\"\\"\\"
+  """The \`BackwardCompound\` at the end of the edge."""
   node: BackwardCompound
 }
 
-\\"\\"\\"Methods to use when ordering \`BackwardCompound\`.\\"\\"\\"
+"""Methods to use when ordering \`BackwardCompound\`."""
 enum BackwardCompoundsOrderBy {
   BACKWARD_COMPOUND_1_ASC
   BACKWARD_COMPOUND_1_DESC
@@ -326,56 +326,56 @@ enum BackwardCompoundsOrderBy {
   PRIMARY_KEY_DESC
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`Backward\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input BackwardFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [BackwardFilter!]
 
-  \\"\\"\\"Filter by the object’s \`filterableId\` field.\\"\\"\\"
+  """Filter by the object’s \`filterableId\` field."""
   filterableId: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`name\` field.\\"\\"\\"
+  """Filter by the object’s \`name\` field."""
   name: StringFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: BackwardFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [BackwardFilter!]
 }
 
-\\"\\"\\"A connection to a list of \`Backward\` values.\\"\\"\\"
+"""A connection to a list of \`Backward\` values."""
 type BackwardsConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`Backward\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [BackwardsEdge!]!
 
-  \\"\\"\\"A list of \`Backward\` objects.\\"\\"\\"
+  """A list of \`Backward\` objects."""
   nodes: [Backward]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`Backward\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`Backward\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`Backward\` edge in the connection.\\"\\"\\"
+"""A \`Backward\` edge in the connection."""
 type BackwardsEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`Backward\` at the end of the edge.\\"\\"\\"
+  """The \`Backward\` at the end of the edge."""
   node: Backward
 }
 
-\\"\\"\\"Methods to use when ordering \`Backward\`.\\"\\"\\"
+"""Methods to use when ordering \`Backward\`."""
 enum BackwardsOrderBy {
   FILTERABLE_ID_ASC
   FILTERABLE_ID_DESC
@@ -388,1037 +388,1037 @@ enum BackwardsOrderBy {
   PRIMARY_KEY_DESC
 }
 
-\\"\\"\\"
+"""
 A floating point number that requires more precision than IEEE 754 binary 64
-\\"\\"\\"
+"""
 scalar BigFloat
 
-\\"\\"\\"
+"""
 A filter to be used against BigFloat fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input BigFloatFilter {
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: BigFloat
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: BigFloat
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: BigFloat
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: BigFloat
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [BigFloat!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: BigFloat
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: BigFloat
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: BigFloat
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: BigFloat
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [BigFloat!]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against BigFloat List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input BigFloatListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: BigFloat
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: BigFloat
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: BigFloat
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: BigFloat
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: BigFloat
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: BigFloat
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [BigFloat]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [BigFloat]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [BigFloat]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [BigFloat]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [BigFloat]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [BigFloat]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [BigFloat]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [BigFloat]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [BigFloat]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [BigFloat]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [BigFloat]
 }
 
-\\"\\"\\"A range of \`BigFloat\`.\\"\\"\\"
+"""A range of \`BigFloat\`."""
 type BigFloatRange {
-  \\"\\"\\"The ending bound of our range.\\"\\"\\"
+  """The ending bound of our range."""
   end: BigFloatRangeBound
 
-  \\"\\"\\"The starting bound of our range.\\"\\"\\"
+  """The starting bound of our range."""
   start: BigFloatRangeBound
 }
 
-\\"\\"\\"
+"""
 The value at one end of a range. A range can either include this value, or not.
-\\"\\"\\"
+"""
 type BigFloatRangeBound {
-  \\"\\"\\"Whether or not the value of this bound is included in the range.\\"\\"\\"
+  """Whether or not the value of this bound is included in the range."""
   inclusive: Boolean!
 
-  \\"\\"\\"The value at one end of our range.\\"\\"\\"
+  """The value at one end of our range."""
   value: BigFloat!
 }
 
-\\"\\"\\"
+"""
 The value at one end of a range. A range can either include this value, or not.
-\\"\\"\\"
+"""
 input BigFloatRangeBoundInput {
-  \\"\\"\\"Whether or not the value of this bound is included in the range.\\"\\"\\"
+  """Whether or not the value of this bound is included in the range."""
   inclusive: Boolean!
 
-  \\"\\"\\"The value at one end of our range.\\"\\"\\"
+  """The value at one end of our range."""
   value: BigFloat!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against BigFloatRange fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input BigFloatRangeFilter {
-  \\"\\"\\"Adjacent to the specified range.\\"\\"\\"
+  """Adjacent to the specified range."""
   adjacentTo: BigFloatRangeInput
 
-  \\"\\"\\"Contained by the specified range.\\"\\"\\"
+  """Contained by the specified range."""
   containedBy: BigFloatRangeInput
 
-  \\"\\"\\"Contains the specified range.\\"\\"\\"
+  """Contains the specified range."""
   contains: BigFloatRangeInput
 
-  \\"\\"\\"Contains the specified value.\\"\\"\\"
+  """Contains the specified value."""
   containsElement: BigFloat
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: BigFloatRangeInput
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: BigFloatRangeInput
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: BigFloatRangeInput
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: BigFloatRangeInput
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [BigFloatRangeInput!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: BigFloatRangeInput
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: BigFloatRangeInput
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: BigFloatRangeInput
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: BigFloatRangeInput
 
-  \\"\\"\\"Does not extend left of the specified range.\\"\\"\\"
+  """Does not extend left of the specified range."""
   notExtendsLeftOf: BigFloatRangeInput
 
-  \\"\\"\\"Does not extend right of the specified range.\\"\\"\\"
+  """Does not extend right of the specified range."""
   notExtendsRightOf: BigFloatRangeInput
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [BigFloatRangeInput!]
 
-  \\"\\"\\"Overlaps the specified range.\\"\\"\\"
+  """Overlaps the specified range."""
   overlaps: BigFloatRangeInput
 
-  \\"\\"\\"Strictly left of the specified range.\\"\\"\\"
+  """Strictly left of the specified range."""
   strictlyLeftOf: BigFloatRangeInput
 
-  \\"\\"\\"Strictly right of the specified range.\\"\\"\\"
+  """Strictly right of the specified range."""
   strictlyRightOf: BigFloatRangeInput
 }
 
-\\"\\"\\"A range of \`BigFloat\`.\\"\\"\\"
+"""A range of \`BigFloat\`."""
 input BigFloatRangeInput {
-  \\"\\"\\"The ending bound of our range.\\"\\"\\"
+  """The ending bound of our range."""
   end: BigFloatRangeBoundInput
 
-  \\"\\"\\"The starting bound of our range.\\"\\"\\"
+  """The starting bound of our range."""
   start: BigFloatRangeBoundInput
 }
 
-\\"\\"\\"
+"""
 A filter to be used against BigFloatRange List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input BigFloatRangeListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: BigFloatRangeInput
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: BigFloatRangeInput
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: BigFloatRangeInput
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: BigFloatRangeInput
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: BigFloatRangeInput
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: BigFloatRangeInput
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [BigFloatRangeInput]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [BigFloatRangeInput]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [BigFloatRangeInput]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [BigFloatRangeInput]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [BigFloatRangeInput]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [BigFloatRangeInput]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [BigFloatRangeInput]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [BigFloatRangeInput]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [BigFloatRangeInput]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [BigFloatRangeInput]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [BigFloatRangeInput]
 }
 
-\\"\\"\\"
+"""
 A signed eight-byte integer. The upper big integer values are greater than the
 max value for a JavaScript number. Therefore all big integers will be output as
 strings and not numbers.
-\\"\\"\\"
+"""
 scalar BigInt
 
-\\"\\"\\"
+"""
 A filter to be used against BigInt fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input BigIntFilter {
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: BigInt
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: BigInt
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: BigInt
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: BigInt
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [BigInt!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: BigInt
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: BigInt
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: BigInt
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: BigInt
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [BigInt!]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against BigInt List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input BigIntListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: BigInt
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: BigInt
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: BigInt
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: BigInt
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: BigInt
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: BigInt
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [BigInt]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [BigInt]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [BigInt]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [BigInt]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [BigInt]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [BigInt]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [BigInt]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [BigInt]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [BigInt]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [BigInt]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [BigInt]
 }
 
-\\"\\"\\"A range of \`BigInt\`.\\"\\"\\"
+"""A range of \`BigInt\`."""
 type BigIntRange {
-  \\"\\"\\"The ending bound of our range.\\"\\"\\"
+  """The ending bound of our range."""
   end: BigIntRangeBound
 
-  \\"\\"\\"The starting bound of our range.\\"\\"\\"
+  """The starting bound of our range."""
   start: BigIntRangeBound
 }
 
-\\"\\"\\"
+"""
 The value at one end of a range. A range can either include this value, or not.
-\\"\\"\\"
+"""
 type BigIntRangeBound {
-  \\"\\"\\"Whether or not the value of this bound is included in the range.\\"\\"\\"
+  """Whether or not the value of this bound is included in the range."""
   inclusive: Boolean!
 
-  \\"\\"\\"The value at one end of our range.\\"\\"\\"
+  """The value at one end of our range."""
   value: BigInt!
 }
 
-\\"\\"\\"
+"""
 The value at one end of a range. A range can either include this value, or not.
-\\"\\"\\"
+"""
 input BigIntRangeBoundInput {
-  \\"\\"\\"Whether or not the value of this bound is included in the range.\\"\\"\\"
+  """Whether or not the value of this bound is included in the range."""
   inclusive: Boolean!
 
-  \\"\\"\\"The value at one end of our range.\\"\\"\\"
+  """The value at one end of our range."""
   value: BigInt!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against BigIntRange fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input BigIntRangeFilter {
-  \\"\\"\\"Adjacent to the specified range.\\"\\"\\"
+  """Adjacent to the specified range."""
   adjacentTo: BigIntRangeInput
 
-  \\"\\"\\"Contained by the specified range.\\"\\"\\"
+  """Contained by the specified range."""
   containedBy: BigIntRangeInput
 
-  \\"\\"\\"Contains the specified range.\\"\\"\\"
+  """Contains the specified range."""
   contains: BigIntRangeInput
 
-  \\"\\"\\"Contains the specified value.\\"\\"\\"
+  """Contains the specified value."""
   containsElement: BigInt
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: BigIntRangeInput
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: BigIntRangeInput
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: BigIntRangeInput
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: BigIntRangeInput
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [BigIntRangeInput!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: BigIntRangeInput
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: BigIntRangeInput
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: BigIntRangeInput
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: BigIntRangeInput
 
-  \\"\\"\\"Does not extend left of the specified range.\\"\\"\\"
+  """Does not extend left of the specified range."""
   notExtendsLeftOf: BigIntRangeInput
 
-  \\"\\"\\"Does not extend right of the specified range.\\"\\"\\"
+  """Does not extend right of the specified range."""
   notExtendsRightOf: BigIntRangeInput
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [BigIntRangeInput!]
 
-  \\"\\"\\"Overlaps the specified range.\\"\\"\\"
+  """Overlaps the specified range."""
   overlaps: BigIntRangeInput
 
-  \\"\\"\\"Strictly left of the specified range.\\"\\"\\"
+  """Strictly left of the specified range."""
   strictlyLeftOf: BigIntRangeInput
 
-  \\"\\"\\"Strictly right of the specified range.\\"\\"\\"
+  """Strictly right of the specified range."""
   strictlyRightOf: BigIntRangeInput
 }
 
-\\"\\"\\"A range of \`BigInt\`.\\"\\"\\"
+"""A range of \`BigInt\`."""
 input BigIntRangeInput {
-  \\"\\"\\"The ending bound of our range.\\"\\"\\"
+  """The ending bound of our range."""
   end: BigIntRangeBoundInput
 
-  \\"\\"\\"The starting bound of our range.\\"\\"\\"
+  """The starting bound of our range."""
   start: BigIntRangeBoundInput
 }
 
-\\"\\"\\"
+"""
 A filter to be used against BigIntRange List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input BigIntRangeListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: BigIntRangeInput
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: BigIntRangeInput
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: BigIntRangeInput
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: BigIntRangeInput
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: BigIntRangeInput
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: BigIntRangeInput
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [BigIntRangeInput]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [BigIntRangeInput]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [BigIntRangeInput]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [BigIntRangeInput]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [BigIntRangeInput]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [BigIntRangeInput]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [BigIntRangeInput]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [BigIntRangeInput]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [BigIntRangeInput]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [BigIntRangeInput]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [BigIntRangeInput]
 }
 
-\\"\\"\\"A string representing a series of binary bits\\"\\"\\"
+"""A string representing a series of binary bits"""
 scalar BitString
 
-\\"\\"\\"
+"""
 A filter to be used against BitString fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input BitStringFilter {
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: BitString
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: BitString
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: BitString
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: BitString
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [BitString!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: BitString
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: BitString
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: BitString
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: BitString
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [BitString!]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against BitString List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input BitStringListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: BitString
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: BitString
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: BitString
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: BitString
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: BitString
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: BitString
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [BitString]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [BitString]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [BitString]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [BitString]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [BitString]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [BitString]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [BitString]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [BitString]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [BitString]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [BitString]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [BitString]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against Boolean fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input BooleanFilter {
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: Boolean
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: Boolean
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: Boolean
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: Boolean
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [Boolean!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: Boolean
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: Boolean
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: Boolean
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: Boolean
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [Boolean!]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against Boolean List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input BooleanListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: Boolean
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: Boolean
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: Boolean
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: Boolean
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: Boolean
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: Boolean
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [Boolean]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [Boolean]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [Boolean]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [Boolean]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [Boolean]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [Boolean]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [Boolean]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [Boolean]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [Boolean]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [Boolean]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [Boolean]
 }
 
 scalar Char4Domain
 
-\\"\\"\\"
+"""
 A filter to be used against Char4Domain fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input Char4DomainFilter {
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: Char4Domain
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value (case-insensitive).
-  \\"\\"\\"
+  """
   distinctFromInsensitive: Char4Domain
 
-  \\"\\"\\"Ends with the specified string (case-sensitive).\\"\\"\\"
+  """Ends with the specified string (case-sensitive)."""
   endsWith: Char4Domain
 
-  \\"\\"\\"Ends with the specified string (case-insensitive).\\"\\"\\"
+  """Ends with the specified string (case-insensitive)."""
   endsWithInsensitive: Char4Domain
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: Char4Domain
 
-  \\"\\"\\"Equal to the specified value (case-insensitive).\\"\\"\\"
+  """Equal to the specified value (case-insensitive)."""
   equalToInsensitive: Char4Domain
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: Char4Domain
 
-  \\"\\"\\"Greater than the specified value (case-insensitive).\\"\\"\\"
+  """Greater than the specified value (case-insensitive)."""
   greaterThanInsensitive: Char4Domain
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: Char4Domain
 
-  \\"\\"\\"Greater than or equal to the specified value (case-insensitive).\\"\\"\\"
+  """Greater than or equal to the specified value (case-insensitive)."""
   greaterThanOrEqualToInsensitive: Char4Domain
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [Char4Domain!]
 
-  \\"\\"\\"Included in the specified list (case-insensitive).\\"\\"\\"
-  inInsensitive: [Char4Domain!]
-
-  \\"\\"\\"Contains the specified string (case-sensitive).\\"\\"\\"
+  """Contains the specified string (case-sensitive)."""
   includes: Char4Domain
 
-  \\"\\"\\"Contains the specified string (case-insensitive).\\"\\"\\"
+  """Contains the specified string (case-insensitive)."""
   includesInsensitive: Char4Domain
 
-  \\"\\"\\"
+  """Included in the specified list (case-insensitive)."""
+  inInsensitive: [Char4Domain!]
+
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: Char4Domain
 
-  \\"\\"\\"Less than the specified value (case-insensitive).\\"\\"\\"
+  """Less than the specified value (case-insensitive)."""
   lessThanInsensitive: Char4Domain
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: Char4Domain
 
-  \\"\\"\\"Less than or equal to the specified value (case-insensitive).\\"\\"\\"
+  """Less than or equal to the specified value (case-insensitive)."""
   lessThanOrEqualToInsensitive: Char4Domain
 
-  \\"\\"\\"
+  """
   Matches the specified pattern (case-sensitive). An underscore (_) matches any
   single character; a percent sign (%) matches any sequence of zero or more characters.
-  \\"\\"\\"
+  """
   like: Char4Domain
 
-  \\"\\"\\"
+  """
   Matches the specified pattern (case-insensitive). An underscore (_) matches
   any single character; a percent sign (%) matches any sequence of zero or more characters.
-  \\"\\"\\"
+  """
   likeInsensitive: Char4Domain
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: Char4Domain
 
-  \\"\\"\\"
+  """
   Equal to the specified value, treating null like an ordinary value (case-insensitive).
-  \\"\\"\\"
+  """
   notDistinctFromInsensitive: Char4Domain
 
-  \\"\\"\\"Does not end with the specified string (case-sensitive).\\"\\"\\"
+  """Does not end with the specified string (case-sensitive)."""
   notEndsWith: Char4Domain
 
-  \\"\\"\\"Does not end with the specified string (case-insensitive).\\"\\"\\"
+  """Does not end with the specified string (case-insensitive)."""
   notEndsWithInsensitive: Char4Domain
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: Char4Domain
 
-  \\"\\"\\"Not equal to the specified value (case-insensitive).\\"\\"\\"
+  """Not equal to the specified value (case-insensitive)."""
   notEqualToInsensitive: Char4Domain
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [Char4Domain!]
 
-  \\"\\"\\"Not included in the specified list (case-insensitive).\\"\\"\\"
-  notInInsensitive: [Char4Domain!]
-
-  \\"\\"\\"Does not contain the specified string (case-sensitive).\\"\\"\\"
+  """Does not contain the specified string (case-sensitive)."""
   notIncludes: Char4Domain
 
-  \\"\\"\\"Does not contain the specified string (case-insensitive).\\"\\"\\"
+  """Does not contain the specified string (case-insensitive)."""
   notIncludesInsensitive: Char4Domain
 
-  \\"\\"\\"
+  """Not included in the specified list (case-insensitive)."""
+  notInInsensitive: [Char4Domain!]
+
+  """
   Does not match the specified pattern (case-sensitive). An underscore (_)
   matches any single character; a percent sign (%) matches any sequence of zero
   or more characters.
-  \\"\\"\\"
+  """
   notLike: Char4Domain
 
-  \\"\\"\\"
+  """
   Does not match the specified pattern (case-insensitive). An underscore (_)
   matches any single character; a percent sign (%) matches any sequence of zero
   or more characters.
-  \\"\\"\\"
+  """
   notLikeInsensitive: Char4Domain
 
-  \\"\\"\\"Does not start with the specified string (case-sensitive).\\"\\"\\"
+  """Does not start with the specified string (case-sensitive)."""
   notStartsWith: Char4Domain
 
-  \\"\\"\\"Does not start with the specified string (case-insensitive).\\"\\"\\"
+  """Does not start with the specified string (case-insensitive)."""
   notStartsWithInsensitive: Char4Domain
 
-  \\"\\"\\"Starts with the specified string (case-sensitive).\\"\\"\\"
+  """Starts with the specified string (case-sensitive)."""
   startsWith: Char4Domain
 
-  \\"\\"\\"Starts with the specified string (case-insensitive).\\"\\"\\"
+  """Starts with the specified string (case-insensitive)."""
   startsWithInsensitive: Char4Domain
 }
 
 type Child implements Node {
-  \\"\\"\\"Reads a single \`Filterable\` that is related to this \`Child\`.\\"\\"\\"
+  """Reads a single \`Filterable\` that is related to this \`Child\`."""
   filterableByFilterableId: Filterable
   filterableId: Int
   id: Int!
   name: String!
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`Child\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input ChildFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [ChildFilter!]
 
-  \\"\\"\\"Filter by the object’s \`filterableId\` field.\\"\\"\\"
+  """Filter by the object’s \`filterableId\` field."""
   filterableId: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`name\` field.\\"\\"\\"
+  """Filter by the object’s \`name\` field."""
   name: StringFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: ChildFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [ChildFilter!]
 }
 
 type ChildNoRelatedFilter implements Node {
-  \\"\\"\\"
+  """
   Reads a single \`Filterable\` that is related to this \`ChildNoRelatedFilter\`.
-  \\"\\"\\"
+  """
   filterableByFilterableId: Filterable
   filterableId: Int
   id: Int!
   name: String!
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 
-  \\"\\"\\"
+  """
   Reads a single \`Unfilterable\` that is related to this \`ChildNoRelatedFilter\`.
-  \\"\\"\\"
+  """
   unfilterableByUnfilterableId: Unfilterable
   unfilterableId: Int
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`ChildNoRelatedFilter\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input ChildNoRelatedFilterFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [ChildNoRelatedFilterFilter!]
 
-  \\"\\"\\"Filter by the object’s \`filterableId\` field.\\"\\"\\"
+  """Filter by the object’s \`filterableId\` field."""
   filterableId: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`name\` field.\\"\\"\\"
+  """Filter by the object’s \`name\` field."""
   name: StringFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: ChildNoRelatedFilterFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [ChildNoRelatedFilterFilter!]
 
-  \\"\\"\\"Filter by the object’s \`unfilterableId\` field.\\"\\"\\"
+  """Filter by the object’s \`unfilterableId\` field."""
   unfilterableId: IntFilter
 }
 
-\\"\\"\\"A connection to a list of \`ChildNoRelatedFilter\` values.\\"\\"\\"
+"""A connection to a list of \`ChildNoRelatedFilter\` values."""
 type ChildNoRelatedFiltersConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`ChildNoRelatedFilter\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [ChildNoRelatedFiltersEdge!]!
 
-  \\"\\"\\"A list of \`ChildNoRelatedFilter\` objects.\\"\\"\\"
+  """A list of \`ChildNoRelatedFilter\` objects."""
   nodes: [ChildNoRelatedFilter]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"
+  """
   The count of *all* \`ChildNoRelatedFilter\` you could get from the connection.
-  \\"\\"\\"
+  """
   totalCount: Int!
 }
 
-\\"\\"\\"A \`ChildNoRelatedFilter\` edge in the connection.\\"\\"\\"
+"""A \`ChildNoRelatedFilter\` edge in the connection."""
 type ChildNoRelatedFiltersEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`ChildNoRelatedFilter\` at the end of the edge.\\"\\"\\"
+  """The \`ChildNoRelatedFilter\` at the end of the edge."""
   node: ChildNoRelatedFilter
 }
 
-\\"\\"\\"Methods to use when ordering \`ChildNoRelatedFilter\`.\\"\\"\\"
+"""Methods to use when ordering \`ChildNoRelatedFilter\`."""
 enum ChildNoRelatedFiltersOrderBy {
   FILTERABLE_ID_ASC
   FILTERABLE_ID_DESC
@@ -1433,33 +1433,33 @@ enum ChildNoRelatedFiltersOrderBy {
   UNFILTERABLE_ID_DESC
 }
 
-\\"\\"\\"A connection to a list of \`Child\` values.\\"\\"\\"
+"""A connection to a list of \`Child\` values."""
 type ChildrenConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`Child\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [ChildrenEdge!]!
 
-  \\"\\"\\"A list of \`Child\` objects.\\"\\"\\"
+  """A list of \`Child\` objects."""
   nodes: [Child]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`Child\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`Child\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`Child\` edge in the connection.\\"\\"\\"
+"""A \`Child\` edge in the connection."""
 type ChildrenEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`Child\` at the end of the edge.\\"\\"\\"
+  """The \`Child\` at the end of the edge."""
   node: Child
 }
 
-\\"\\"\\"Methods to use when ordering \`Child\`.\\"\\"\\"
+"""Methods to use when ordering \`Child\`."""
 enum ChildrenOrderBy {
   FILTERABLE_ID_ASC
   FILTERABLE_ID_DESC
@@ -1477,633 +1477,633 @@ type Composite {
   b: String
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`Composite\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input CompositeFilter {
-  \\"\\"\\"Filter by the object’s \`a\` field.\\"\\"\\"
+  """Filter by the object’s \`a\` field."""
   a: IntFilter
 
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [CompositeFilter!]
 
-  \\"\\"\\"Filter by the object’s \`b\` field.\\"\\"\\"
+  """Filter by the object’s \`b\` field."""
   b: StringFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: CompositeFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [CompositeFilter!]
 }
 
-\\"\\"\\"A location in a connection that can be used for resuming pagination.\\"\\"\\"
+"""A location in a connection that can be used for resuming pagination."""
 scalar Cursor
 
-\\"\\"\\"The day, does not include a time.\\"\\"\\"
+"""The day, does not include a time."""
 scalar Date
 
 scalar DateDomain
 
-\\"\\"\\"
+"""
 A filter to be used against DateDomain fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input DateDomainFilter {
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: DateDomain
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: DateDomain
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: DateDomain
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: DateDomain
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [DateDomain!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: DateDomain
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: DateDomain
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: DateDomain
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: DateDomain
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [DateDomain!]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against Date fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input DateFilter {
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: Date
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: Date
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: Date
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: Date
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [Date!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: Date
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: Date
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: Date
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: Date
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [Date!]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against Date List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input DateListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: Date
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: Date
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: Date
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: Date
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: Date
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: Date
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [Date]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [Date]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [Date]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [Date]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [Date]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [Date]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [Date]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [Date]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [Date]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [Date]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [Date]
 }
 
-\\"\\"\\"A range of \`Date\`.\\"\\"\\"
+"""A range of \`Date\`."""
 type DateRange {
-  \\"\\"\\"The ending bound of our range.\\"\\"\\"
+  """The ending bound of our range."""
   end: DateRangeBound
 
-  \\"\\"\\"The starting bound of our range.\\"\\"\\"
+  """The starting bound of our range."""
   start: DateRangeBound
 }
 
-\\"\\"\\"
+"""
 The value at one end of a range. A range can either include this value, or not.
-\\"\\"\\"
+"""
 type DateRangeBound {
-  \\"\\"\\"Whether or not the value of this bound is included in the range.\\"\\"\\"
+  """Whether or not the value of this bound is included in the range."""
   inclusive: Boolean!
 
-  \\"\\"\\"The value at one end of our range.\\"\\"\\"
+  """The value at one end of our range."""
   value: Date!
 }
 
-\\"\\"\\"
+"""
 The value at one end of a range. A range can either include this value, or not.
-\\"\\"\\"
+"""
 input DateRangeBoundInput {
-  \\"\\"\\"Whether or not the value of this bound is included in the range.\\"\\"\\"
+  """Whether or not the value of this bound is included in the range."""
   inclusive: Boolean!
 
-  \\"\\"\\"The value at one end of our range.\\"\\"\\"
+  """The value at one end of our range."""
   value: Date!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against DateRange fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input DateRangeFilter {
-  \\"\\"\\"Adjacent to the specified range.\\"\\"\\"
+  """Adjacent to the specified range."""
   adjacentTo: DateRangeInput
 
-  \\"\\"\\"Contained by the specified range.\\"\\"\\"
+  """Contained by the specified range."""
   containedBy: DateRangeInput
 
-  \\"\\"\\"Contains the specified range.\\"\\"\\"
+  """Contains the specified range."""
   contains: DateRangeInput
 
-  \\"\\"\\"Contains the specified value.\\"\\"\\"
+  """Contains the specified value."""
   containsElement: Date
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: DateRangeInput
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: DateRangeInput
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: DateRangeInput
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: DateRangeInput
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [DateRangeInput!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: DateRangeInput
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: DateRangeInput
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: DateRangeInput
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: DateRangeInput
 
-  \\"\\"\\"Does not extend left of the specified range.\\"\\"\\"
+  """Does not extend left of the specified range."""
   notExtendsLeftOf: DateRangeInput
 
-  \\"\\"\\"Does not extend right of the specified range.\\"\\"\\"
+  """Does not extend right of the specified range."""
   notExtendsRightOf: DateRangeInput
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [DateRangeInput!]
 
-  \\"\\"\\"Overlaps the specified range.\\"\\"\\"
+  """Overlaps the specified range."""
   overlaps: DateRangeInput
 
-  \\"\\"\\"Strictly left of the specified range.\\"\\"\\"
+  """Strictly left of the specified range."""
   strictlyLeftOf: DateRangeInput
 
-  \\"\\"\\"Strictly right of the specified range.\\"\\"\\"
+  """Strictly right of the specified range."""
   strictlyRightOf: DateRangeInput
 }
 
-\\"\\"\\"A range of \`Date\`.\\"\\"\\"
+"""A range of \`Date\`."""
 input DateRangeInput {
-  \\"\\"\\"The ending bound of our range.\\"\\"\\"
+  """The ending bound of our range."""
   end: DateRangeBoundInput
 
-  \\"\\"\\"The starting bound of our range.\\"\\"\\"
+  """The starting bound of our range."""
   start: DateRangeBoundInput
 }
 
-\\"\\"\\"
+"""
 A filter to be used against DateRange List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input DateRangeListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: DateRangeInput
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: DateRangeInput
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: DateRangeInput
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: DateRangeInput
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: DateRangeInput
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: DateRangeInput
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [DateRangeInput]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [DateRangeInput]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [DateRangeInput]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [DateRangeInput]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [DateRangeInput]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [DateRangeInput]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [DateRangeInput]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [DateRangeInput]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [DateRangeInput]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [DateRangeInput]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [DateRangeInput]
 }
 
-\\"\\"\\"
+"""
 A point in time as described by the [ISO
 8601](https://en.wikipedia.org/wiki/ISO_8601) standard. May or may not include a timezone.
-\\"\\"\\"
+"""
 scalar Datetime
 
-\\"\\"\\"
+"""
 A filter to be used against Datetime fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input DatetimeFilter {
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: Datetime
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: Datetime
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: Datetime
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: Datetime
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [Datetime!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: Datetime
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: Datetime
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: Datetime
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: Datetime
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [Datetime!]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against Datetime List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input DatetimeListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: Datetime
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: Datetime
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: Datetime
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: Datetime
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: Datetime
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: Datetime
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [Datetime]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [Datetime]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [Datetime]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [Datetime]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [Datetime]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [Datetime]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [Datetime]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [Datetime]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [Datetime]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [Datetime]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [Datetime]
 }
 
-\\"\\"\\"A range of \`Datetime\`.\\"\\"\\"
+"""A range of \`Datetime\`."""
 type DatetimeRange {
-  \\"\\"\\"The ending bound of our range.\\"\\"\\"
+  """The ending bound of our range."""
   end: DatetimeRangeBound
 
-  \\"\\"\\"The starting bound of our range.\\"\\"\\"
+  """The starting bound of our range."""
   start: DatetimeRangeBound
 }
 
-\\"\\"\\"
+"""
 The value at one end of a range. A range can either include this value, or not.
-\\"\\"\\"
+"""
 type DatetimeRangeBound {
-  \\"\\"\\"Whether or not the value of this bound is included in the range.\\"\\"\\"
+  """Whether or not the value of this bound is included in the range."""
   inclusive: Boolean!
 
-  \\"\\"\\"The value at one end of our range.\\"\\"\\"
+  """The value at one end of our range."""
   value: Datetime!
 }
 
-\\"\\"\\"
+"""
 The value at one end of a range. A range can either include this value, or not.
-\\"\\"\\"
+"""
 input DatetimeRangeBoundInput {
-  \\"\\"\\"Whether or not the value of this bound is included in the range.\\"\\"\\"
+  """Whether or not the value of this bound is included in the range."""
   inclusive: Boolean!
 
-  \\"\\"\\"The value at one end of our range.\\"\\"\\"
+  """The value at one end of our range."""
   value: Datetime!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against DatetimeRange fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input DatetimeRangeFilter {
-  \\"\\"\\"Adjacent to the specified range.\\"\\"\\"
+  """Adjacent to the specified range."""
   adjacentTo: DatetimeRangeInput
 
-  \\"\\"\\"Contained by the specified range.\\"\\"\\"
+  """Contained by the specified range."""
   containedBy: DatetimeRangeInput
 
-  \\"\\"\\"Contains the specified range.\\"\\"\\"
+  """Contains the specified range."""
   contains: DatetimeRangeInput
 
-  \\"\\"\\"Contains the specified value.\\"\\"\\"
+  """Contains the specified value."""
   containsElement: Datetime
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: DatetimeRangeInput
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: DatetimeRangeInput
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: DatetimeRangeInput
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: DatetimeRangeInput
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [DatetimeRangeInput!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: DatetimeRangeInput
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: DatetimeRangeInput
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: DatetimeRangeInput
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: DatetimeRangeInput
 
-  \\"\\"\\"Does not extend left of the specified range.\\"\\"\\"
+  """Does not extend left of the specified range."""
   notExtendsLeftOf: DatetimeRangeInput
 
-  \\"\\"\\"Does not extend right of the specified range.\\"\\"\\"
+  """Does not extend right of the specified range."""
   notExtendsRightOf: DatetimeRangeInput
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [DatetimeRangeInput!]
 
-  \\"\\"\\"Overlaps the specified range.\\"\\"\\"
+  """Overlaps the specified range."""
   overlaps: DatetimeRangeInput
 
-  \\"\\"\\"Strictly left of the specified range.\\"\\"\\"
+  """Strictly left of the specified range."""
   strictlyLeftOf: DatetimeRangeInput
 
-  \\"\\"\\"Strictly right of the specified range.\\"\\"\\"
+  """Strictly right of the specified range."""
   strictlyRightOf: DatetimeRangeInput
 }
 
-\\"\\"\\"A range of \`Datetime\`.\\"\\"\\"
+"""A range of \`Datetime\`."""
 input DatetimeRangeInput {
-  \\"\\"\\"The ending bound of our range.\\"\\"\\"
+  """The ending bound of our range."""
   end: DatetimeRangeBoundInput
 
-  \\"\\"\\"The starting bound of our range.\\"\\"\\"
+  """The starting bound of our range."""
   start: DatetimeRangeBoundInput
 }
 
-\\"\\"\\"
+"""
 A filter to be used against DatetimeRange List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input DatetimeRangeListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: DatetimeRangeInput
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: DatetimeRangeInput
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: DatetimeRangeInput
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: DatetimeRangeInput
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: DatetimeRangeInput
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: DatetimeRangeInput
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [DatetimeRangeInput]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [DatetimeRangeInput]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [DatetimeRangeInput]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [DatetimeRangeInput]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [DatetimeRangeInput]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [DatetimeRangeInput]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [DatetimeRangeInput]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [DatetimeRangeInput]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [DatetimeRangeInput]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [DatetimeRangeInput]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [DatetimeRangeInput]
 }
 
@@ -2113,65 +2113,65 @@ type DomainType implements Node {
   id: Int!
   int4Domain: Int4Domain
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`DomainType\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input DomainTypeFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [DomainTypeFilter!]
 
-  \\"\\"\\"Filter by the object’s \`char4Domain\` field.\\"\\"\\"
+  """Filter by the object’s \`char4Domain\` field."""
   char4Domain: Char4DomainFilter
 
-  \\"\\"\\"Filter by the object’s \`dateDomain\` field.\\"\\"\\"
+  """Filter by the object’s \`dateDomain\` field."""
   dateDomain: DateDomainFilter
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`int4Domain\` field.\\"\\"\\"
+  """Filter by the object’s \`int4Domain\` field."""
   int4Domain: Int4DomainFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: DomainTypeFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [DomainTypeFilter!]
 }
 
-\\"\\"\\"A connection to a list of \`DomainType\` values.\\"\\"\\"
+"""A connection to a list of \`DomainType\` values."""
 type DomainTypesConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`DomainType\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [DomainTypesEdge!]!
 
-  \\"\\"\\"A list of \`DomainType\` objects.\\"\\"\\"
+  """A list of \`DomainType\` objects."""
   nodes: [DomainType]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`DomainType\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`DomainType\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`DomainType\` edge in the connection.\\"\\"\\"
+"""A \`DomainType\` edge in the connection."""
 type DomainTypesEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`DomainType\` at the end of the edge.\\"\\"\\"
+  """The \`DomainType\` at the end of the edge."""
   node: DomainType
 }
 
-\\"\\"\\"Methods to use when ordering \`DomainType\`.\\"\\"\\"
+"""Methods to use when ordering \`DomainType\`."""
 enum DomainTypesOrderBy {
   CHAR4_DOMAIN_ASC
   CHAR4_DOMAIN_DESC
@@ -2190,59 +2190,59 @@ type EnumArrayType implements Node {
   enumArray: [Mood]
   id: Int!
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`EnumArrayType\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input EnumArrayTypeFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [EnumArrayTypeFilter!]
 
-  \\"\\"\\"Filter by the object’s \`enumArray\` field.\\"\\"\\"
+  """Filter by the object’s \`enumArray\` field."""
   enumArray: MoodListFilter
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: EnumArrayTypeFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [EnumArrayTypeFilter!]
 }
 
-\\"\\"\\"A connection to a list of \`EnumArrayType\` values.\\"\\"\\"
+"""A connection to a list of \`EnumArrayType\` values."""
 type EnumArrayTypesConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`EnumArrayType\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [EnumArrayTypesEdge!]!
 
-  \\"\\"\\"A list of \`EnumArrayType\` objects.\\"\\"\\"
+  """A list of \`EnumArrayType\` objects."""
   nodes: [EnumArrayType]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`EnumArrayType\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`EnumArrayType\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`EnumArrayType\` edge in the connection.\\"\\"\\"
+"""A \`EnumArrayType\` edge in the connection."""
 type EnumArrayTypesEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`EnumArrayType\` at the end of the edge.\\"\\"\\"
+  """The \`EnumArrayType\` at the end of the edge."""
   node: EnumArrayType
 }
 
-\\"\\"\\"Methods to use when ordering \`EnumArrayType\`.\\"\\"\\"
+"""Methods to use when ordering \`EnumArrayType\`."""
 enum EnumArrayTypesOrderBy {
   ENUM_ARRAY_ASC
   ENUM_ARRAY_DESC
@@ -2257,59 +2257,59 @@ type EnumType implements Node {
   enum: Mood
   id: Int!
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`EnumType\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input EnumTypeFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [EnumTypeFilter!]
 
-  \\"\\"\\"Filter by the object’s \`enum\` field.\\"\\"\\"
+  """Filter by the object’s \`enum\` field."""
   enum: MoodFilter
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: EnumTypeFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [EnumTypeFilter!]
 }
 
-\\"\\"\\"A connection to a list of \`EnumType\` values.\\"\\"\\"
+"""A connection to a list of \`EnumType\` values."""
 type EnumTypesConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`EnumType\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [EnumTypesEdge!]!
 
-  \\"\\"\\"A list of \`EnumType\` objects.\\"\\"\\"
+  """A list of \`EnumType\` objects."""
   nodes: [EnumType]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`EnumType\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`EnumType\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`EnumType\` edge in the connection.\\"\\"\\"
+"""A \`EnumType\` edge in the connection."""
 type EnumTypesEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`EnumType\` at the end of the edge.\\"\\"\\"
+  """The \`EnumType\` at the end of the edge."""
   node: EnumType
 }
 
-\\"\\"\\"Methods to use when ordering \`EnumType\`.\\"\\"\\"
+"""Methods to use when ordering \`EnumType\`."""
 enum EnumTypesOrderBy {
   ENUM_ASC
   ENUM_DESC
@@ -2321,14 +2321,14 @@ enum EnumTypesOrderBy {
 }
 
 type Filterable implements Node {
-  \\"\\"\\"Reads a single \`Backward\` that is related to this \`Filterable\`.\\"\\"\\"
+  """Reads a single \`Backward\` that is related to this \`Filterable\`."""
   backwardByFilterableId: Backward
   backwardCompound1: Int
   backwardCompound2: Int
 
-  \\"\\"\\"
+  """
   Reads a single \`BackwardCompound\` that is related to this \`Filterable\`.
-  \\"\\"\\"
+  """
   backwardCompoundByBackwardCompound1AndBackwardCompound2: BackwardCompound
   bit4: BitString
   bool: Boolean
@@ -2336,61 +2336,61 @@ type Filterable implements Node {
   bytea: String
   char4: String
 
-  \\"\\"\\"Reads and enables pagination through a set of \`ChildNoRelatedFilter\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`ChildNoRelatedFilter\`."""
   childNoRelatedFiltersByFilterableId(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: ChildNoRelatedFilterFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`ChildNoRelatedFilter\`.\\"\\"\\"
+    """The method to use when ordering \`ChildNoRelatedFilter\`."""
     orderBy: [ChildNoRelatedFiltersOrderBy!] = [PRIMARY_KEY_ASC]
   ): ChildNoRelatedFiltersConnection!
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Child\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Child\`."""
   childrenByFilterableId(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: ChildFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`Child\`.\\"\\"\\"
+    """The method to use when ordering \`Child\`."""
     orderBy: [ChildrenOrderBy!] = [PRIMARY_KEY_ASC]
   ): ChildrenConnection!
   cidr: String
@@ -2401,126 +2401,126 @@ type Filterable implements Node {
   computedChild: Child
   computedIntArray: [Int]
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Child\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Child\`."""
   computedSetofChild(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: ChildFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
   ): ChildrenConnection!
   computedSetofInt(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: IntFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
   ): FilterableComputedSetofIntConnection!
   computedTaggedFilterable: Int
   computedWithRequiredArg(i: Int!): Int
   date: Date
 
-  \\"\\"\\"Reads and enables pagination through a set of \`FilterableClosure\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`FilterableClosure\`."""
   filterableClosuresByAncestorId(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: FilterableClosureFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`FilterableClosure\`.\\"\\"\\"
+    """The method to use when ordering \`FilterableClosure\`."""
     orderBy: [FilterableClosuresOrderBy!] = [PRIMARY_KEY_ASC]
   ): FilterableClosuresConnection!
 
-  \\"\\"\\"Reads and enables pagination through a set of \`FilterableClosure\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`FilterableClosure\`."""
   filterableClosuresByDescendantId(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: FilterableClosureFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`FilterableClosure\`.\\"\\"\\"
+    """The method to use when ordering \`FilterableClosure\`."""
     orderBy: [FilterableClosuresOrderBy!] = [PRIMARY_KEY_ASC]
   ): FilterableClosuresConnection!
   float4: Float
   float8: Float
 
-  \\"\\"\\"Reads a single \`Forward\` that is related to this \`Filterable\`.\\"\\"\\"
+  """Reads a single \`Forward\` that is related to this \`Filterable\`."""
   forwardByForwardId: Forward
   forwardColumn: Forward
   forwardCompound1: Int
   forwardCompound2: Int
 
-  \\"\\"\\"Reads a single \`ForwardCompound\` that is related to this \`Filterable\`.\\"\\"\\"
+  """Reads a single \`ForwardCompound\` that is related to this \`Filterable\`."""
   forwardCompoundByForwardCompound1AndForwardCompound2: ForwardCompound
   forwardId: Int
   hstore: KeyValueHash
@@ -2536,13 +2536,13 @@ type Filterable implements Node {
   money: Float
   name: String
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
   numeric: BigFloat
 
-  \\"\\"\\"Reads a single \`Parent\` that is related to this \`Filterable\`.\\"\\"\\"
+  """Reads a single \`Parent\` that is related to this \`Filterable\`."""
   parentByParentId: Parent
   parentId: Int
   text: String
@@ -2562,78 +2562,78 @@ type FilterableClosure implements Node {
   depth: Int!
   descendantId: Int!
 
-  \\"\\"\\"
+  """
   Reads a single \`Filterable\` that is related to this \`FilterableClosure\`.
-  \\"\\"\\"
+  """
   filterableByAncestorId: Filterable
 
-  \\"\\"\\"
+  """
   Reads a single \`Filterable\` that is related to this \`FilterableClosure\`.
-  \\"\\"\\"
+  """
   filterableByDescendantId: Filterable
   id: Int!
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`FilterableClosure\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input FilterableClosureFilter {
-  \\"\\"\\"Filter by the object’s \`ancestorId\` field.\\"\\"\\"
+  """Filter by the object’s \`ancestorId\` field."""
   ancestorId: IntFilter
 
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [FilterableClosureFilter!]
 
-  \\"\\"\\"Filter by the object’s \`depth\` field.\\"\\"\\"
+  """Filter by the object’s \`depth\` field."""
   depth: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`descendantId\` field.\\"\\"\\"
+  """Filter by the object’s \`descendantId\` field."""
   descendantId: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: FilterableClosureFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [FilterableClosureFilter!]
 }
 
-\\"\\"\\"A connection to a list of \`FilterableClosure\` values.\\"\\"\\"
+"""A connection to a list of \`FilterableClosure\` values."""
 type FilterableClosuresConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`FilterableClosure\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [FilterableClosuresEdge!]!
 
-  \\"\\"\\"A list of \`FilterableClosure\` objects.\\"\\"\\"
+  """A list of \`FilterableClosure\` objects."""
   nodes: [FilterableClosure]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"
+  """
   The count of *all* \`FilterableClosure\` you could get from the connection.
-  \\"\\"\\"
+  """
   totalCount: Int!
 }
 
-\\"\\"\\"A \`FilterableClosure\` edge in the connection.\\"\\"\\"
+"""A \`FilterableClosure\` edge in the connection."""
 type FilterableClosuresEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`FilterableClosure\` at the end of the edge.\\"\\"\\"
+  """The \`FilterableClosure\` at the end of the edge."""
   node: FilterableClosure
 }
 
-\\"\\"\\"Methods to use when ordering \`FilterableClosure\`.\\"\\"\\"
+"""Methods to use when ordering \`FilterableClosure\`."""
 enum FilterableClosuresOrderBy {
   ANCESTOR_ID_ASC
   ANCESTOR_ID_DESC
@@ -2648,175 +2648,175 @@ enum FilterableClosuresOrderBy {
   PRIMARY_KEY_DESC
 }
 
-\\"\\"\\"A connection to a list of \`Int\` values.\\"\\"\\"
+"""A connection to a list of \`Int\` values."""
 type FilterableComputedSetofIntConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`Int\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [FilterableComputedSetofIntEdge!]!
 
-  \\"\\"\\"A list of \`Int\` objects.\\"\\"\\"
+  """A list of \`Int\` objects."""
   nodes: [Int]!
 
-  \\"\\"\\"The count of *all* \`Int\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`Int\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`Int\` edge in the connection.\\"\\"\\"
+"""A \`Int\` edge in the connection."""
 type FilterableComputedSetofIntEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`Int\` at the end of the edge.\\"\\"\\"
+  """The \`Int\` at the end of the edge."""
   node: Int
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`Filterable\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input FilterableFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [FilterableFilter!]
 
-  \\"\\"\\"Filter by the object’s \`backwardCompound1\` field.\\"\\"\\"
+  """Filter by the object’s \`backwardCompound1\` field."""
   backwardCompound1: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`backwardCompound2\` field.\\"\\"\\"
+  """Filter by the object’s \`backwardCompound2\` field."""
   backwardCompound2: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`bit4\` field.\\"\\"\\"
+  """Filter by the object’s \`bit4\` field."""
   bit4: BitStringFilter
 
-  \\"\\"\\"Filter by the object’s \`bool\` field.\\"\\"\\"
+  """Filter by the object’s \`bool\` field."""
   bool: BooleanFilter
 
-  \\"\\"\\"Filter by the object’s \`bpchar4\` field.\\"\\"\\"
+  """Filter by the object’s \`bpchar4\` field."""
   bpchar4: StringFilter
 
-  \\"\\"\\"Filter by the object’s \`char4\` field.\\"\\"\\"
+  """Filter by the object’s \`char4\` field."""
   char4: StringFilter
 
-  \\"\\"\\"Filter by the object’s \`citext\` field.\\"\\"\\"
+  """Filter by the object’s \`citext\` field."""
   citext: StringFilter
 
-  \\"\\"\\"Filter by the object’s \`compositeColumn\` field.\\"\\"\\"
+  """Filter by the object’s \`compositeColumn\` field."""
   compositeColumn: CompositeFilter
 
-  \\"\\"\\"Filter by the object’s \`computedTaggedFilterable\` field.\\"\\"\\"
+  """Filter by the object’s \`computedTaggedFilterable\` field."""
   computedTaggedFilterable: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`date\` field.\\"\\"\\"
+  """Filter by the object’s \`date\` field."""
   date: DateFilter
 
-  \\"\\"\\"Filter by the object’s \`float4\` field.\\"\\"\\"
+  """Filter by the object’s \`float4\` field."""
   float4: FloatFilter
 
-  \\"\\"\\"Filter by the object’s \`float8\` field.\\"\\"\\"
+  """Filter by the object’s \`float8\` field."""
   float8: FloatFilter
 
-  \\"\\"\\"Filter by the object’s \`forwardCompound1\` field.\\"\\"\\"
+  """Filter by the object’s \`forwardCompound1\` field."""
   forwardCompound1: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`forwardCompound2\` field.\\"\\"\\"
+  """Filter by the object’s \`forwardCompound2\` field."""
   forwardCompound2: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`forwardId\` field.\\"\\"\\"
+  """Filter by the object’s \`forwardId\` field."""
   forwardId: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`hstore\` field.\\"\\"\\"
+  """Filter by the object’s \`hstore\` field."""
   hstore: KeyValueHashFilter
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`inet\` field.\\"\\"\\"
+  """Filter by the object’s \`inet\` field."""
   inet: InternetAddressFilter
 
-  \\"\\"\\"Filter by the object’s \`int2\` field.\\"\\"\\"
+  """Filter by the object’s \`int2\` field."""
   int2: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`int4\` field.\\"\\"\\"
+  """Filter by the object’s \`int4\` field."""
   int4: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`int8\` field.\\"\\"\\"
+  """Filter by the object’s \`int8\` field."""
   int8: BigIntFilter
 
-  \\"\\"\\"Filter by the object’s \`interval\` field.\\"\\"\\"
+  """Filter by the object’s \`interval\` field."""
   interval: IntervalFilter
 
-  \\"\\"\\"Filter by the object’s \`jsonb\` field.\\"\\"\\"
+  """Filter by the object’s \`jsonb\` field."""
   jsonb: JSONFilter
 
-  \\"\\"\\"Filter by the object’s \`money\` field.\\"\\"\\"
+  """Filter by the object’s \`money\` field."""
   money: FloatFilter
 
-  \\"\\"\\"Filter by the object’s \`name\` field.\\"\\"\\"
+  """Filter by the object’s \`name\` field."""
   name: StringFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: FilterableFilter
 
-  \\"\\"\\"Filter by the object’s \`numeric\` field.\\"\\"\\"
+  """Filter by the object’s \`numeric\` field."""
   numeric: BigFloatFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [FilterableFilter!]
 
-  \\"\\"\\"Filter by the object’s \`parentId\` field.\\"\\"\\"
+  """Filter by the object’s \`parentId\` field."""
   parentId: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`text\` field.\\"\\"\\"
+  """Filter by the object’s \`text\` field."""
   text: StringFilter
 
-  \\"\\"\\"Filter by the object’s \`time\` field.\\"\\"\\"
+  """Filter by the object’s \`time\` field."""
   time: TimeFilter
 
-  \\"\\"\\"Filter by the object’s \`timestamp\` field.\\"\\"\\"
+  """Filter by the object’s \`timestamp\` field."""
   timestamp: DatetimeFilter
 
-  \\"\\"\\"Filter by the object’s \`timestamptz\` field.\\"\\"\\"
+  """Filter by the object’s \`timestamptz\` field."""
   timestamptz: DatetimeFilter
 
-  \\"\\"\\"Filter by the object’s \`timetz\` field.\\"\\"\\"
+  """Filter by the object’s \`timetz\` field."""
   timetz: TimeFilter
 
-  \\"\\"\\"Filter by the object’s \`uuid\` field.\\"\\"\\"
+  """Filter by the object’s \`uuid\` field."""
   uuid: UUIDFilter
 
-  \\"\\"\\"Filter by the object’s \`varbit\` field.\\"\\"\\"
+  """Filter by the object’s \`varbit\` field."""
   varbit: BitStringFilter
 
-  \\"\\"\\"Filter by the object’s \`varchar\` field.\\"\\"\\"
+  """Filter by the object’s \`varchar\` field."""
   varchar: StringFilter
 }
 
-\\"\\"\\"A connection to a list of \`Filterable\` values.\\"\\"\\"
+"""A connection to a list of \`Filterable\` values."""
 type FilterablesConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`Filterable\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [FilterablesEdge!]!
 
-  \\"\\"\\"A list of \`Filterable\` objects.\\"\\"\\"
+  """A list of \`Filterable\` objects."""
   nodes: [Filterable]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`Filterable\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`Filterable\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`Filterable\` edge in the connection.\\"\\"\\"
+"""A \`Filterable\` edge in the connection."""
 type FilterablesEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`Filterable\` at the end of the edge.\\"\\"\\"
+  """The \`Filterable\` at the end of the edge."""
   node: Filterable
 }
 
-\\"\\"\\"Methods to use when ordering \`Filterable\`.\\"\\"\\"
+"""Methods to use when ordering \`Filterable\`."""
 enum FilterablesOrderBy {
   BACKWARD_COMPOUND_1_ASC
   BACKWARD_COMPOUND_1_DESC
@@ -2905,188 +2905,188 @@ enum FilterablesOrderBy {
   XML_DESC
 }
 
-\\"\\"\\"
+"""
 A filter to be used against Float fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input FloatFilter {
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: Float
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: Float
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: Float
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: Float
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [Float!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: Float
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: Float
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: Float
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: Float
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [Float!]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against Float List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input FloatListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: Float
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: Float
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: Float
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: Float
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: Float
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: Float
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [Float]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [Float]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [Float]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [Float]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [Float]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [Float]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [Float]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [Float]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [Float]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [Float]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [Float]
 }
 
 type Forward implements Node {
-  \\"\\"\\"Reads a single \`Filterable\` that is related to this \`Forward\`.\\"\\"\\"
+  """Reads a single \`Filterable\` that is related to this \`Forward\`."""
   filterableByForwardId: Filterable
   id: Int!
   name: String!
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
 type ForwardCompound implements Node {
-  \\"\\"\\"Reads a single \`Filterable\` that is related to this \`ForwardCompound\`.\\"\\"\\"
+  """Reads a single \`Filterable\` that is related to this \`ForwardCompound\`."""
   filterableByForwardCompound1AndForwardCompound2: Filterable
   forwardCompound1: Int!
   forwardCompound2: Int!
   name: String
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`ForwardCompound\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input ForwardCompoundFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [ForwardCompoundFilter!]
 
-  \\"\\"\\"Filter by the object’s \`forwardCompound1\` field.\\"\\"\\"
+  """Filter by the object’s \`forwardCompound1\` field."""
   forwardCompound1: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`forwardCompound2\` field.\\"\\"\\"
+  """Filter by the object’s \`forwardCompound2\` field."""
   forwardCompound2: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`name\` field.\\"\\"\\"
+  """Filter by the object’s \`name\` field."""
   name: StringFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: ForwardCompoundFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [ForwardCompoundFilter!]
 }
 
-\\"\\"\\"A connection to a list of \`ForwardCompound\` values.\\"\\"\\"
+"""A connection to a list of \`ForwardCompound\` values."""
 type ForwardCompoundsConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`ForwardCompound\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [ForwardCompoundsEdge!]!
 
-  \\"\\"\\"A list of \`ForwardCompound\` objects.\\"\\"\\"
+  """A list of \`ForwardCompound\` objects."""
   nodes: [ForwardCompound]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"
+  """
   The count of *all* \`ForwardCompound\` you could get from the connection.
-  \\"\\"\\"
+  """
   totalCount: Int!
 }
 
-\\"\\"\\"A \`ForwardCompound\` edge in the connection.\\"\\"\\"
+"""A \`ForwardCompound\` edge in the connection."""
 type ForwardCompoundsEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`ForwardCompound\` at the end of the edge.\\"\\"\\"
+  """The \`ForwardCompound\` at the end of the edge."""
   node: ForwardCompound
 }
 
-\\"\\"\\"Methods to use when ordering \`ForwardCompound\`.\\"\\"\\"
+"""Methods to use when ordering \`ForwardCompound\`."""
 enum ForwardCompoundsOrderBy {
   FORWARD_COMPOUND_1_ASC
   FORWARD_COMPOUND_1_DESC
@@ -3099,53 +3099,53 @@ enum ForwardCompoundsOrderBy {
   PRIMARY_KEY_DESC
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`Forward\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input ForwardFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [ForwardFilter!]
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`name\` field.\\"\\"\\"
+  """Filter by the object’s \`name\` field."""
   name: StringFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: ForwardFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [ForwardFilter!]
 }
 
-\\"\\"\\"A connection to a list of \`Forward\` values.\\"\\"\\"
+"""A connection to a list of \`Forward\` values."""
 type ForwardsConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`Forward\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [ForwardsEdge!]!
 
-  \\"\\"\\"A list of \`Forward\` objects.\\"\\"\\"
+  """A list of \`Forward\` objects."""
   nodes: [Forward]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`Forward\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`Forward\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`Forward\` edge in the connection.\\"\\"\\"
+"""A \`Forward\` edge in the connection."""
 type ForwardsEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`Forward\` at the end of the edge.\\"\\"\\"
+  """The \`Forward\` at the end of the edge."""
   node: Forward
 }
 
-\\"\\"\\"Methods to use when ordering \`Forward\`.\\"\\"\\"
+"""Methods to use when ordering \`Forward\`."""
 enum ForwardsOrderBy {
   ID_ASC
   ID_DESC
@@ -3159,40 +3159,40 @@ enum ForwardsOrderBy {
 type FullyOmitted implements Node {
   id: Int!
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
   text: String
 }
 
-\\"\\"\\"A connection to a list of \`FullyOmitted\` values.\\"\\"\\"
+"""A connection to a list of \`FullyOmitted\` values."""
 type FullyOmittedsConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`FullyOmitted\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [FullyOmittedsEdge!]!
 
-  \\"\\"\\"A list of \`FullyOmitted\` objects.\\"\\"\\"
+  """A list of \`FullyOmitted\` objects."""
   nodes: [FullyOmitted]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`FullyOmitted\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`FullyOmitted\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`FullyOmitted\` edge in the connection.\\"\\"\\"
+"""A \`FullyOmitted\` edge in the connection."""
 type FullyOmittedsEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`FullyOmitted\` at the end of the edge.\\"\\"\\"
+  """The \`FullyOmitted\` at the end of the edge."""
   node: FullyOmitted
 }
 
-\\"\\"\\"Methods to use when ordering \`FullyOmitted\`.\\"\\"\\"
+"""Methods to use when ordering \`FullyOmitted\`."""
 enum FullyOmittedsOrderBy {
   ID_ASC
   ID_DESC
@@ -3203,746 +3203,746 @@ enum FullyOmittedsOrderBy {
   TEXT_DESC
 }
 
-\\"\\"\\"A connection to a list of \`FuncReturnsTableMultiColRecord\` values.\\"\\"\\"
+"""A connection to a list of \`FuncReturnsTableMultiColRecord\` values."""
 type FuncReturnsTableMultiColConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`FuncReturnsTableMultiColRecord\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [FuncReturnsTableMultiColEdge!]!
 
-  \\"\\"\\"A list of \`FuncReturnsTableMultiColRecord\` objects.\\"\\"\\"
+  """A list of \`FuncReturnsTableMultiColRecord\` objects."""
   nodes: [FuncReturnsTableMultiColRecord]!
 
-  \\"\\"\\"
+  """
   The count of *all* \`FuncReturnsTableMultiColRecord\` you could get from the connection.
-  \\"\\"\\"
+  """
   totalCount: Int!
 }
 
-\\"\\"\\"A \`FuncReturnsTableMultiColRecord\` edge in the connection.\\"\\"\\"
+"""A \`FuncReturnsTableMultiColRecord\` edge in the connection."""
 type FuncReturnsTableMultiColEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`FuncReturnsTableMultiColRecord\` at the end of the edge.\\"\\"\\"
+  """The \`FuncReturnsTableMultiColRecord\` at the end of the edge."""
   node: FuncReturnsTableMultiColRecord
 }
 
-\\"\\"\\"The return type of our \`funcReturnsTableMultiCol\` query.\\"\\"\\"
+"""The return type of our \`funcReturnsTableMultiCol\` query."""
 type FuncReturnsTableMultiColRecord {
   col1: Int
   col2: String
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`FuncReturnsTableMultiColRecord\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input FuncReturnsTableMultiColRecordFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [FuncReturnsTableMultiColRecordFilter!]
 
-  \\"\\"\\"Filter by the object’s \`col1\` field.\\"\\"\\"
+  """Filter by the object’s \`col1\` field."""
   col1: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`col2\` field.\\"\\"\\"
+  """Filter by the object’s \`col2\` field."""
   col2: StringFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: FuncReturnsTableMultiColRecordFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [FuncReturnsTableMultiColRecordFilter!]
 }
 
-\\"\\"\\"A connection to a list of \`Int\` values.\\"\\"\\"
+"""A connection to a list of \`Int\` values."""
 type FuncReturnsTableOneColConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`Int\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [FuncReturnsTableOneColEdge!]!
 
-  \\"\\"\\"A list of \`Int\` objects.\\"\\"\\"
+  """A list of \`Int\` objects."""
   nodes: [Int]!
 
-  \\"\\"\\"The count of *all* \`Int\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`Int\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`Int\` edge in the connection.\\"\\"\\"
+"""A \`Int\` edge in the connection."""
 type FuncReturnsTableOneColEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`Int\` at the end of the edge.\\"\\"\\"
+  """The \`Int\` at the end of the edge."""
   node: Int
 }
 
-\\"\\"\\"
+"""
 A connection to a list of \`FuncTaggedFilterableReturnsTableMultiColRecord\` values.
-\\"\\"\\"
+"""
 type FuncTaggedFilterableReturnsTableMultiColConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`FuncTaggedFilterableReturnsTableMultiColRecord\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [FuncTaggedFilterableReturnsTableMultiColEdge!]!
 
-  \\"\\"\\"A list of \`FuncTaggedFilterableReturnsTableMultiColRecord\` objects.\\"\\"\\"
+  """A list of \`FuncTaggedFilterableReturnsTableMultiColRecord\` objects."""
   nodes: [FuncTaggedFilterableReturnsTableMultiColRecord]!
 
-  \\"\\"\\"
+  """
   The count of *all* \`FuncTaggedFilterableReturnsTableMultiColRecord\` you could get from the connection.
-  \\"\\"\\"
+  """
   totalCount: Int!
 }
 
-\\"\\"\\"
+"""
 A \`FuncTaggedFilterableReturnsTableMultiColRecord\` edge in the connection.
-\\"\\"\\"
+"""
 type FuncTaggedFilterableReturnsTableMultiColEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"
+  """
   The \`FuncTaggedFilterableReturnsTableMultiColRecord\` at the end of the edge.
-  \\"\\"\\"
+  """
   node: FuncTaggedFilterableReturnsTableMultiColRecord
 }
 
-\\"\\"\\"
+"""
 The return type of our \`funcTaggedFilterableReturnsTableMultiCol\` query.
-\\"\\"\\"
+"""
 type FuncTaggedFilterableReturnsTableMultiColRecord {
   col1: Int
   col2: String
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`FuncTaggedFilterableReturnsTableMultiColRecord\`
 object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input FuncTaggedFilterableReturnsTableMultiColRecordFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [FuncTaggedFilterableReturnsTableMultiColRecordFilter!]
 
-  \\"\\"\\"Filter by the object’s \`col1\` field.\\"\\"\\"
+  """Filter by the object’s \`col1\` field."""
   col1: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`col2\` field.\\"\\"\\"
+  """Filter by the object’s \`col2\` field."""
   col2: StringFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: FuncTaggedFilterableReturnsTableMultiColRecordFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [FuncTaggedFilterableReturnsTableMultiColRecordFilter!]
 }
 
 scalar Int4Domain
 
-\\"\\"\\"
+"""
 A filter to be used against Int4Domain fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input Int4DomainFilter {
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: Int4Domain
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: Int4Domain
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: Int4Domain
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: Int4Domain
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [Int4Domain!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: Int4Domain
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: Int4Domain
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: Int4Domain
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: Int4Domain
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [Int4Domain!]
 }
 
-\\"\\"\\"An IPv4 or IPv6 host address, and optionally its subnet.\\"\\"\\"
+"""An IPv4 or IPv6 host address, and optionally its subnet."""
 scalar InternetAddress
 
-\\"\\"\\"
+"""
 A filter to be used against InternetAddress fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input InternetAddressFilter {
-  \\"\\"\\"Contained by the specified internet address.\\"\\"\\"
+  """Contained by the specified internet address."""
   containedBy: InternetAddress
 
-  \\"\\"\\"Contained by or equal to the specified internet address.\\"\\"\\"
+  """Contained by or equal to the specified internet address."""
   containedByOrEqualTo: InternetAddress
 
-  \\"\\"\\"Contains the specified internet address.\\"\\"\\"
+  """Contains the specified internet address."""
   contains: InternetAddress
 
-  \\"\\"\\"Contains or contained by the specified internet address.\\"\\"\\"
+  """Contains or contained by the specified internet address."""
   containsOrContainedBy: InternetAddress
 
-  \\"\\"\\"Contains or equal to the specified internet address.\\"\\"\\"
+  """Contains or equal to the specified internet address."""
   containsOrEqualTo: InternetAddress
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: InternetAddress
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: InternetAddress
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: InternetAddress
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: InternetAddress
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [InternetAddress!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: InternetAddress
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: InternetAddress
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: InternetAddress
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: InternetAddress
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [InternetAddress!]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against InternetAddress List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input InternetAddressListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: InternetAddress
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: InternetAddress
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: InternetAddress
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: InternetAddress
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: InternetAddress
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: InternetAddress
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [InternetAddress]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [InternetAddress]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [InternetAddress]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [InternetAddress]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [InternetAddress]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [InternetAddress]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [InternetAddress]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [InternetAddress]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [InternetAddress]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [InternetAddress]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [InternetAddress]
 }
 
-\\"\\"\\"
+"""
 An interval of time that has passed where the smallest distinct unit is a second.
-\\"\\"\\"
+"""
 type Interval {
-  \\"\\"\\"A quantity of days.\\"\\"\\"
+  """A quantity of days."""
   days: Int
 
-  \\"\\"\\"A quantity of hours.\\"\\"\\"
+  """A quantity of hours."""
   hours: Int
 
-  \\"\\"\\"A quantity of minutes.\\"\\"\\"
+  """A quantity of minutes."""
   minutes: Int
 
-  \\"\\"\\"A quantity of months.\\"\\"\\"
+  """A quantity of months."""
   months: Int
 
-  \\"\\"\\"
+  """
   A quantity of seconds. This is the only non-integer field, as all the other
   fields will dump their overflow into a smaller unit of time. Intervals don’t
   have a smaller unit than seconds.
-  \\"\\"\\"
+  """
   seconds: Float
 
-  \\"\\"\\"A quantity of years.\\"\\"\\"
+  """A quantity of years."""
   years: Int
 }
 
-\\"\\"\\"
+"""
 A filter to be used against Interval fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input IntervalFilter {
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: IntervalInput
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: IntervalInput
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: IntervalInput
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: IntervalInput
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [IntervalInput!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: IntervalInput
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: IntervalInput
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: IntervalInput
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: IntervalInput
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [IntervalInput!]
 }
 
-\\"\\"\\"
+"""
 An interval of time that has passed where the smallest distinct unit is a second.
-\\"\\"\\"
+"""
 input IntervalInput {
-  \\"\\"\\"A quantity of days.\\"\\"\\"
+  """A quantity of days."""
   days: Int
 
-  \\"\\"\\"A quantity of hours.\\"\\"\\"
+  """A quantity of hours."""
   hours: Int
 
-  \\"\\"\\"A quantity of minutes.\\"\\"\\"
+  """A quantity of minutes."""
   minutes: Int
 
-  \\"\\"\\"A quantity of months.\\"\\"\\"
+  """A quantity of months."""
   months: Int
 
-  \\"\\"\\"
+  """
   A quantity of seconds. This is the only non-integer field, as all the other
   fields will dump their overflow into a smaller unit of time. Intervals don’t
   have a smaller unit than seconds.
-  \\"\\"\\"
+  """
   seconds: Float
 
-  \\"\\"\\"A quantity of years.\\"\\"\\"
+  """A quantity of years."""
   years: Int
 }
 
-\\"\\"\\"
+"""
 A filter to be used against Interval List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input IntervalListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: IntervalInput
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: IntervalInput
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: IntervalInput
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: IntervalInput
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: IntervalInput
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: IntervalInput
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [IntervalInput]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [IntervalInput]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [IntervalInput]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [IntervalInput]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [IntervalInput]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [IntervalInput]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [IntervalInput]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [IntervalInput]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [IntervalInput]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [IntervalInput]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [IntervalInput]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against Int fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input IntFilter {
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: Int
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: Int
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: Int
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: Int
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [Int!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: Int
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: Int
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: Int
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: Int
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [Int!]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against Int List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input IntListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: Int
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: Int
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: Int
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: Int
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: Int
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: Int
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [Int]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [Int]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [Int]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [Int]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [Int]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [Int]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [Int]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [Int]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [Int]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [Int]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [Int]
 }
 
-\\"\\"\\"A range of \`Int\`.\\"\\"\\"
+"""A range of \`Int\`."""
 type IntRange {
-  \\"\\"\\"The ending bound of our range.\\"\\"\\"
+  """The ending bound of our range."""
   end: IntRangeBound
 
-  \\"\\"\\"The starting bound of our range.\\"\\"\\"
+  """The starting bound of our range."""
   start: IntRangeBound
 }
 
-\\"\\"\\"
+"""
 The value at one end of a range. A range can either include this value, or not.
-\\"\\"\\"
+"""
 type IntRangeBound {
-  \\"\\"\\"Whether or not the value of this bound is included in the range.\\"\\"\\"
+  """Whether or not the value of this bound is included in the range."""
   inclusive: Boolean!
 
-  \\"\\"\\"The value at one end of our range.\\"\\"\\"
+  """The value at one end of our range."""
   value: Int!
 }
 
-\\"\\"\\"
+"""
 The value at one end of a range. A range can either include this value, or not.
-\\"\\"\\"
+"""
 input IntRangeBoundInput {
-  \\"\\"\\"Whether or not the value of this bound is included in the range.\\"\\"\\"
+  """Whether or not the value of this bound is included in the range."""
   inclusive: Boolean!
 
-  \\"\\"\\"The value at one end of our range.\\"\\"\\"
+  """The value at one end of our range."""
   value: Int!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against IntRange fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input IntRangeFilter {
-  \\"\\"\\"Adjacent to the specified range.\\"\\"\\"
+  """Adjacent to the specified range."""
   adjacentTo: IntRangeInput
 
-  \\"\\"\\"Contained by the specified range.\\"\\"\\"
+  """Contained by the specified range."""
   containedBy: IntRangeInput
 
-  \\"\\"\\"Contains the specified range.\\"\\"\\"
+  """Contains the specified range."""
   contains: IntRangeInput
 
-  \\"\\"\\"Contains the specified value.\\"\\"\\"
+  """Contains the specified value."""
   containsElement: Int
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: IntRangeInput
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: IntRangeInput
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: IntRangeInput
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: IntRangeInput
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [IntRangeInput!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: IntRangeInput
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: IntRangeInput
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: IntRangeInput
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: IntRangeInput
 
-  \\"\\"\\"Does not extend left of the specified range.\\"\\"\\"
+  """Does not extend left of the specified range."""
   notExtendsLeftOf: IntRangeInput
 
-  \\"\\"\\"Does not extend right of the specified range.\\"\\"\\"
+  """Does not extend right of the specified range."""
   notExtendsRightOf: IntRangeInput
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [IntRangeInput!]
 
-  \\"\\"\\"Overlaps the specified range.\\"\\"\\"
+  """Overlaps the specified range."""
   overlaps: IntRangeInput
 
-  \\"\\"\\"Strictly left of the specified range.\\"\\"\\"
+  """Strictly left of the specified range."""
   strictlyLeftOf: IntRangeInput
 
-  \\"\\"\\"Strictly right of the specified range.\\"\\"\\"
+  """Strictly right of the specified range."""
   strictlyRightOf: IntRangeInput
 }
 
-\\"\\"\\"A range of \`Int\`.\\"\\"\\"
+"""A range of \`Int\`."""
 input IntRangeInput {
-  \\"\\"\\"The ending bound of our range.\\"\\"\\"
+  """The ending bound of our range."""
   end: IntRangeBoundInput
 
-  \\"\\"\\"The starting bound of our range.\\"\\"\\"
+  """The starting bound of our range."""
   start: IntRangeBoundInput
 }
 
-\\"\\"\\"
+"""
 A filter to be used against IntRange List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input IntRangeListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: IntRangeInput
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: IntRangeInput
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: IntRangeInput
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: IntRangeInput
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: IntRangeInput
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: IntRangeInput
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [IntRangeInput]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [IntRangeInput]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [IntRangeInput]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [IntRangeInput]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [IntRangeInput]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [IntRangeInput]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [IntRangeInput]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [IntRangeInput]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [IntRangeInput]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [IntRangeInput]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [IntRangeInput]
 }
 
-\\"\\"\\"
+"""
 A JavaScript object encoded in the JSON format as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf).
-\\"\\"\\"
+"""
 scalar JSON
 
 type JsonbTest implements Node {
@@ -3950,62 +3950,62 @@ type JsonbTest implements Node {
   jsonbWithArray: JSON
   jsonbWithObject: JSON
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`JsonbTest\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input JsonbTestFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [JsonbTestFilter!]
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`jsonbWithArray\` field.\\"\\"\\"
+  """Filter by the object’s \`jsonbWithArray\` field."""
   jsonbWithArray: JSONFilter
 
-  \\"\\"\\"Filter by the object’s \`jsonbWithObject\` field.\\"\\"\\"
+  """Filter by the object’s \`jsonbWithObject\` field."""
   jsonbWithObject: JSONFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: JsonbTestFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [JsonbTestFilter!]
 }
 
-\\"\\"\\"A connection to a list of \`JsonbTest\` values.\\"\\"\\"
+"""A connection to a list of \`JsonbTest\` values."""
 type JsonbTestsConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`JsonbTest\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [JsonbTestsEdge!]!
 
-  \\"\\"\\"A list of \`JsonbTest\` objects.\\"\\"\\"
+  """A list of \`JsonbTest\` objects."""
   nodes: [JsonbTest]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`JsonbTest\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`JsonbTest\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`JsonbTest\` edge in the connection.\\"\\"\\"
+"""A \`JsonbTest\` edge in the connection."""
 type JsonbTestsEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`JsonbTest\` at the end of the edge.\\"\\"\\"
+  """The \`JsonbTest\` at the end of the edge."""
   node: JsonbTest
 }
 
-\\"\\"\\"Methods to use when ordering \`JsonbTest\`.\\"\\"\\"
+"""Methods to use when ordering \`JsonbTest\`."""
 enum JsonbTestsOrderBy {
   ID_ASC
   ID_DESC
@@ -4018,188 +4018,188 @@ enum JsonbTestsOrderBy {
   PRIMARY_KEY_DESC
 }
 
-\\"\\"\\"
+"""
 A filter to be used against JSON fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input JSONFilter {
-  \\"\\"\\"Contained by the specified JSON.\\"\\"\\"
+  """Contained by the specified JSON."""
   containedBy: JSON
 
-  \\"\\"\\"Contains the specified JSON.\\"\\"\\"
+  """Contains the specified JSON."""
   contains: JSON
 
-  \\"\\"\\"Contains all of the specified keys.\\"\\"\\"
+  """Contains all of the specified keys."""
   containsAllKeys: [String!]
 
-  \\"\\"\\"Contains any of the specified keys.\\"\\"\\"
+  """Contains any of the specified keys."""
   containsAnyKeys: [String!]
 
-  \\"\\"\\"Contains the specified key.\\"\\"\\"
+  """Contains the specified key."""
   containsKey: String
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: JSON
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: JSON
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: JSON
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: JSON
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [JSON!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: JSON
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: JSON
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: JSON
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: JSON
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [JSON!]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against JSON List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input JSONListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: JSON
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: JSON
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: JSON
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: JSON
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: JSON
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: JSON
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [JSON]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [JSON]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [JSON]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [JSON]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [JSON]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [JSON]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [JSON]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [JSON]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [JSON]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [JSON]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [JSON]
 }
 
 type Junction implements Node {
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 
-  \\"\\"\\"Reads a single \`SideA\` that is related to this \`Junction\`.\\"\\"\\"
+  """Reads a single \`SideA\` that is related to this \`Junction\`."""
   sideABySideAId: SideA
   sideAId: Int!
 
-  \\"\\"\\"Reads a single \`SideB\` that is related to this \`Junction\`.\\"\\"\\"
+  """Reads a single \`SideB\` that is related to this \`Junction\`."""
   sideBBySideBId: SideB
   sideBId: Int!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`Junction\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input JunctionFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [JunctionFilter!]
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: JunctionFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [JunctionFilter!]
 
-  \\"\\"\\"Filter by the object’s \`sideAId\` field.\\"\\"\\"
+  """Filter by the object’s \`sideAId\` field."""
   sideAId: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`sideBId\` field.\\"\\"\\"
+  """Filter by the object’s \`sideBId\` field."""
   sideBId: IntFilter
 }
 
-\\"\\"\\"A connection to a list of \`Junction\` values.\\"\\"\\"
+"""A connection to a list of \`Junction\` values."""
 type JunctionsConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`Junction\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [JunctionsEdge!]!
 
-  \\"\\"\\"A list of \`Junction\` objects.\\"\\"\\"
+  """A list of \`Junction\` objects."""
   nodes: [Junction]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`Junction\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`Junction\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`Junction\` edge in the connection.\\"\\"\\"
+"""A \`Junction\` edge in the connection."""
 type JunctionsEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`Junction\` at the end of the edge.\\"\\"\\"
+  """The \`Junction\` at the end of the edge."""
   node: Junction
 }
 
-\\"\\"\\"Methods to use when ordering \`Junction\`.\\"\\"\\"
+"""Methods to use when ordering \`Junction\`."""
 enum JunctionsOrderBy {
   NATURAL
   PRIMARY_KEY_ASC
@@ -4210,116 +4210,116 @@ enum JunctionsOrderBy {
   SIDE_B_ID_DESC
 }
 
-\\"\\"\\"
+"""
 A set of key/value pairs, keys are strings, values may be a string or null. Exposed as a JSON object.
-\\"\\"\\"
+"""
 scalar KeyValueHash
 
-\\"\\"\\"
+"""
 A filter to be used against KeyValueHash fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input KeyValueHashFilter {
-  \\"\\"\\"Contained by the specified KeyValueHash.\\"\\"\\"
+  """Contained by the specified KeyValueHash."""
   containedBy: KeyValueHash
 
-  \\"\\"\\"Contains the specified KeyValueHash.\\"\\"\\"
+  """Contains the specified KeyValueHash."""
   contains: KeyValueHash
 
-  \\"\\"\\"Contains all of the specified keys.\\"\\"\\"
+  """Contains all of the specified keys."""
   containsAllKeys: [String!]
 
-  \\"\\"\\"Contains any of the specified keys.\\"\\"\\"
+  """Contains any of the specified keys."""
   containsAnyKeys: [String!]
 
-  \\"\\"\\"Contains the specified key.\\"\\"\\"
+  """Contains the specified key."""
   containsKey: String
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: KeyValueHash
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: KeyValueHash
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [KeyValueHash!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: KeyValueHash
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: KeyValueHash
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [KeyValueHash!]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against KeyValueHash List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input KeyValueHashListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: KeyValueHash
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: KeyValueHash
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: KeyValueHash
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: KeyValueHash
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: KeyValueHash
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: KeyValueHash
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [KeyValueHash]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [KeyValueHash]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [KeyValueHash]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [KeyValueHash]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [KeyValueHash]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [KeyValueHash]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [KeyValueHash]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [KeyValueHash]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [KeyValueHash]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [KeyValueHash]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [KeyValueHash]
 }
 
@@ -4329,219 +4329,219 @@ enum Mood {
   SAD
 }
 
-\\"\\"\\"
+"""
 A filter to be used against Mood fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input MoodFilter {
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: Mood
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: Mood
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: Mood
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: Mood
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [Mood!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: Mood
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: Mood
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: Mood
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: Mood
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [Mood!]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against Mood List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input MoodListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: Mood
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: Mood
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: Mood
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: Mood
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: Mood
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: Mood
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [Mood]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [Mood]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [Mood]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [Mood]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [Mood]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [Mood]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [Mood]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [Mood]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [Mood]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [Mood]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [Mood]
 }
 
-\\"\\"\\"An object with a globally unique \`ID\`.\\"\\"\\"
+"""An object with a globally unique \`ID\`."""
 interface Node {
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
-\\"\\"\\"Information about pagination in a connection.\\"\\"\\"
+"""Information about pagination in a connection."""
 type PageInfo {
-  \\"\\"\\"When paginating forwards, the cursor to continue.\\"\\"\\"
+  """When paginating forwards, the cursor to continue."""
   endCursor: Cursor
 
-  \\"\\"\\"When paginating forwards, are there more items?\\"\\"\\"
+  """When paginating forwards, are there more items?"""
   hasNextPage: Boolean!
 
-  \\"\\"\\"When paginating backwards, are there more items?\\"\\"\\"
+  """When paginating backwards, are there more items?"""
   hasPreviousPage: Boolean!
 
-  \\"\\"\\"When paginating backwards, the cursor to continue.\\"\\"\\"
+  """When paginating backwards, the cursor to continue."""
   startCursor: Cursor
 }
 
 type Parent implements Node {
-  \\"\\"\\"Reads and enables pagination through a set of \`Filterable\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Filterable\`."""
   filterablesByParentId(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: FilterableFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`Filterable\`.\\"\\"\\"
+    """The method to use when ordering \`Filterable\`."""
     orderBy: [FilterablesOrderBy!] = [PRIMARY_KEY_ASC]
   ): FilterablesConnection!
   id: Int!
   name: String!
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`Parent\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input ParentFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [ParentFilter!]
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`name\` field.\\"\\"\\"
+  """Filter by the object’s \`name\` field."""
   name: StringFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: ParentFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [ParentFilter!]
 }
 
-\\"\\"\\"A connection to a list of \`Parent\` values.\\"\\"\\"
+"""A connection to a list of \`Parent\` values."""
 type ParentsConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`Parent\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [ParentsEdge!]!
 
-  \\"\\"\\"A list of \`Parent\` objects.\\"\\"\\"
+  """A list of \`Parent\` objects."""
   nodes: [Parent]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`Parent\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`Parent\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`Parent\` edge in the connection.\\"\\"\\"
+"""A \`Parent\` edge in the connection."""
 type ParentsEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`Parent\` at the end of the edge.\\"\\"\\"
+  """The \`Parent\` at the end of the edge."""
   node: Parent
 }
 
-\\"\\"\\"Methods to use when ordering \`Parent\`.\\"\\"\\"
+"""Methods to use when ordering \`Parent\`."""
 enum ParentsOrderBy {
   ID_ASC
   ID_DESC
@@ -4556,704 +4556,704 @@ type Protected implements Node {
   id: Int!
   name: String
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
   otherId: Int
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`Protected\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input ProtectedFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [ProtectedFilter!]
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`name\` field.\\"\\"\\"
+  """Filter by the object’s \`name\` field."""
   name: StringFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: ProtectedFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [ProtectedFilter!]
 
-  \\"\\"\\"Filter by the object’s \`otherId\` field.\\"\\"\\"
+  """Filter by the object’s \`otherId\` field."""
   otherId: IntFilter
 }
 
-\\"\\"\\"A connection to a list of \`Protected\` values.\\"\\"\\"
+"""A connection to a list of \`Protected\` values."""
 type ProtectedsConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`Protected\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [ProtectedsEdge!]!
 
-  \\"\\"\\"A list of \`Protected\` objects.\\"\\"\\"
+  """A list of \`Protected\` objects."""
   nodes: [Protected]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`Protected\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`Protected\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`Protected\` edge in the connection.\\"\\"\\"
+"""A \`Protected\` edge in the connection."""
 type ProtectedsEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`Protected\` at the end of the edge.\\"\\"\\"
+  """The \`Protected\` at the end of the edge."""
   node: Protected
 }
 
-\\"\\"\\"The root query type which gives access points into the data universe.\\"\\"\\"
+"""The root query type which gives access points into the data universe."""
 type Query implements Node {
-  \\"\\"\\"Reads and enables pagination through a set of \`ArrayType\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`ArrayType\`."""
   allArrayTypes(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: ArrayTypeFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`ArrayType\`.\\"\\"\\"
+    """The method to use when ordering \`ArrayType\`."""
     orderBy: [ArrayTypesOrderBy!] = [PRIMARY_KEY_ASC]
   ): ArrayTypesConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`BackwardCompound\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`BackwardCompound\`."""
   allBackwardCompounds(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: BackwardCompoundFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`BackwardCompound\`.\\"\\"\\"
+    """The method to use when ordering \`BackwardCompound\`."""
     orderBy: [BackwardCompoundsOrderBy!] = [PRIMARY_KEY_ASC]
   ): BackwardCompoundsConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Backward\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Backward\`."""
   allBackwards(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: BackwardFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`Backward\`.\\"\\"\\"
+    """The method to use when ordering \`Backward\`."""
     orderBy: [BackwardsOrderBy!] = [PRIMARY_KEY_ASC]
   ): BackwardsConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`ChildNoRelatedFilter\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`ChildNoRelatedFilter\`."""
   allChildNoRelatedFilters(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: ChildNoRelatedFilterFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`ChildNoRelatedFilter\`.\\"\\"\\"
+    """The method to use when ordering \`ChildNoRelatedFilter\`."""
     orderBy: [ChildNoRelatedFiltersOrderBy!] = [PRIMARY_KEY_ASC]
   ): ChildNoRelatedFiltersConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Child\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Child\`."""
   allChildren(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: ChildFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`Child\`.\\"\\"\\"
+    """The method to use when ordering \`Child\`."""
     orderBy: [ChildrenOrderBy!] = [PRIMARY_KEY_ASC]
   ): ChildrenConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`DomainType\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`DomainType\`."""
   allDomainTypes(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: DomainTypeFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`DomainType\`.\\"\\"\\"
+    """The method to use when ordering \`DomainType\`."""
     orderBy: [DomainTypesOrderBy!] = [PRIMARY_KEY_ASC]
   ): DomainTypesConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`EnumArrayType\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`EnumArrayType\`."""
   allEnumArrayTypes(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: EnumArrayTypeFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`EnumArrayType\`.\\"\\"\\"
+    """The method to use when ordering \`EnumArrayType\`."""
     orderBy: [EnumArrayTypesOrderBy!] = [PRIMARY_KEY_ASC]
   ): EnumArrayTypesConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`EnumType\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`EnumType\`."""
   allEnumTypes(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: EnumTypeFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`EnumType\`.\\"\\"\\"
+    """The method to use when ordering \`EnumType\`."""
     orderBy: [EnumTypesOrderBy!] = [PRIMARY_KEY_ASC]
   ): EnumTypesConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Filterable\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Filterable\`."""
   allFilterables(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: FilterableFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`Filterable\`.\\"\\"\\"
+    """The method to use when ordering \`Filterable\`."""
     orderBy: [FilterablesOrderBy!] = [PRIMARY_KEY_ASC]
   ): FilterablesConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`ForwardCompound\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`ForwardCompound\`."""
   allForwardCompounds(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: ForwardCompoundFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`ForwardCompound\`.\\"\\"\\"
+    """The method to use when ordering \`ForwardCompound\`."""
     orderBy: [ForwardCompoundsOrderBy!] = [PRIMARY_KEY_ASC]
   ): ForwardCompoundsConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Forward\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Forward\`."""
   allForwards(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: ForwardFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`Forward\`.\\"\\"\\"
+    """The method to use when ordering \`Forward\`."""
     orderBy: [ForwardsOrderBy!] = [PRIMARY_KEY_ASC]
   ): ForwardsConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`FullyOmitted\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`FullyOmitted\`."""
   allFullyOmitteds(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`FullyOmitted\`.\\"\\"\\"
+    """The method to use when ordering \`FullyOmitted\`."""
     orderBy: [FullyOmittedsOrderBy!] = [PRIMARY_KEY_ASC]
   ): FullyOmittedsConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`JsonbTest\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`JsonbTest\`."""
   allJsonbTests(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: JsonbTestFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`JsonbTest\`.\\"\\"\\"
+    """The method to use when ordering \`JsonbTest\`."""
     orderBy: [JsonbTestsOrderBy!] = [PRIMARY_KEY_ASC]
   ): JsonbTestsConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Junction\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Junction\`."""
   allJunctions(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: JunctionFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`Junction\`.\\"\\"\\"
+    """The method to use when ordering \`Junction\`."""
     orderBy: [JunctionsOrderBy!] = [PRIMARY_KEY_ASC]
   ): JunctionsConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Parent\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Parent\`."""
   allParents(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: ParentFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`Parent\`.\\"\\"\\"
+    """The method to use when ordering \`Parent\`."""
     orderBy: [ParentsOrderBy!] = [PRIMARY_KEY_ASC]
   ): ParentsConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`RangeArrayType\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`RangeArrayType\`."""
   allRangeArrayTypes(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: RangeArrayTypeFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`RangeArrayType\`.\\"\\"\\"
+    """The method to use when ordering \`RangeArrayType\`."""
     orderBy: [RangeArrayTypesOrderBy!] = [PRIMARY_KEY_ASC]
   ): RangeArrayTypesConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`RangeType\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`RangeType\`."""
   allRangeTypes(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: RangeTypeFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`RangeType\`.\\"\\"\\"
+    """The method to use when ordering \`RangeType\`."""
     orderBy: [RangeTypesOrderBy!] = [PRIMARY_KEY_ASC]
   ): RangeTypesConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`SideA\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`SideA\`."""
   allSideAs(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: SideAFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`SideA\`.\\"\\"\\"
+    """The method to use when ordering \`SideA\`."""
     orderBy: [SideAsOrderBy!] = [PRIMARY_KEY_ASC]
   ): SideAsConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`SideB\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`SideB\`."""
   allSideBs(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: SideBFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`SideB\`.\\"\\"\\"
+    """The method to use when ordering \`SideB\`."""
     orderBy: [SideBsOrderBy!] = [PRIMARY_KEY_ASC]
   ): SideBsConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Unfilterable\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Unfilterable\`."""
   allUnfilterables(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`Unfilterable\`.\\"\\"\\"
+    """The method to use when ordering \`Unfilterable\`."""
     orderBy: [UnfilterablesOrderBy!] = [PRIMARY_KEY_ASC]
   ): UnfilterablesConnection
 
-  \\"\\"\\"Reads a single \`ArrayType\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`ArrayType\` using its globally unique \`ID\`."""
   arrayType(
-    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`ArrayType\`.\\"\\"\\"
+    """The globally unique \`ID\` to be used in selecting a single \`ArrayType\`."""
     nodeId: ID!
   ): ArrayType
   arrayTypeById(id: Int!): ArrayType
 
-  \\"\\"\\"Reads a single \`Backward\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`Backward\` using its globally unique \`ID\`."""
   backward(
-    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`Backward\`.\\"\\"\\"
+    """The globally unique \`ID\` to be used in selecting a single \`Backward\`."""
     nodeId: ID!
   ): Backward
   backwardByFilterableId(filterableId: Int!): Backward
   backwardById(id: Int!): Backward
 
-  \\"\\"\\"Reads a single \`BackwardCompound\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`BackwardCompound\` using its globally unique \`ID\`."""
   backwardCompound(
-    \\"\\"\\"
+    """
     The globally unique \`ID\` to be used in selecting a single \`BackwardCompound\`.
-    \\"\\"\\"
+    """
     nodeId: ID!
   ): BackwardCompound
   backwardCompoundByBackwardCompound1AndBackwardCompound2(backwardCompound1: Int!, backwardCompound2: Int!): BackwardCompound
 
-  \\"\\"\\"Reads a single \`Child\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`Child\` using its globally unique \`ID\`."""
   child(
-    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`Child\`.\\"\\"\\"
+    """The globally unique \`ID\` to be used in selecting a single \`Child\`."""
     nodeId: ID!
   ): Child
   childById(id: Int!): Child
 
-  \\"\\"\\"Reads a single \`ChildNoRelatedFilter\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`ChildNoRelatedFilter\` using its globally unique \`ID\`."""
   childNoRelatedFilter(
-    \\"\\"\\"
+    """
     The globally unique \`ID\` to be used in selecting a single \`ChildNoRelatedFilter\`.
-    \\"\\"\\"
+    """
     nodeId: ID!
   ): ChildNoRelatedFilter
   childNoRelatedFilterById(id: Int!): ChildNoRelatedFilter
 
-  \\"\\"\\"Reads a single \`DomainType\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`DomainType\` using its globally unique \`ID\`."""
   domainType(
-    \\"\\"\\"
+    """
     The globally unique \`ID\` to be used in selecting a single \`DomainType\`.
-    \\"\\"\\"
+    """
     nodeId: ID!
   ): DomainType
   domainTypeById(id: Int!): DomainType
 
-  \\"\\"\\"Reads a single \`EnumArrayType\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`EnumArrayType\` using its globally unique \`ID\`."""
   enumArrayType(
-    \\"\\"\\"
+    """
     The globally unique \`ID\` to be used in selecting a single \`EnumArrayType\`.
-    \\"\\"\\"
+    """
     nodeId: ID!
   ): EnumArrayType
   enumArrayTypeById(id: Int!): EnumArrayType
 
-  \\"\\"\\"Reads a single \`EnumType\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`EnumType\` using its globally unique \`ID\`."""
   enumType(
-    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`EnumType\`.\\"\\"\\"
+    """The globally unique \`ID\` to be used in selecting a single \`EnumType\`."""
     nodeId: ID!
   ): EnumType
   enumTypeById(id: Int!): EnumType
 
-  \\"\\"\\"Reads a single \`Filterable\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`Filterable\` using its globally unique \`ID\`."""
   filterable(
-    \\"\\"\\"
+    """
     The globally unique \`ID\` to be used in selecting a single \`Filterable\`.
-    \\"\\"\\"
+    """
     nodeId: ID!
   ): Filterable
   filterableByBackwardCompound1AndBackwardCompound2(backwardCompound1: Int!, backwardCompound2: Int!): Filterable
@@ -5261,247 +5261,247 @@ type Query implements Node {
   filterableByForwardId(forwardId: Int!): Filterable
   filterableById(id: Int!): Filterable
 
-  \\"\\"\\"Reads a single \`FilterableClosure\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`FilterableClosure\` using its globally unique \`ID\`."""
   filterableClosure(
-    \\"\\"\\"
+    """
     The globally unique \`ID\` to be used in selecting a single \`FilterableClosure\`.
-    \\"\\"\\"
+    """
     nodeId: ID!
   ): FilterableClosure
   filterableClosureById(id: Int!): FilterableClosure
 
-  \\"\\"\\"Reads a single \`Forward\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`Forward\` using its globally unique \`ID\`."""
   forward(
-    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`Forward\`.\\"\\"\\"
+    """The globally unique \`ID\` to be used in selecting a single \`Forward\`."""
     nodeId: ID!
   ): Forward
   forwardById(id: Int!): Forward
 
-  \\"\\"\\"Reads a single \`ForwardCompound\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`ForwardCompound\` using its globally unique \`ID\`."""
   forwardCompound(
-    \\"\\"\\"
+    """
     The globally unique \`ID\` to be used in selecting a single \`ForwardCompound\`.
-    \\"\\"\\"
+    """
     nodeId: ID!
   ): ForwardCompound
   forwardCompoundByForwardCompound1AndForwardCompound2(forwardCompound1: Int!, forwardCompound2: Int!): ForwardCompound
 
-  \\"\\"\\"Reads a single \`FullyOmitted\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`FullyOmitted\` using its globally unique \`ID\`."""
   fullyOmitted(
-    \\"\\"\\"
+    """
     The globally unique \`ID\` to be used in selecting a single \`FullyOmitted\`.
-    \\"\\"\\"
+    """
     nodeId: ID!
   ): FullyOmitted
   fullyOmittedById(id: Int!): FullyOmitted
   funcReturnsTableMultiCol(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: FuncReturnsTableMultiColRecordFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
     i: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
   ): FuncReturnsTableMultiColConnection!
   funcReturnsTableOneCol(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: IntFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
     i: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
   ): FuncReturnsTableOneColConnection!
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Filterable\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Filterable\`."""
   funcTaggedFilterableReturnsSetofFilterable(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: FilterableFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
   ): FilterablesConnection!
   funcTaggedFilterableReturnsTableMultiCol(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: FuncTaggedFilterableReturnsTableMultiColRecordFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
   ): FuncTaggedFilterableReturnsTableMultiColConnection!
 
-  \\"\\"\\"Reads a single \`JsonbTest\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`JsonbTest\` using its globally unique \`ID\`."""
   jsonbTest(
-    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`JsonbTest\`.\\"\\"\\"
+    """The globally unique \`ID\` to be used in selecting a single \`JsonbTest\`."""
     nodeId: ID!
   ): JsonbTest
   jsonbTestById(id: Int!): JsonbTest
 
-  \\"\\"\\"Reads a single \`Junction\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`Junction\` using its globally unique \`ID\`."""
   junction(
-    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`Junction\`.\\"\\"\\"
+    """The globally unique \`ID\` to be used in selecting a single \`Junction\`."""
     nodeId: ID!
   ): Junction
   junctionBySideAIdAndSideBId(sideAId: Int!, sideBId: Int!): Junction
 
-  \\"\\"\\"Fetches an object given its globally unique \`ID\`.\\"\\"\\"
+  """Fetches an object given its globally unique \`ID\`."""
   node(
-    \\"\\"\\"The globally unique \`ID\`.\\"\\"\\"
+    """The globally unique \`ID\`."""
     nodeId: ID!
   ): Node
 
-  \\"\\"\\"
+  """
   The root query type must be a \`Node\` to work well with Relay 1 mutations. This just resolves to \`query\`.
-  \\"\\"\\"
+  """
   nodeId: ID!
 
-  \\"\\"\\"Reads a single \`Parent\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`Parent\` using its globally unique \`ID\`."""
   parent(
-    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`Parent\`.\\"\\"\\"
+    """The globally unique \`ID\` to be used in selecting a single \`Parent\`."""
     nodeId: ID!
   ): Parent
   parentById(id: Int!): Parent
 
-  \\"\\"\\"Reads a single \`Protected\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`Protected\` using its globally unique \`ID\`."""
   protected(
-    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`Protected\`.\\"\\"\\"
+    """The globally unique \`ID\` to be used in selecting a single \`Protected\`."""
     nodeId: ID!
   ): Protected
   protectedById(id: Int!): Protected
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Protected\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Protected\`."""
   protectedsByOtherId(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: ProtectedFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
     otherId: Int
   ): ProtectedsConnection!
 
-  \\"\\"\\"
+  """
   Exposes the root query type nested one level down. This is helpful for Relay 1
   which can only query top level fields if they are in a particular form.
-  \\"\\"\\"
+  """
   query: Query!
 
-  \\"\\"\\"Reads a single \`RangeArrayType\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`RangeArrayType\` using its globally unique \`ID\`."""
   rangeArrayType(
-    \\"\\"\\"
+    """
     The globally unique \`ID\` to be used in selecting a single \`RangeArrayType\`.
-    \\"\\"\\"
+    """
     nodeId: ID!
   ): RangeArrayType
   rangeArrayTypeById(id: Int!): RangeArrayType
 
-  \\"\\"\\"Reads a single \`RangeType\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`RangeType\` using its globally unique \`ID\`."""
   rangeType(
-    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`RangeType\`.\\"\\"\\"
+    """The globally unique \`ID\` to be used in selecting a single \`RangeType\`."""
     nodeId: ID!
   ): RangeType
   rangeTypeById(id: Int!): RangeType
 
-  \\"\\"\\"Reads a single \`SideA\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`SideA\` using its globally unique \`ID\`."""
   sideA(
-    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`SideA\`.\\"\\"\\"
+    """The globally unique \`ID\` to be used in selecting a single \`SideA\`."""
     nodeId: ID!
   ): SideA
   sideAByAId(aId: Int!): SideA
 
-  \\"\\"\\"Reads a single \`SideB\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`SideB\` using its globally unique \`ID\`."""
   sideB(
-    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`SideB\`.\\"\\"\\"
+    """The globally unique \`ID\` to be used in selecting a single \`SideB\`."""
     nodeId: ID!
   ): SideB
   sideBByBId(bId: Int!): SideB
 
-  \\"\\"\\"Reads a single \`Unfilterable\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`Unfilterable\` using its globally unique \`ID\`."""
   unfilterable(
-    \\"\\"\\"
+    """
     The globally unique \`ID\` to be used in selecting a single \`Unfilterable\`.
-    \\"\\"\\"
+    """
     nodeId: ID!
   ): Unfilterable
   unfilterableById(id: Int!): Unfilterable
@@ -5513,77 +5513,77 @@ type RangeArrayType implements Node {
   int4RangeArray: [IntRange]
   int8RangeArray: [BigIntRange]
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
   numericRangeArray: [BigFloatRange]
   timestampRangeArray: [DatetimeRange]
   timestamptzRangeArray: [DatetimeRange]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`RangeArrayType\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input RangeArrayTypeFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [RangeArrayTypeFilter!]
 
-  \\"\\"\\"Filter by the object’s \`dateRangeArray\` field.\\"\\"\\"
+  """Filter by the object’s \`dateRangeArray\` field."""
   dateRangeArray: DateRangeListFilter
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`int4RangeArray\` field.\\"\\"\\"
+  """Filter by the object’s \`int4RangeArray\` field."""
   int4RangeArray: IntRangeListFilter
 
-  \\"\\"\\"Filter by the object’s \`int8RangeArray\` field.\\"\\"\\"
+  """Filter by the object’s \`int8RangeArray\` field."""
   int8RangeArray: BigIntRangeListFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: RangeArrayTypeFilter
 
-  \\"\\"\\"Filter by the object’s \`numericRangeArray\` field.\\"\\"\\"
+  """Filter by the object’s \`numericRangeArray\` field."""
   numericRangeArray: BigFloatRangeListFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [RangeArrayTypeFilter!]
 
-  \\"\\"\\"Filter by the object’s \`timestampRangeArray\` field.\\"\\"\\"
+  """Filter by the object’s \`timestampRangeArray\` field."""
   timestampRangeArray: DatetimeRangeListFilter
 
-  \\"\\"\\"Filter by the object’s \`timestamptzRangeArray\` field.\\"\\"\\"
+  """Filter by the object’s \`timestamptzRangeArray\` field."""
   timestamptzRangeArray: DatetimeRangeListFilter
 }
 
-\\"\\"\\"A connection to a list of \`RangeArrayType\` values.\\"\\"\\"
+"""A connection to a list of \`RangeArrayType\` values."""
 type RangeArrayTypesConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`RangeArrayType\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [RangeArrayTypesEdge!]!
 
-  \\"\\"\\"A list of \`RangeArrayType\` objects.\\"\\"\\"
+  """A list of \`RangeArrayType\` objects."""
   nodes: [RangeArrayType]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`RangeArrayType\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`RangeArrayType\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`RangeArrayType\` edge in the connection.\\"\\"\\"
+"""A \`RangeArrayType\` edge in the connection."""
 type RangeArrayTypesEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`RangeArrayType\` at the end of the edge.\\"\\"\\"
+  """The \`RangeArrayType\` at the end of the edge."""
   node: RangeArrayType
 }
 
-\\"\\"\\"Methods to use when ordering \`RangeArrayType\`.\\"\\"\\"
+"""Methods to use when ordering \`RangeArrayType\`."""
 enum RangeArrayTypesOrderBy {
   DATE_RANGE_ARRAY_ASC
   DATE_RANGE_ARRAY_DESC
@@ -5610,77 +5610,77 @@ type RangeType implements Node {
   int4Range: IntRange
   int8Range: BigIntRange
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
   numericRange: BigFloatRange
   timestampRange: DatetimeRange
   timestamptzRange: DatetimeRange
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`RangeType\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input RangeTypeFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [RangeTypeFilter!]
 
-  \\"\\"\\"Filter by the object’s \`dateRange\` field.\\"\\"\\"
+  """Filter by the object’s \`dateRange\` field."""
   dateRange: DateRangeFilter
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`int4Range\` field.\\"\\"\\"
+  """Filter by the object’s \`int4Range\` field."""
   int4Range: IntRangeFilter
 
-  \\"\\"\\"Filter by the object’s \`int8Range\` field.\\"\\"\\"
+  """Filter by the object’s \`int8Range\` field."""
   int8Range: BigIntRangeFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: RangeTypeFilter
 
-  \\"\\"\\"Filter by the object’s \`numericRange\` field.\\"\\"\\"
+  """Filter by the object’s \`numericRange\` field."""
   numericRange: BigFloatRangeFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [RangeTypeFilter!]
 
-  \\"\\"\\"Filter by the object’s \`timestampRange\` field.\\"\\"\\"
+  """Filter by the object’s \`timestampRange\` field."""
   timestampRange: DatetimeRangeFilter
 
-  \\"\\"\\"Filter by the object’s \`timestamptzRange\` field.\\"\\"\\"
+  """Filter by the object’s \`timestamptzRange\` field."""
   timestamptzRange: DatetimeRangeFilter
 }
 
-\\"\\"\\"A connection to a list of \`RangeType\` values.\\"\\"\\"
+"""A connection to a list of \`RangeType\` values."""
 type RangeTypesConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`RangeType\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [RangeTypesEdge!]!
 
-  \\"\\"\\"A list of \`RangeType\` objects.\\"\\"\\"
+  """A list of \`RangeType\` objects."""
   nodes: [RangeType]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`RangeType\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`RangeType\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`RangeType\` edge in the connection.\\"\\"\\"
+"""A \`RangeType\` edge in the connection."""
 type RangeTypesEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`RangeType\` at the end of the edge.\\"\\"\\"
+  """The \`RangeType\` at the end of the edge."""
   node: RangeType
 }
 
-\\"\\"\\"Methods to use when ordering \`RangeType\`.\\"\\"\\"
+"""Methods to use when ordering \`RangeType\`."""
 enum RangeTypesOrderBy {
   DATE_RANGE_ASC
   DATE_RANGE_DESC
@@ -5704,89 +5704,89 @@ enum RangeTypesOrderBy {
 type SideA implements Node {
   aId: Int!
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Junction\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Junction\`."""
   junctionsBySideAId(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: JunctionFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`Junction\`.\\"\\"\\"
+    """The method to use when ordering \`Junction\`."""
     orderBy: [JunctionsOrderBy!] = [PRIMARY_KEY_ASC]
   ): JunctionsConnection!
   name: String!
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`SideA\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input SideAFilter {
-  \\"\\"\\"Filter by the object’s \`aId\` field.\\"\\"\\"
+  """Filter by the object’s \`aId\` field."""
   aId: IntFilter
 
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [SideAFilter!]
 
-  \\"\\"\\"Filter by the object’s \`name\` field.\\"\\"\\"
+  """Filter by the object’s \`name\` field."""
   name: StringFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: SideAFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [SideAFilter!]
 }
 
-\\"\\"\\"A connection to a list of \`SideA\` values.\\"\\"\\"
+"""A connection to a list of \`SideA\` values."""
 type SideAsConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`SideA\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [SideAsEdge!]!
 
-  \\"\\"\\"A list of \`SideA\` objects.\\"\\"\\"
+  """A list of \`SideA\` objects."""
   nodes: [SideA]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`SideA\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`SideA\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`SideA\` edge in the connection.\\"\\"\\"
+"""A \`SideA\` edge in the connection."""
 type SideAsEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`SideA\` at the end of the edge.\\"\\"\\"
+  """The \`SideA\` at the end of the edge."""
   node: SideA
 }
 
-\\"\\"\\"Methods to use when ordering \`SideA\`.\\"\\"\\"
+"""Methods to use when ordering \`SideA\`."""
 enum SideAsOrderBy {
   A_ID_ASC
   A_ID_DESC
@@ -5800,89 +5800,89 @@ enum SideAsOrderBy {
 type SideB implements Node {
   bId: Int!
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Junction\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Junction\`."""
   junctionsBySideBId(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: JunctionFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`Junction\`.\\"\\"\\"
+    """The method to use when ordering \`Junction\`."""
     orderBy: [JunctionsOrderBy!] = [PRIMARY_KEY_ASC]
   ): JunctionsConnection!
   name: String!
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`SideB\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input SideBFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [SideBFilter!]
 
-  \\"\\"\\"Filter by the object’s \`bId\` field.\\"\\"\\"
+  """Filter by the object’s \`bId\` field."""
   bId: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`name\` field.\\"\\"\\"
+  """Filter by the object’s \`name\` field."""
   name: StringFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: SideBFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [SideBFilter!]
 }
 
-\\"\\"\\"A connection to a list of \`SideB\` values.\\"\\"\\"
+"""A connection to a list of \`SideB\` values."""
 type SideBsConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`SideB\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [SideBsEdge!]!
 
-  \\"\\"\\"A list of \`SideB\` objects.\\"\\"\\"
+  """A list of \`SideB\` objects."""
   nodes: [SideB]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`SideB\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`SideB\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`SideB\` edge in the connection.\\"\\"\\"
+"""A \`SideB\` edge in the connection."""
 type SideBsEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`SideB\` at the end of the edge.\\"\\"\\"
+  """The \`SideB\` at the end of the edge."""
   node: SideB
 }
 
-\\"\\"\\"Methods to use when ordering \`SideB\`.\\"\\"\\"
+"""Methods to use when ordering \`SideB\`."""
 enum SideBsOrderBy {
   B_ID_ASC
   B_ID_DESC
@@ -5893,382 +5893,382 @@ enum SideBsOrderBy {
   PRIMARY_KEY_DESC
 }
 
-\\"\\"\\"
+"""
 A filter to be used against String fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input StringFilter {
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: String
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value (case-insensitive).
-  \\"\\"\\"
+  """
   distinctFromInsensitive: String
 
-  \\"\\"\\"Ends with the specified string (case-sensitive).\\"\\"\\"
+  """Ends with the specified string (case-sensitive)."""
   endsWith: String
 
-  \\"\\"\\"Ends with the specified string (case-insensitive).\\"\\"\\"
+  """Ends with the specified string (case-insensitive)."""
   endsWithInsensitive: String
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: String
 
-  \\"\\"\\"Equal to the specified value (case-insensitive).\\"\\"\\"
+  """Equal to the specified value (case-insensitive)."""
   equalToInsensitive: String
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: String
 
-  \\"\\"\\"Greater than the specified value (case-insensitive).\\"\\"\\"
+  """Greater than the specified value (case-insensitive)."""
   greaterThanInsensitive: String
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: String
 
-  \\"\\"\\"Greater than or equal to the specified value (case-insensitive).\\"\\"\\"
+  """Greater than or equal to the specified value (case-insensitive)."""
   greaterThanOrEqualToInsensitive: String
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [String!]
 
-  \\"\\"\\"Included in the specified list (case-insensitive).\\"\\"\\"
-  inInsensitive: [String!]
-
-  \\"\\"\\"Contains the specified string (case-sensitive).\\"\\"\\"
+  """Contains the specified string (case-sensitive)."""
   includes: String
 
-  \\"\\"\\"Contains the specified string (case-insensitive).\\"\\"\\"
+  """Contains the specified string (case-insensitive)."""
   includesInsensitive: String
 
-  \\"\\"\\"
+  """Included in the specified list (case-insensitive)."""
+  inInsensitive: [String!]
+
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: String
 
-  \\"\\"\\"Less than the specified value (case-insensitive).\\"\\"\\"
+  """Less than the specified value (case-insensitive)."""
   lessThanInsensitive: String
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: String
 
-  \\"\\"\\"Less than or equal to the specified value (case-insensitive).\\"\\"\\"
+  """Less than or equal to the specified value (case-insensitive)."""
   lessThanOrEqualToInsensitive: String
 
-  \\"\\"\\"
+  """
   Matches the specified pattern (case-sensitive). An underscore (_) matches any
   single character; a percent sign (%) matches any sequence of zero or more characters.
-  \\"\\"\\"
+  """
   like: String
 
-  \\"\\"\\"
+  """
   Matches the specified pattern (case-insensitive). An underscore (_) matches
   any single character; a percent sign (%) matches any sequence of zero or more characters.
-  \\"\\"\\"
+  """
   likeInsensitive: String
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: String
 
-  \\"\\"\\"
+  """
   Equal to the specified value, treating null like an ordinary value (case-insensitive).
-  \\"\\"\\"
+  """
   notDistinctFromInsensitive: String
 
-  \\"\\"\\"Does not end with the specified string (case-sensitive).\\"\\"\\"
+  """Does not end with the specified string (case-sensitive)."""
   notEndsWith: String
 
-  \\"\\"\\"Does not end with the specified string (case-insensitive).\\"\\"\\"
+  """Does not end with the specified string (case-insensitive)."""
   notEndsWithInsensitive: String
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: String
 
-  \\"\\"\\"Not equal to the specified value (case-insensitive).\\"\\"\\"
+  """Not equal to the specified value (case-insensitive)."""
   notEqualToInsensitive: String
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [String!]
 
-  \\"\\"\\"Not included in the specified list (case-insensitive).\\"\\"\\"
-  notInInsensitive: [String!]
-
-  \\"\\"\\"Does not contain the specified string (case-sensitive).\\"\\"\\"
+  """Does not contain the specified string (case-sensitive)."""
   notIncludes: String
 
-  \\"\\"\\"Does not contain the specified string (case-insensitive).\\"\\"\\"
+  """Does not contain the specified string (case-insensitive)."""
   notIncludesInsensitive: String
 
-  \\"\\"\\"
+  """Not included in the specified list (case-insensitive)."""
+  notInInsensitive: [String!]
+
+  """
   Does not match the specified pattern (case-sensitive). An underscore (_)
   matches any single character; a percent sign (%) matches any sequence of zero
   or more characters.
-  \\"\\"\\"
+  """
   notLike: String
 
-  \\"\\"\\"
+  """
   Does not match the specified pattern (case-insensitive). An underscore (_)
   matches any single character; a percent sign (%) matches any sequence of zero
   or more characters.
-  \\"\\"\\"
+  """
   notLikeInsensitive: String
 
-  \\"\\"\\"Does not start with the specified string (case-sensitive).\\"\\"\\"
+  """Does not start with the specified string (case-sensitive)."""
   notStartsWith: String
 
-  \\"\\"\\"Does not start with the specified string (case-insensitive).\\"\\"\\"
+  """Does not start with the specified string (case-insensitive)."""
   notStartsWithInsensitive: String
 
-  \\"\\"\\"Starts with the specified string (case-sensitive).\\"\\"\\"
+  """Starts with the specified string (case-sensitive)."""
   startsWith: String
 
-  \\"\\"\\"Starts with the specified string (case-insensitive).\\"\\"\\"
+  """Starts with the specified string (case-insensitive)."""
   startsWithInsensitive: String
 }
 
-\\"\\"\\"
+"""
 A filter to be used against String List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input StringListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: String
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: String
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: String
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: String
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: String
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: String
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [String]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [String]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [String]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [String]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [String]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [String]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [String]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [String]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [String]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [String]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [String]
 }
 
-\\"\\"\\"
+"""
 The exact time of day, does not include the date. May or may not have a timezone offset.
-\\"\\"\\"
+"""
 scalar Time
 
-\\"\\"\\"
+"""
 A filter to be used against Time fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input TimeFilter {
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: Time
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: Time
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: Time
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: Time
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [Time!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: Time
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: Time
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: Time
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: Time
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [Time!]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against Time List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input TimeListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: Time
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: Time
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: Time
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: Time
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: Time
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: Time
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [Time]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [Time]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [Time]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [Time]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [Time]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [Time]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [Time]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [Time]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [Time]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [Time]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [Time]
 }
 
 type Unfilterable implements Node {
-  \\"\\"\\"Reads and enables pagination through a set of \`ChildNoRelatedFilter\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`ChildNoRelatedFilter\`."""
   childNoRelatedFiltersByUnfilterableId(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: ChildNoRelatedFilterFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`ChildNoRelatedFilter\`.\\"\\"\\"
+    """The method to use when ordering \`ChildNoRelatedFilter\`."""
     orderBy: [ChildNoRelatedFiltersOrderBy!] = [PRIMARY_KEY_ASC]
   ): ChildNoRelatedFiltersConnection!
   id: Int!
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
   text: String
 }
 
-\\"\\"\\"A connection to a list of \`Unfilterable\` values.\\"\\"\\"
+"""A connection to a list of \`Unfilterable\` values."""
 type UnfilterablesConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`Unfilterable\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [UnfilterablesEdge!]!
 
-  \\"\\"\\"A list of \`Unfilterable\` objects.\\"\\"\\"
+  """A list of \`Unfilterable\` objects."""
   nodes: [Unfilterable]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`Unfilterable\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`Unfilterable\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`Unfilterable\` edge in the connection.\\"\\"\\"
+"""A \`Unfilterable\` edge in the connection."""
 type UnfilterablesEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`Unfilterable\` at the end of the edge.\\"\\"\\"
+  """The \`Unfilterable\` at the end of the edge."""
   node: Unfilterable
 }
 
-\\"\\"\\"Methods to use when ordering \`Unfilterable\`.\\"\\"\\"
+"""Methods to use when ordering \`Unfilterable\`."""
 enum UnfilterablesOrderBy {
   ID_ASC
   ID_DESC
@@ -6279,114 +6279,114 @@ enum UnfilterablesOrderBy {
   TEXT_DESC
 }
 
-\\"\\"\\"
+"""
 A universally unique identifier as defined by [RFC 4122](https://tools.ietf.org/html/rfc4122).
-\\"\\"\\"
+"""
 scalar UUID
 
-\\"\\"\\"
+"""
 A filter to be used against UUID fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input UUIDFilter {
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: UUID
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: UUID
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: UUID
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: UUID
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [UUID!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: UUID
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: UUID
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: UUID
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: UUID
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [UUID!]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against UUID List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input UUIDListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: UUID
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: UUID
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: UUID
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: UUID
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: UUID
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: UUID
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [UUID]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [UUID]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [UUID]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [UUID]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [UUID]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [UUID]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [UUID]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [UUID]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [UUID]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [UUID]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [UUID]
 }
-"
+
 `;

--- a/__tests__/integration/schema/__snapshots__/defaultOptions.test.ts.snap
+++ b/__tests__/integration/schema/__snapshots__/defaultOptions.test.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`prints a schema with the filter plugin 1`] = `
-"type ArrayType implements Node {
+type ArrayType implements Node {
   bit4Array: [BitString]
   boolArray: [Boolean]
   bpchar4Array: [String]
@@ -25,9 +25,9 @@ exports[`prints a schema with the filter plugin 1`] = `
   moneyArray: [Float]
   nameArray: [String]
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
   numericArray: [BigFloat]
   textArray: [String]
@@ -41,128 +41,128 @@ exports[`prints a schema with the filter plugin 1`] = `
   xmlArray: [String]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`ArrayType\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input ArrayTypeFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [ArrayTypeFilter!]
 
-  \\"\\"\\"Filter by the object’s \`bit4Array\` field.\\"\\"\\"
+  """Filter by the object’s \`bit4Array\` field."""
   bit4Array: BitStringListFilter
 
-  \\"\\"\\"Filter by the object’s \`boolArray\` field.\\"\\"\\"
+  """Filter by the object’s \`boolArray\` field."""
   boolArray: BooleanListFilter
 
-  \\"\\"\\"Filter by the object’s \`bpchar4Array\` field.\\"\\"\\"
+  """Filter by the object’s \`bpchar4Array\` field."""
   bpchar4Array: StringListFilter
 
-  \\"\\"\\"Filter by the object’s \`char4Array\` field.\\"\\"\\"
+  """Filter by the object’s \`char4Array\` field."""
   char4Array: StringListFilter
 
-  \\"\\"\\"Filter by the object’s \`citextArray\` field.\\"\\"\\"
+  """Filter by the object’s \`citextArray\` field."""
   citextArray: StringListFilter
 
-  \\"\\"\\"Filter by the object’s \`dateArray\` field.\\"\\"\\"
+  """Filter by the object’s \`dateArray\` field."""
   dateArray: DateListFilter
 
-  \\"\\"\\"Filter by the object’s \`float4Array\` field.\\"\\"\\"
+  """Filter by the object’s \`float4Array\` field."""
   float4Array: FloatListFilter
 
-  \\"\\"\\"Filter by the object’s \`float8Array\` field.\\"\\"\\"
+  """Filter by the object’s \`float8Array\` field."""
   float8Array: FloatListFilter
 
-  \\"\\"\\"Filter by the object’s \`hstoreArray\` field.\\"\\"\\"
+  """Filter by the object’s \`hstoreArray\` field."""
   hstoreArray: KeyValueHashListFilter
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`inetArray\` field.\\"\\"\\"
+  """Filter by the object’s \`inetArray\` field."""
   inetArray: InternetAddressListFilter
 
-  \\"\\"\\"Filter by the object’s \`int2Array\` field.\\"\\"\\"
+  """Filter by the object’s \`int2Array\` field."""
   int2Array: IntListFilter
 
-  \\"\\"\\"Filter by the object’s \`int4Array\` field.\\"\\"\\"
+  """Filter by the object’s \`int4Array\` field."""
   int4Array: IntListFilter
 
-  \\"\\"\\"Filter by the object’s \`int8Array\` field.\\"\\"\\"
+  """Filter by the object’s \`int8Array\` field."""
   int8Array: BigIntListFilter
 
-  \\"\\"\\"Filter by the object’s \`intervalArray\` field.\\"\\"\\"
+  """Filter by the object’s \`intervalArray\` field."""
   intervalArray: IntervalListFilter
 
-  \\"\\"\\"Filter by the object’s \`jsonbArray\` field.\\"\\"\\"
+  """Filter by the object’s \`jsonbArray\` field."""
   jsonbArray: JSONListFilter
 
-  \\"\\"\\"Filter by the object’s \`moneyArray\` field.\\"\\"\\"
+  """Filter by the object’s \`moneyArray\` field."""
   moneyArray: FloatListFilter
 
-  \\"\\"\\"Filter by the object’s \`nameArray\` field.\\"\\"\\"
+  """Filter by the object’s \`nameArray\` field."""
   nameArray: StringListFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: ArrayTypeFilter
 
-  \\"\\"\\"Filter by the object’s \`numericArray\` field.\\"\\"\\"
+  """Filter by the object’s \`numericArray\` field."""
   numericArray: BigFloatListFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [ArrayTypeFilter!]
 
-  \\"\\"\\"Filter by the object’s \`textArray\` field.\\"\\"\\"
+  """Filter by the object’s \`textArray\` field."""
   textArray: StringListFilter
 
-  \\"\\"\\"Filter by the object’s \`timeArray\` field.\\"\\"\\"
+  """Filter by the object’s \`timeArray\` field."""
   timeArray: TimeListFilter
 
-  \\"\\"\\"Filter by the object’s \`timestampArray\` field.\\"\\"\\"
+  """Filter by the object’s \`timestampArray\` field."""
   timestampArray: DatetimeListFilter
 
-  \\"\\"\\"Filter by the object’s \`timestamptzArray\` field.\\"\\"\\"
+  """Filter by the object’s \`timestamptzArray\` field."""
   timestamptzArray: DatetimeListFilter
 
-  \\"\\"\\"Filter by the object’s \`timetzArray\` field.\\"\\"\\"
+  """Filter by the object’s \`timetzArray\` field."""
   timetzArray: TimeListFilter
 
-  \\"\\"\\"Filter by the object’s \`uuidArray\` field.\\"\\"\\"
+  """Filter by the object’s \`uuidArray\` field."""
   uuidArray: UUIDListFilter
 
-  \\"\\"\\"Filter by the object’s \`varbitArray\` field.\\"\\"\\"
+  """Filter by the object’s \`varbitArray\` field."""
   varbitArray: BitStringListFilter
 
-  \\"\\"\\"Filter by the object’s \`varcharArray\` field.\\"\\"\\"
+  """Filter by the object’s \`varcharArray\` field."""
   varcharArray: StringListFilter
 }
 
-\\"\\"\\"A connection to a list of \`ArrayType\` values.\\"\\"\\"
+"""A connection to a list of \`ArrayType\` values."""
 type ArrayTypesConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`ArrayType\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [ArrayTypesEdge!]!
 
-  \\"\\"\\"A list of \`ArrayType\` objects.\\"\\"\\"
+  """A list of \`ArrayType\` objects."""
   nodes: [ArrayType]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`ArrayType\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`ArrayType\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`ArrayType\` edge in the connection.\\"\\"\\"
+"""A \`ArrayType\` edge in the connection."""
 type ArrayTypesEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`ArrayType\` at the end of the edge.\\"\\"\\"
+  """The \`ArrayType\` at the end of the edge."""
   node: ArrayType
 }
 
-\\"\\"\\"Methods to use when ordering \`ArrayType\`.\\"\\"\\"
+"""Methods to use when ordering \`ArrayType\`."""
 enum ArrayTypesOrderBy {
   BIT4_ARRAY_ASC
   BIT4_ARRAY_DESC
@@ -234,15 +234,15 @@ enum ArrayTypesOrderBy {
 }
 
 type Backward implements Node {
-  \\"\\"\\"Reads a single \`Filterable\` that is related to this \`Backward\`.\\"\\"\\"
+  """Reads a single \`Filterable\` that is related to this \`Backward\`."""
   filterableByFilterableId: Filterable
   filterableId: Int
   id: Int!
   name: String!
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
@@ -250,70 +250,70 @@ type BackwardCompound implements Node {
   backwardCompound1: Int!
   backwardCompound2: Int!
 
-  \\"\\"\\"
+  """
   Reads a single \`Filterable\` that is related to this \`BackwardCompound\`.
-  \\"\\"\\"
+  """
   filterableByBackwardCompound1AndBackwardCompound2: Filterable
   name: String
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`BackwardCompound\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input BackwardCompoundFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [BackwardCompoundFilter!]
 
-  \\"\\"\\"Filter by the object’s \`backwardCompound1\` field.\\"\\"\\"
+  """Filter by the object’s \`backwardCompound1\` field."""
   backwardCompound1: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`backwardCompound2\` field.\\"\\"\\"
+  """Filter by the object’s \`backwardCompound2\` field."""
   backwardCompound2: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`name\` field.\\"\\"\\"
+  """Filter by the object’s \`name\` field."""
   name: StringFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: BackwardCompoundFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [BackwardCompoundFilter!]
 }
 
-\\"\\"\\"A connection to a list of \`BackwardCompound\` values.\\"\\"\\"
+"""A connection to a list of \`BackwardCompound\` values."""
 type BackwardCompoundsConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`BackwardCompound\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [BackwardCompoundsEdge!]!
 
-  \\"\\"\\"A list of \`BackwardCompound\` objects.\\"\\"\\"
+  """A list of \`BackwardCompound\` objects."""
   nodes: [BackwardCompound]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"
+  """
   The count of *all* \`BackwardCompound\` you could get from the connection.
-  \\"\\"\\"
+  """
   totalCount: Int!
 }
 
-\\"\\"\\"A \`BackwardCompound\` edge in the connection.\\"\\"\\"
+"""A \`BackwardCompound\` edge in the connection."""
 type BackwardCompoundsEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`BackwardCompound\` at the end of the edge.\\"\\"\\"
+  """The \`BackwardCompound\` at the end of the edge."""
   node: BackwardCompound
 }
 
-\\"\\"\\"Methods to use when ordering \`BackwardCompound\`.\\"\\"\\"
+"""Methods to use when ordering \`BackwardCompound\`."""
 enum BackwardCompoundsOrderBy {
   BACKWARD_COMPOUND_1_ASC
   BACKWARD_COMPOUND_1_DESC
@@ -326,56 +326,56 @@ enum BackwardCompoundsOrderBy {
   PRIMARY_KEY_DESC
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`Backward\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input BackwardFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [BackwardFilter!]
 
-  \\"\\"\\"Filter by the object’s \`filterableId\` field.\\"\\"\\"
+  """Filter by the object’s \`filterableId\` field."""
   filterableId: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`name\` field.\\"\\"\\"
+  """Filter by the object’s \`name\` field."""
   name: StringFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: BackwardFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [BackwardFilter!]
 }
 
-\\"\\"\\"A connection to a list of \`Backward\` values.\\"\\"\\"
+"""A connection to a list of \`Backward\` values."""
 type BackwardsConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`Backward\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [BackwardsEdge!]!
 
-  \\"\\"\\"A list of \`Backward\` objects.\\"\\"\\"
+  """A list of \`Backward\` objects."""
   nodes: [Backward]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`Backward\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`Backward\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`Backward\` edge in the connection.\\"\\"\\"
+"""A \`Backward\` edge in the connection."""
 type BackwardsEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`Backward\` at the end of the edge.\\"\\"\\"
+  """The \`Backward\` at the end of the edge."""
   node: Backward
 }
 
-\\"\\"\\"Methods to use when ordering \`Backward\`.\\"\\"\\"
+"""Methods to use when ordering \`Backward\`."""
 enum BackwardsOrderBy {
   FILTERABLE_ID_ASC
   FILTERABLE_ID_DESC
@@ -388,1037 +388,1037 @@ enum BackwardsOrderBy {
   PRIMARY_KEY_DESC
 }
 
-\\"\\"\\"
+"""
 A floating point number that requires more precision than IEEE 754 binary 64
-\\"\\"\\"
+"""
 scalar BigFloat
 
-\\"\\"\\"
+"""
 A filter to be used against BigFloat fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input BigFloatFilter {
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: BigFloat
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: BigFloat
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: BigFloat
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: BigFloat
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [BigFloat!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: BigFloat
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: BigFloat
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: BigFloat
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: BigFloat
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [BigFloat!]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against BigFloat List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input BigFloatListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: BigFloat
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: BigFloat
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: BigFloat
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: BigFloat
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: BigFloat
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: BigFloat
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [BigFloat]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [BigFloat]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [BigFloat]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [BigFloat]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [BigFloat]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [BigFloat]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [BigFloat]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [BigFloat]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [BigFloat]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [BigFloat]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [BigFloat]
 }
 
-\\"\\"\\"A range of \`BigFloat\`.\\"\\"\\"
+"""A range of \`BigFloat\`."""
 type BigFloatRange {
-  \\"\\"\\"The ending bound of our range.\\"\\"\\"
+  """The ending bound of our range."""
   end: BigFloatRangeBound
 
-  \\"\\"\\"The starting bound of our range.\\"\\"\\"
+  """The starting bound of our range."""
   start: BigFloatRangeBound
 }
 
-\\"\\"\\"
+"""
 The value at one end of a range. A range can either include this value, or not.
-\\"\\"\\"
+"""
 type BigFloatRangeBound {
-  \\"\\"\\"Whether or not the value of this bound is included in the range.\\"\\"\\"
+  """Whether or not the value of this bound is included in the range."""
   inclusive: Boolean!
 
-  \\"\\"\\"The value at one end of our range.\\"\\"\\"
+  """The value at one end of our range."""
   value: BigFloat!
 }
 
-\\"\\"\\"
+"""
 The value at one end of a range. A range can either include this value, or not.
-\\"\\"\\"
+"""
 input BigFloatRangeBoundInput {
-  \\"\\"\\"Whether or not the value of this bound is included in the range.\\"\\"\\"
+  """Whether or not the value of this bound is included in the range."""
   inclusive: Boolean!
 
-  \\"\\"\\"The value at one end of our range.\\"\\"\\"
+  """The value at one end of our range."""
   value: BigFloat!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against BigFloatRange fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input BigFloatRangeFilter {
-  \\"\\"\\"Adjacent to the specified range.\\"\\"\\"
+  """Adjacent to the specified range."""
   adjacentTo: BigFloatRangeInput
 
-  \\"\\"\\"Contained by the specified range.\\"\\"\\"
+  """Contained by the specified range."""
   containedBy: BigFloatRangeInput
 
-  \\"\\"\\"Contains the specified range.\\"\\"\\"
+  """Contains the specified range."""
   contains: BigFloatRangeInput
 
-  \\"\\"\\"Contains the specified value.\\"\\"\\"
+  """Contains the specified value."""
   containsElement: BigFloat
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: BigFloatRangeInput
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: BigFloatRangeInput
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: BigFloatRangeInput
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: BigFloatRangeInput
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [BigFloatRangeInput!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: BigFloatRangeInput
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: BigFloatRangeInput
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: BigFloatRangeInput
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: BigFloatRangeInput
 
-  \\"\\"\\"Does not extend left of the specified range.\\"\\"\\"
+  """Does not extend left of the specified range."""
   notExtendsLeftOf: BigFloatRangeInput
 
-  \\"\\"\\"Does not extend right of the specified range.\\"\\"\\"
+  """Does not extend right of the specified range."""
   notExtendsRightOf: BigFloatRangeInput
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [BigFloatRangeInput!]
 
-  \\"\\"\\"Overlaps the specified range.\\"\\"\\"
+  """Overlaps the specified range."""
   overlaps: BigFloatRangeInput
 
-  \\"\\"\\"Strictly left of the specified range.\\"\\"\\"
+  """Strictly left of the specified range."""
   strictlyLeftOf: BigFloatRangeInput
 
-  \\"\\"\\"Strictly right of the specified range.\\"\\"\\"
+  """Strictly right of the specified range."""
   strictlyRightOf: BigFloatRangeInput
 }
 
-\\"\\"\\"A range of \`BigFloat\`.\\"\\"\\"
+"""A range of \`BigFloat\`."""
 input BigFloatRangeInput {
-  \\"\\"\\"The ending bound of our range.\\"\\"\\"
+  """The ending bound of our range."""
   end: BigFloatRangeBoundInput
 
-  \\"\\"\\"The starting bound of our range.\\"\\"\\"
+  """The starting bound of our range."""
   start: BigFloatRangeBoundInput
 }
 
-\\"\\"\\"
+"""
 A filter to be used against BigFloatRange List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input BigFloatRangeListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: BigFloatRangeInput
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: BigFloatRangeInput
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: BigFloatRangeInput
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: BigFloatRangeInput
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: BigFloatRangeInput
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: BigFloatRangeInput
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [BigFloatRangeInput]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [BigFloatRangeInput]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [BigFloatRangeInput]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [BigFloatRangeInput]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [BigFloatRangeInput]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [BigFloatRangeInput]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [BigFloatRangeInput]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [BigFloatRangeInput]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [BigFloatRangeInput]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [BigFloatRangeInput]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [BigFloatRangeInput]
 }
 
-\\"\\"\\"
+"""
 A signed eight-byte integer. The upper big integer values are greater than the
 max value for a JavaScript number. Therefore all big integers will be output as
 strings and not numbers.
-\\"\\"\\"
+"""
 scalar BigInt
 
-\\"\\"\\"
+"""
 A filter to be used against BigInt fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input BigIntFilter {
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: BigInt
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: BigInt
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: BigInt
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: BigInt
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [BigInt!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: BigInt
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: BigInt
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: BigInt
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: BigInt
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [BigInt!]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against BigInt List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input BigIntListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: BigInt
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: BigInt
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: BigInt
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: BigInt
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: BigInt
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: BigInt
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [BigInt]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [BigInt]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [BigInt]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [BigInt]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [BigInt]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [BigInt]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [BigInt]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [BigInt]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [BigInt]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [BigInt]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [BigInt]
 }
 
-\\"\\"\\"A range of \`BigInt\`.\\"\\"\\"
+"""A range of \`BigInt\`."""
 type BigIntRange {
-  \\"\\"\\"The ending bound of our range.\\"\\"\\"
+  """The ending bound of our range."""
   end: BigIntRangeBound
 
-  \\"\\"\\"The starting bound of our range.\\"\\"\\"
+  """The starting bound of our range."""
   start: BigIntRangeBound
 }
 
-\\"\\"\\"
+"""
 The value at one end of a range. A range can either include this value, or not.
-\\"\\"\\"
+"""
 type BigIntRangeBound {
-  \\"\\"\\"Whether or not the value of this bound is included in the range.\\"\\"\\"
+  """Whether or not the value of this bound is included in the range."""
   inclusive: Boolean!
 
-  \\"\\"\\"The value at one end of our range.\\"\\"\\"
+  """The value at one end of our range."""
   value: BigInt!
 }
 
-\\"\\"\\"
+"""
 The value at one end of a range. A range can either include this value, or not.
-\\"\\"\\"
+"""
 input BigIntRangeBoundInput {
-  \\"\\"\\"Whether or not the value of this bound is included in the range.\\"\\"\\"
+  """Whether or not the value of this bound is included in the range."""
   inclusive: Boolean!
 
-  \\"\\"\\"The value at one end of our range.\\"\\"\\"
+  """The value at one end of our range."""
   value: BigInt!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against BigIntRange fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input BigIntRangeFilter {
-  \\"\\"\\"Adjacent to the specified range.\\"\\"\\"
+  """Adjacent to the specified range."""
   adjacentTo: BigIntRangeInput
 
-  \\"\\"\\"Contained by the specified range.\\"\\"\\"
+  """Contained by the specified range."""
   containedBy: BigIntRangeInput
 
-  \\"\\"\\"Contains the specified range.\\"\\"\\"
+  """Contains the specified range."""
   contains: BigIntRangeInput
 
-  \\"\\"\\"Contains the specified value.\\"\\"\\"
+  """Contains the specified value."""
   containsElement: BigInt
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: BigIntRangeInput
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: BigIntRangeInput
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: BigIntRangeInput
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: BigIntRangeInput
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [BigIntRangeInput!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: BigIntRangeInput
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: BigIntRangeInput
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: BigIntRangeInput
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: BigIntRangeInput
 
-  \\"\\"\\"Does not extend left of the specified range.\\"\\"\\"
+  """Does not extend left of the specified range."""
   notExtendsLeftOf: BigIntRangeInput
 
-  \\"\\"\\"Does not extend right of the specified range.\\"\\"\\"
+  """Does not extend right of the specified range."""
   notExtendsRightOf: BigIntRangeInput
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [BigIntRangeInput!]
 
-  \\"\\"\\"Overlaps the specified range.\\"\\"\\"
+  """Overlaps the specified range."""
   overlaps: BigIntRangeInput
 
-  \\"\\"\\"Strictly left of the specified range.\\"\\"\\"
+  """Strictly left of the specified range."""
   strictlyLeftOf: BigIntRangeInput
 
-  \\"\\"\\"Strictly right of the specified range.\\"\\"\\"
+  """Strictly right of the specified range."""
   strictlyRightOf: BigIntRangeInput
 }
 
-\\"\\"\\"A range of \`BigInt\`.\\"\\"\\"
+"""A range of \`BigInt\`."""
 input BigIntRangeInput {
-  \\"\\"\\"The ending bound of our range.\\"\\"\\"
+  """The ending bound of our range."""
   end: BigIntRangeBoundInput
 
-  \\"\\"\\"The starting bound of our range.\\"\\"\\"
+  """The starting bound of our range."""
   start: BigIntRangeBoundInput
 }
 
-\\"\\"\\"
+"""
 A filter to be used against BigIntRange List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input BigIntRangeListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: BigIntRangeInput
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: BigIntRangeInput
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: BigIntRangeInput
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: BigIntRangeInput
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: BigIntRangeInput
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: BigIntRangeInput
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [BigIntRangeInput]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [BigIntRangeInput]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [BigIntRangeInput]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [BigIntRangeInput]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [BigIntRangeInput]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [BigIntRangeInput]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [BigIntRangeInput]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [BigIntRangeInput]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [BigIntRangeInput]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [BigIntRangeInput]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [BigIntRangeInput]
 }
 
-\\"\\"\\"A string representing a series of binary bits\\"\\"\\"
+"""A string representing a series of binary bits"""
 scalar BitString
 
-\\"\\"\\"
+"""
 A filter to be used against BitString fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input BitStringFilter {
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: BitString
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: BitString
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: BitString
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: BitString
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [BitString!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: BitString
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: BitString
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: BitString
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: BitString
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [BitString!]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against BitString List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input BitStringListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: BitString
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: BitString
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: BitString
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: BitString
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: BitString
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: BitString
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [BitString]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [BitString]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [BitString]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [BitString]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [BitString]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [BitString]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [BitString]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [BitString]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [BitString]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [BitString]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [BitString]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against Boolean fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input BooleanFilter {
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: Boolean
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: Boolean
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: Boolean
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: Boolean
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [Boolean!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: Boolean
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: Boolean
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: Boolean
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: Boolean
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [Boolean!]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against Boolean List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input BooleanListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: Boolean
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: Boolean
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: Boolean
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: Boolean
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: Boolean
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: Boolean
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [Boolean]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [Boolean]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [Boolean]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [Boolean]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [Boolean]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [Boolean]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [Boolean]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [Boolean]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [Boolean]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [Boolean]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [Boolean]
 }
 
 scalar Char4Domain
 
-\\"\\"\\"
+"""
 A filter to be used against Char4Domain fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input Char4DomainFilter {
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: Char4Domain
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value (case-insensitive).
-  \\"\\"\\"
+  """
   distinctFromInsensitive: Char4Domain
 
-  \\"\\"\\"Ends with the specified string (case-sensitive).\\"\\"\\"
+  """Ends with the specified string (case-sensitive)."""
   endsWith: Char4Domain
 
-  \\"\\"\\"Ends with the specified string (case-insensitive).\\"\\"\\"
+  """Ends with the specified string (case-insensitive)."""
   endsWithInsensitive: Char4Domain
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: Char4Domain
 
-  \\"\\"\\"Equal to the specified value (case-insensitive).\\"\\"\\"
+  """Equal to the specified value (case-insensitive)."""
   equalToInsensitive: Char4Domain
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: Char4Domain
 
-  \\"\\"\\"Greater than the specified value (case-insensitive).\\"\\"\\"
+  """Greater than the specified value (case-insensitive)."""
   greaterThanInsensitive: Char4Domain
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: Char4Domain
 
-  \\"\\"\\"Greater than or equal to the specified value (case-insensitive).\\"\\"\\"
+  """Greater than or equal to the specified value (case-insensitive)."""
   greaterThanOrEqualToInsensitive: Char4Domain
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [Char4Domain!]
 
-  \\"\\"\\"Included in the specified list (case-insensitive).\\"\\"\\"
-  inInsensitive: [Char4Domain!]
-
-  \\"\\"\\"Contains the specified string (case-sensitive).\\"\\"\\"
+  """Contains the specified string (case-sensitive)."""
   includes: Char4Domain
 
-  \\"\\"\\"Contains the specified string (case-insensitive).\\"\\"\\"
+  """Contains the specified string (case-insensitive)."""
   includesInsensitive: Char4Domain
 
-  \\"\\"\\"
+  """Included in the specified list (case-insensitive)."""
+  inInsensitive: [Char4Domain!]
+
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: Char4Domain
 
-  \\"\\"\\"Less than the specified value (case-insensitive).\\"\\"\\"
+  """Less than the specified value (case-insensitive)."""
   lessThanInsensitive: Char4Domain
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: Char4Domain
 
-  \\"\\"\\"Less than or equal to the specified value (case-insensitive).\\"\\"\\"
+  """Less than or equal to the specified value (case-insensitive)."""
   lessThanOrEqualToInsensitive: Char4Domain
 
-  \\"\\"\\"
+  """
   Matches the specified pattern (case-sensitive). An underscore (_) matches any
   single character; a percent sign (%) matches any sequence of zero or more characters.
-  \\"\\"\\"
+  """
   like: Char4Domain
 
-  \\"\\"\\"
+  """
   Matches the specified pattern (case-insensitive). An underscore (_) matches
   any single character; a percent sign (%) matches any sequence of zero or more characters.
-  \\"\\"\\"
+  """
   likeInsensitive: Char4Domain
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: Char4Domain
 
-  \\"\\"\\"
+  """
   Equal to the specified value, treating null like an ordinary value (case-insensitive).
-  \\"\\"\\"
+  """
   notDistinctFromInsensitive: Char4Domain
 
-  \\"\\"\\"Does not end with the specified string (case-sensitive).\\"\\"\\"
+  """Does not end with the specified string (case-sensitive)."""
   notEndsWith: Char4Domain
 
-  \\"\\"\\"Does not end with the specified string (case-insensitive).\\"\\"\\"
+  """Does not end with the specified string (case-insensitive)."""
   notEndsWithInsensitive: Char4Domain
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: Char4Domain
 
-  \\"\\"\\"Not equal to the specified value (case-insensitive).\\"\\"\\"
+  """Not equal to the specified value (case-insensitive)."""
   notEqualToInsensitive: Char4Domain
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [Char4Domain!]
 
-  \\"\\"\\"Not included in the specified list (case-insensitive).\\"\\"\\"
-  notInInsensitive: [Char4Domain!]
-
-  \\"\\"\\"Does not contain the specified string (case-sensitive).\\"\\"\\"
+  """Does not contain the specified string (case-sensitive)."""
   notIncludes: Char4Domain
 
-  \\"\\"\\"Does not contain the specified string (case-insensitive).\\"\\"\\"
+  """Does not contain the specified string (case-insensitive)."""
   notIncludesInsensitive: Char4Domain
 
-  \\"\\"\\"
+  """Not included in the specified list (case-insensitive)."""
+  notInInsensitive: [Char4Domain!]
+
+  """
   Does not match the specified pattern (case-sensitive). An underscore (_)
   matches any single character; a percent sign (%) matches any sequence of zero
   or more characters.
-  \\"\\"\\"
+  """
   notLike: Char4Domain
 
-  \\"\\"\\"
+  """
   Does not match the specified pattern (case-insensitive). An underscore (_)
   matches any single character; a percent sign (%) matches any sequence of zero
   or more characters.
-  \\"\\"\\"
+  """
   notLikeInsensitive: Char4Domain
 
-  \\"\\"\\"Does not start with the specified string (case-sensitive).\\"\\"\\"
+  """Does not start with the specified string (case-sensitive)."""
   notStartsWith: Char4Domain
 
-  \\"\\"\\"Does not start with the specified string (case-insensitive).\\"\\"\\"
+  """Does not start with the specified string (case-insensitive)."""
   notStartsWithInsensitive: Char4Domain
 
-  \\"\\"\\"Starts with the specified string (case-sensitive).\\"\\"\\"
+  """Starts with the specified string (case-sensitive)."""
   startsWith: Char4Domain
 
-  \\"\\"\\"Starts with the specified string (case-insensitive).\\"\\"\\"
+  """Starts with the specified string (case-insensitive)."""
   startsWithInsensitive: Char4Domain
 }
 
 type Child implements Node {
-  \\"\\"\\"Reads a single \`Filterable\` that is related to this \`Child\`.\\"\\"\\"
+  """Reads a single \`Filterable\` that is related to this \`Child\`."""
   filterableByFilterableId: Filterable
   filterableId: Int
   id: Int!
   name: String!
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`Child\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input ChildFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [ChildFilter!]
 
-  \\"\\"\\"Filter by the object’s \`filterableId\` field.\\"\\"\\"
+  """Filter by the object’s \`filterableId\` field."""
   filterableId: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`name\` field.\\"\\"\\"
+  """Filter by the object’s \`name\` field."""
   name: StringFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: ChildFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [ChildFilter!]
 }
 
 type ChildNoRelatedFilter implements Node {
-  \\"\\"\\"
+  """
   Reads a single \`Filterable\` that is related to this \`ChildNoRelatedFilter\`.
-  \\"\\"\\"
+  """
   filterableByFilterableId: Filterable
   filterableId: Int
   id: Int!
   name: String!
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 
-  \\"\\"\\"
+  """
   Reads a single \`Unfilterable\` that is related to this \`ChildNoRelatedFilter\`.
-  \\"\\"\\"
+  """
   unfilterableByUnfilterableId: Unfilterable
   unfilterableId: Int
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`ChildNoRelatedFilter\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input ChildNoRelatedFilterFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [ChildNoRelatedFilterFilter!]
 
-  \\"\\"\\"Filter by the object’s \`filterableId\` field.\\"\\"\\"
+  """Filter by the object’s \`filterableId\` field."""
   filterableId: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`name\` field.\\"\\"\\"
+  """Filter by the object’s \`name\` field."""
   name: StringFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: ChildNoRelatedFilterFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [ChildNoRelatedFilterFilter!]
 
-  \\"\\"\\"Filter by the object’s \`unfilterableId\` field.\\"\\"\\"
+  """Filter by the object’s \`unfilterableId\` field."""
   unfilterableId: IntFilter
 }
 
-\\"\\"\\"A connection to a list of \`ChildNoRelatedFilter\` values.\\"\\"\\"
+"""A connection to a list of \`ChildNoRelatedFilter\` values."""
 type ChildNoRelatedFiltersConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`ChildNoRelatedFilter\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [ChildNoRelatedFiltersEdge!]!
 
-  \\"\\"\\"A list of \`ChildNoRelatedFilter\` objects.\\"\\"\\"
+  """A list of \`ChildNoRelatedFilter\` objects."""
   nodes: [ChildNoRelatedFilter]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"
+  """
   The count of *all* \`ChildNoRelatedFilter\` you could get from the connection.
-  \\"\\"\\"
+  """
   totalCount: Int!
 }
 
-\\"\\"\\"A \`ChildNoRelatedFilter\` edge in the connection.\\"\\"\\"
+"""A \`ChildNoRelatedFilter\` edge in the connection."""
 type ChildNoRelatedFiltersEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`ChildNoRelatedFilter\` at the end of the edge.\\"\\"\\"
+  """The \`ChildNoRelatedFilter\` at the end of the edge."""
   node: ChildNoRelatedFilter
 }
 
-\\"\\"\\"Methods to use when ordering \`ChildNoRelatedFilter\`.\\"\\"\\"
+"""Methods to use when ordering \`ChildNoRelatedFilter\`."""
 enum ChildNoRelatedFiltersOrderBy {
   FILTERABLE_ID_ASC
   FILTERABLE_ID_DESC
@@ -1433,33 +1433,33 @@ enum ChildNoRelatedFiltersOrderBy {
   UNFILTERABLE_ID_DESC
 }
 
-\\"\\"\\"A connection to a list of \`Child\` values.\\"\\"\\"
+"""A connection to a list of \`Child\` values."""
 type ChildrenConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`Child\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [ChildrenEdge!]!
 
-  \\"\\"\\"A list of \`Child\` objects.\\"\\"\\"
+  """A list of \`Child\` objects."""
   nodes: [Child]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`Child\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`Child\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`Child\` edge in the connection.\\"\\"\\"
+"""A \`Child\` edge in the connection."""
 type ChildrenEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`Child\` at the end of the edge.\\"\\"\\"
+  """The \`Child\` at the end of the edge."""
   node: Child
 }
 
-\\"\\"\\"Methods to use when ordering \`Child\`.\\"\\"\\"
+"""Methods to use when ordering \`Child\`."""
 enum ChildrenOrderBy {
   FILTERABLE_ID_ASC
   FILTERABLE_ID_DESC
@@ -1477,633 +1477,633 @@ type Composite {
   b: String
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`Composite\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input CompositeFilter {
-  \\"\\"\\"Filter by the object’s \`a\` field.\\"\\"\\"
+  """Filter by the object’s \`a\` field."""
   a: IntFilter
 
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [CompositeFilter!]
 
-  \\"\\"\\"Filter by the object’s \`b\` field.\\"\\"\\"
+  """Filter by the object’s \`b\` field."""
   b: StringFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: CompositeFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [CompositeFilter!]
 }
 
-\\"\\"\\"A location in a connection that can be used for resuming pagination.\\"\\"\\"
+"""A location in a connection that can be used for resuming pagination."""
 scalar Cursor
 
-\\"\\"\\"The day, does not include a time.\\"\\"\\"
+"""The day, does not include a time."""
 scalar Date
 
 scalar DateDomain
 
-\\"\\"\\"
+"""
 A filter to be used against DateDomain fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input DateDomainFilter {
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: DateDomain
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: DateDomain
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: DateDomain
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: DateDomain
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [DateDomain!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: DateDomain
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: DateDomain
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: DateDomain
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: DateDomain
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [DateDomain!]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against Date fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input DateFilter {
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: Date
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: Date
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: Date
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: Date
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [Date!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: Date
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: Date
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: Date
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: Date
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [Date!]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against Date List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input DateListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: Date
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: Date
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: Date
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: Date
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: Date
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: Date
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [Date]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [Date]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [Date]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [Date]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [Date]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [Date]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [Date]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [Date]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [Date]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [Date]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [Date]
 }
 
-\\"\\"\\"A range of \`Date\`.\\"\\"\\"
+"""A range of \`Date\`."""
 type DateRange {
-  \\"\\"\\"The ending bound of our range.\\"\\"\\"
+  """The ending bound of our range."""
   end: DateRangeBound
 
-  \\"\\"\\"The starting bound of our range.\\"\\"\\"
+  """The starting bound of our range."""
   start: DateRangeBound
 }
 
-\\"\\"\\"
+"""
 The value at one end of a range. A range can either include this value, or not.
-\\"\\"\\"
+"""
 type DateRangeBound {
-  \\"\\"\\"Whether or not the value of this bound is included in the range.\\"\\"\\"
+  """Whether or not the value of this bound is included in the range."""
   inclusive: Boolean!
 
-  \\"\\"\\"The value at one end of our range.\\"\\"\\"
+  """The value at one end of our range."""
   value: Date!
 }
 
-\\"\\"\\"
+"""
 The value at one end of a range. A range can either include this value, or not.
-\\"\\"\\"
+"""
 input DateRangeBoundInput {
-  \\"\\"\\"Whether or not the value of this bound is included in the range.\\"\\"\\"
+  """Whether or not the value of this bound is included in the range."""
   inclusive: Boolean!
 
-  \\"\\"\\"The value at one end of our range.\\"\\"\\"
+  """The value at one end of our range."""
   value: Date!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against DateRange fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input DateRangeFilter {
-  \\"\\"\\"Adjacent to the specified range.\\"\\"\\"
+  """Adjacent to the specified range."""
   adjacentTo: DateRangeInput
 
-  \\"\\"\\"Contained by the specified range.\\"\\"\\"
+  """Contained by the specified range."""
   containedBy: DateRangeInput
 
-  \\"\\"\\"Contains the specified range.\\"\\"\\"
+  """Contains the specified range."""
   contains: DateRangeInput
 
-  \\"\\"\\"Contains the specified value.\\"\\"\\"
+  """Contains the specified value."""
   containsElement: Date
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: DateRangeInput
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: DateRangeInput
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: DateRangeInput
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: DateRangeInput
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [DateRangeInput!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: DateRangeInput
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: DateRangeInput
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: DateRangeInput
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: DateRangeInput
 
-  \\"\\"\\"Does not extend left of the specified range.\\"\\"\\"
+  """Does not extend left of the specified range."""
   notExtendsLeftOf: DateRangeInput
 
-  \\"\\"\\"Does not extend right of the specified range.\\"\\"\\"
+  """Does not extend right of the specified range."""
   notExtendsRightOf: DateRangeInput
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [DateRangeInput!]
 
-  \\"\\"\\"Overlaps the specified range.\\"\\"\\"
+  """Overlaps the specified range."""
   overlaps: DateRangeInput
 
-  \\"\\"\\"Strictly left of the specified range.\\"\\"\\"
+  """Strictly left of the specified range."""
   strictlyLeftOf: DateRangeInput
 
-  \\"\\"\\"Strictly right of the specified range.\\"\\"\\"
+  """Strictly right of the specified range."""
   strictlyRightOf: DateRangeInput
 }
 
-\\"\\"\\"A range of \`Date\`.\\"\\"\\"
+"""A range of \`Date\`."""
 input DateRangeInput {
-  \\"\\"\\"The ending bound of our range.\\"\\"\\"
+  """The ending bound of our range."""
   end: DateRangeBoundInput
 
-  \\"\\"\\"The starting bound of our range.\\"\\"\\"
+  """The starting bound of our range."""
   start: DateRangeBoundInput
 }
 
-\\"\\"\\"
+"""
 A filter to be used against DateRange List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input DateRangeListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: DateRangeInput
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: DateRangeInput
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: DateRangeInput
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: DateRangeInput
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: DateRangeInput
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: DateRangeInput
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [DateRangeInput]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [DateRangeInput]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [DateRangeInput]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [DateRangeInput]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [DateRangeInput]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [DateRangeInput]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [DateRangeInput]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [DateRangeInput]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [DateRangeInput]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [DateRangeInput]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [DateRangeInput]
 }
 
-\\"\\"\\"
+"""
 A point in time as described by the [ISO
 8601](https://en.wikipedia.org/wiki/ISO_8601) standard. May or may not include a timezone.
-\\"\\"\\"
+"""
 scalar Datetime
 
-\\"\\"\\"
+"""
 A filter to be used against Datetime fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input DatetimeFilter {
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: Datetime
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: Datetime
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: Datetime
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: Datetime
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [Datetime!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: Datetime
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: Datetime
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: Datetime
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: Datetime
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [Datetime!]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against Datetime List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input DatetimeListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: Datetime
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: Datetime
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: Datetime
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: Datetime
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: Datetime
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: Datetime
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [Datetime]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [Datetime]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [Datetime]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [Datetime]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [Datetime]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [Datetime]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [Datetime]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [Datetime]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [Datetime]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [Datetime]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [Datetime]
 }
 
-\\"\\"\\"A range of \`Datetime\`.\\"\\"\\"
+"""A range of \`Datetime\`."""
 type DatetimeRange {
-  \\"\\"\\"The ending bound of our range.\\"\\"\\"
+  """The ending bound of our range."""
   end: DatetimeRangeBound
 
-  \\"\\"\\"The starting bound of our range.\\"\\"\\"
+  """The starting bound of our range."""
   start: DatetimeRangeBound
 }
 
-\\"\\"\\"
+"""
 The value at one end of a range. A range can either include this value, or not.
-\\"\\"\\"
+"""
 type DatetimeRangeBound {
-  \\"\\"\\"Whether or not the value of this bound is included in the range.\\"\\"\\"
+  """Whether or not the value of this bound is included in the range."""
   inclusive: Boolean!
 
-  \\"\\"\\"The value at one end of our range.\\"\\"\\"
+  """The value at one end of our range."""
   value: Datetime!
 }
 
-\\"\\"\\"
+"""
 The value at one end of a range. A range can either include this value, or not.
-\\"\\"\\"
+"""
 input DatetimeRangeBoundInput {
-  \\"\\"\\"Whether or not the value of this bound is included in the range.\\"\\"\\"
+  """Whether or not the value of this bound is included in the range."""
   inclusive: Boolean!
 
-  \\"\\"\\"The value at one end of our range.\\"\\"\\"
+  """The value at one end of our range."""
   value: Datetime!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against DatetimeRange fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input DatetimeRangeFilter {
-  \\"\\"\\"Adjacent to the specified range.\\"\\"\\"
+  """Adjacent to the specified range."""
   adjacentTo: DatetimeRangeInput
 
-  \\"\\"\\"Contained by the specified range.\\"\\"\\"
+  """Contained by the specified range."""
   containedBy: DatetimeRangeInput
 
-  \\"\\"\\"Contains the specified range.\\"\\"\\"
+  """Contains the specified range."""
   contains: DatetimeRangeInput
 
-  \\"\\"\\"Contains the specified value.\\"\\"\\"
+  """Contains the specified value."""
   containsElement: Datetime
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: DatetimeRangeInput
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: DatetimeRangeInput
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: DatetimeRangeInput
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: DatetimeRangeInput
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [DatetimeRangeInput!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: DatetimeRangeInput
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: DatetimeRangeInput
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: DatetimeRangeInput
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: DatetimeRangeInput
 
-  \\"\\"\\"Does not extend left of the specified range.\\"\\"\\"
+  """Does not extend left of the specified range."""
   notExtendsLeftOf: DatetimeRangeInput
 
-  \\"\\"\\"Does not extend right of the specified range.\\"\\"\\"
+  """Does not extend right of the specified range."""
   notExtendsRightOf: DatetimeRangeInput
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [DatetimeRangeInput!]
 
-  \\"\\"\\"Overlaps the specified range.\\"\\"\\"
+  """Overlaps the specified range."""
   overlaps: DatetimeRangeInput
 
-  \\"\\"\\"Strictly left of the specified range.\\"\\"\\"
+  """Strictly left of the specified range."""
   strictlyLeftOf: DatetimeRangeInput
 
-  \\"\\"\\"Strictly right of the specified range.\\"\\"\\"
+  """Strictly right of the specified range."""
   strictlyRightOf: DatetimeRangeInput
 }
 
-\\"\\"\\"A range of \`Datetime\`.\\"\\"\\"
+"""A range of \`Datetime\`."""
 input DatetimeRangeInput {
-  \\"\\"\\"The ending bound of our range.\\"\\"\\"
+  """The ending bound of our range."""
   end: DatetimeRangeBoundInput
 
-  \\"\\"\\"The starting bound of our range.\\"\\"\\"
+  """The starting bound of our range."""
   start: DatetimeRangeBoundInput
 }
 
-\\"\\"\\"
+"""
 A filter to be used against DatetimeRange List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input DatetimeRangeListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: DatetimeRangeInput
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: DatetimeRangeInput
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: DatetimeRangeInput
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: DatetimeRangeInput
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: DatetimeRangeInput
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: DatetimeRangeInput
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [DatetimeRangeInput]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [DatetimeRangeInput]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [DatetimeRangeInput]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [DatetimeRangeInput]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [DatetimeRangeInput]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [DatetimeRangeInput]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [DatetimeRangeInput]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [DatetimeRangeInput]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [DatetimeRangeInput]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [DatetimeRangeInput]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [DatetimeRangeInput]
 }
 
@@ -2113,65 +2113,65 @@ type DomainType implements Node {
   id: Int!
   int4Domain: Int4Domain
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`DomainType\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input DomainTypeFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [DomainTypeFilter!]
 
-  \\"\\"\\"Filter by the object’s \`char4Domain\` field.\\"\\"\\"
+  """Filter by the object’s \`char4Domain\` field."""
   char4Domain: Char4DomainFilter
 
-  \\"\\"\\"Filter by the object’s \`dateDomain\` field.\\"\\"\\"
+  """Filter by the object’s \`dateDomain\` field."""
   dateDomain: DateDomainFilter
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`int4Domain\` field.\\"\\"\\"
+  """Filter by the object’s \`int4Domain\` field."""
   int4Domain: Int4DomainFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: DomainTypeFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [DomainTypeFilter!]
 }
 
-\\"\\"\\"A connection to a list of \`DomainType\` values.\\"\\"\\"
+"""A connection to a list of \`DomainType\` values."""
 type DomainTypesConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`DomainType\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [DomainTypesEdge!]!
 
-  \\"\\"\\"A list of \`DomainType\` objects.\\"\\"\\"
+  """A list of \`DomainType\` objects."""
   nodes: [DomainType]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`DomainType\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`DomainType\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`DomainType\` edge in the connection.\\"\\"\\"
+"""A \`DomainType\` edge in the connection."""
 type DomainTypesEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`DomainType\` at the end of the edge.\\"\\"\\"
+  """The \`DomainType\` at the end of the edge."""
   node: DomainType
 }
 
-\\"\\"\\"Methods to use when ordering \`DomainType\`.\\"\\"\\"
+"""Methods to use when ordering \`DomainType\`."""
 enum DomainTypesOrderBy {
   CHAR4_DOMAIN_ASC
   CHAR4_DOMAIN_DESC
@@ -2190,59 +2190,59 @@ type EnumArrayType implements Node {
   enumArray: [Mood]
   id: Int!
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`EnumArrayType\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input EnumArrayTypeFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [EnumArrayTypeFilter!]
 
-  \\"\\"\\"Filter by the object’s \`enumArray\` field.\\"\\"\\"
+  """Filter by the object’s \`enumArray\` field."""
   enumArray: MoodListFilter
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: EnumArrayTypeFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [EnumArrayTypeFilter!]
 }
 
-\\"\\"\\"A connection to a list of \`EnumArrayType\` values.\\"\\"\\"
+"""A connection to a list of \`EnumArrayType\` values."""
 type EnumArrayTypesConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`EnumArrayType\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [EnumArrayTypesEdge!]!
 
-  \\"\\"\\"A list of \`EnumArrayType\` objects.\\"\\"\\"
+  """A list of \`EnumArrayType\` objects."""
   nodes: [EnumArrayType]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`EnumArrayType\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`EnumArrayType\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`EnumArrayType\` edge in the connection.\\"\\"\\"
+"""A \`EnumArrayType\` edge in the connection."""
 type EnumArrayTypesEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`EnumArrayType\` at the end of the edge.\\"\\"\\"
+  """The \`EnumArrayType\` at the end of the edge."""
   node: EnumArrayType
 }
 
-\\"\\"\\"Methods to use when ordering \`EnumArrayType\`.\\"\\"\\"
+"""Methods to use when ordering \`EnumArrayType\`."""
 enum EnumArrayTypesOrderBy {
   ENUM_ARRAY_ASC
   ENUM_ARRAY_DESC
@@ -2257,59 +2257,59 @@ type EnumType implements Node {
   enum: Mood
   id: Int!
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`EnumType\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input EnumTypeFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [EnumTypeFilter!]
 
-  \\"\\"\\"Filter by the object’s \`enum\` field.\\"\\"\\"
+  """Filter by the object’s \`enum\` field."""
   enum: MoodFilter
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: EnumTypeFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [EnumTypeFilter!]
 }
 
-\\"\\"\\"A connection to a list of \`EnumType\` values.\\"\\"\\"
+"""A connection to a list of \`EnumType\` values."""
 type EnumTypesConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`EnumType\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [EnumTypesEdge!]!
 
-  \\"\\"\\"A list of \`EnumType\` objects.\\"\\"\\"
+  """A list of \`EnumType\` objects."""
   nodes: [EnumType]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`EnumType\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`EnumType\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`EnumType\` edge in the connection.\\"\\"\\"
+"""A \`EnumType\` edge in the connection."""
 type EnumTypesEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`EnumType\` at the end of the edge.\\"\\"\\"
+  """The \`EnumType\` at the end of the edge."""
   node: EnumType
 }
 
-\\"\\"\\"Methods to use when ordering \`EnumType\`.\\"\\"\\"
+"""Methods to use when ordering \`EnumType\`."""
 enum EnumTypesOrderBy {
   ENUM_ASC
   ENUM_DESC
@@ -2321,14 +2321,14 @@ enum EnumTypesOrderBy {
 }
 
 type Filterable implements Node {
-  \\"\\"\\"Reads a single \`Backward\` that is related to this \`Filterable\`.\\"\\"\\"
+  """Reads a single \`Backward\` that is related to this \`Filterable\`."""
   backwardByFilterableId: Backward
   backwardCompound1: Int
   backwardCompound2: Int
 
-  \\"\\"\\"
+  """
   Reads a single \`BackwardCompound\` that is related to this \`Filterable\`.
-  \\"\\"\\"
+  """
   backwardCompoundByBackwardCompound1AndBackwardCompound2: BackwardCompound
   bit4: BitString
   bool: Boolean
@@ -2336,61 +2336,61 @@ type Filterable implements Node {
   bytea: String
   char4: String
 
-  \\"\\"\\"Reads and enables pagination through a set of \`ChildNoRelatedFilter\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`ChildNoRelatedFilter\`."""
   childNoRelatedFiltersByFilterableId(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: ChildNoRelatedFilterFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`ChildNoRelatedFilter\`.\\"\\"\\"
+    """The method to use when ordering \`ChildNoRelatedFilter\`."""
     orderBy: [ChildNoRelatedFiltersOrderBy!] = [PRIMARY_KEY_ASC]
   ): ChildNoRelatedFiltersConnection!
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Child\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Child\`."""
   childrenByFilterableId(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: ChildFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`Child\`.\\"\\"\\"
+    """The method to use when ordering \`Child\`."""
     orderBy: [ChildrenOrderBy!] = [PRIMARY_KEY_ASC]
   ): ChildrenConnection!
   cidr: String
@@ -2401,126 +2401,126 @@ type Filterable implements Node {
   computedChild: Child
   computedIntArray: [Int]
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Child\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Child\`."""
   computedSetofChild(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: ChildFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
   ): ChildrenConnection!
   computedSetofInt(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: IntFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
   ): FilterableComputedSetofIntConnection!
   computedTaggedFilterable: Int
   computedWithRequiredArg(i: Int!): Int
   date: Date
 
-  \\"\\"\\"Reads and enables pagination through a set of \`FilterableClosure\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`FilterableClosure\`."""
   filterableClosuresByAncestorId(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: FilterableClosureFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`FilterableClosure\`.\\"\\"\\"
+    """The method to use when ordering \`FilterableClosure\`."""
     orderBy: [FilterableClosuresOrderBy!] = [PRIMARY_KEY_ASC]
   ): FilterableClosuresConnection!
 
-  \\"\\"\\"Reads and enables pagination through a set of \`FilterableClosure\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`FilterableClosure\`."""
   filterableClosuresByDescendantId(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: FilterableClosureFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`FilterableClosure\`.\\"\\"\\"
+    """The method to use when ordering \`FilterableClosure\`."""
     orderBy: [FilterableClosuresOrderBy!] = [PRIMARY_KEY_ASC]
   ): FilterableClosuresConnection!
   float4: Float
   float8: Float
 
-  \\"\\"\\"Reads a single \`Forward\` that is related to this \`Filterable\`.\\"\\"\\"
+  """Reads a single \`Forward\` that is related to this \`Filterable\`."""
   forwardByForwardId: Forward
   forwardColumn: Forward
   forwardCompound1: Int
   forwardCompound2: Int
 
-  \\"\\"\\"Reads a single \`ForwardCompound\` that is related to this \`Filterable\`.\\"\\"\\"
+  """Reads a single \`ForwardCompound\` that is related to this \`Filterable\`."""
   forwardCompoundByForwardCompound1AndForwardCompound2: ForwardCompound
   forwardId: Int
   hstore: KeyValueHash
@@ -2536,13 +2536,13 @@ type Filterable implements Node {
   money: Float
   name: String
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
   numeric: BigFloat
 
-  \\"\\"\\"Reads a single \`Parent\` that is related to this \`Filterable\`.\\"\\"\\"
+  """Reads a single \`Parent\` that is related to this \`Filterable\`."""
   parentByParentId: Parent
   parentId: Int
   text: String
@@ -2562,78 +2562,78 @@ type FilterableClosure implements Node {
   depth: Int!
   descendantId: Int!
 
-  \\"\\"\\"
+  """
   Reads a single \`Filterable\` that is related to this \`FilterableClosure\`.
-  \\"\\"\\"
+  """
   filterableByAncestorId: Filterable
 
-  \\"\\"\\"
+  """
   Reads a single \`Filterable\` that is related to this \`FilterableClosure\`.
-  \\"\\"\\"
+  """
   filterableByDescendantId: Filterable
   id: Int!
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`FilterableClosure\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input FilterableClosureFilter {
-  \\"\\"\\"Filter by the object’s \`ancestorId\` field.\\"\\"\\"
+  """Filter by the object’s \`ancestorId\` field."""
   ancestorId: IntFilter
 
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [FilterableClosureFilter!]
 
-  \\"\\"\\"Filter by the object’s \`depth\` field.\\"\\"\\"
+  """Filter by the object’s \`depth\` field."""
   depth: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`descendantId\` field.\\"\\"\\"
+  """Filter by the object’s \`descendantId\` field."""
   descendantId: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: FilterableClosureFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [FilterableClosureFilter!]
 }
 
-\\"\\"\\"A connection to a list of \`FilterableClosure\` values.\\"\\"\\"
+"""A connection to a list of \`FilterableClosure\` values."""
 type FilterableClosuresConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`FilterableClosure\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [FilterableClosuresEdge!]!
 
-  \\"\\"\\"A list of \`FilterableClosure\` objects.\\"\\"\\"
+  """A list of \`FilterableClosure\` objects."""
   nodes: [FilterableClosure]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"
+  """
   The count of *all* \`FilterableClosure\` you could get from the connection.
-  \\"\\"\\"
+  """
   totalCount: Int!
 }
 
-\\"\\"\\"A \`FilterableClosure\` edge in the connection.\\"\\"\\"
+"""A \`FilterableClosure\` edge in the connection."""
 type FilterableClosuresEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`FilterableClosure\` at the end of the edge.\\"\\"\\"
+  """The \`FilterableClosure\` at the end of the edge."""
   node: FilterableClosure
 }
 
-\\"\\"\\"Methods to use when ordering \`FilterableClosure\`.\\"\\"\\"
+"""Methods to use when ordering \`FilterableClosure\`."""
 enum FilterableClosuresOrderBy {
   ANCESTOR_ID_ASC
   ANCESTOR_ID_DESC
@@ -2648,181 +2648,181 @@ enum FilterableClosuresOrderBy {
   PRIMARY_KEY_DESC
 }
 
-\\"\\"\\"A connection to a list of \`Int\` values.\\"\\"\\"
+"""A connection to a list of \`Int\` values."""
 type FilterableComputedSetofIntConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`Int\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [FilterableComputedSetofIntEdge!]!
 
-  \\"\\"\\"A list of \`Int\` objects.\\"\\"\\"
+  """A list of \`Int\` objects."""
   nodes: [Int]!
 
-  \\"\\"\\"The count of *all* \`Int\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`Int\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`Int\` edge in the connection.\\"\\"\\"
+"""A \`Int\` edge in the connection."""
 type FilterableComputedSetofIntEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`Int\` at the end of the edge.\\"\\"\\"
+  """The \`Int\` at the end of the edge."""
   node: Int
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`Filterable\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input FilterableFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [FilterableFilter!]
 
-  \\"\\"\\"Filter by the object’s \`backwardCompound1\` field.\\"\\"\\"
+  """Filter by the object’s \`backwardCompound1\` field."""
   backwardCompound1: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`backwardCompound2\` field.\\"\\"\\"
+  """Filter by the object’s \`backwardCompound2\` field."""
   backwardCompound2: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`bit4\` field.\\"\\"\\"
+  """Filter by the object’s \`bit4\` field."""
   bit4: BitStringFilter
 
-  \\"\\"\\"Filter by the object’s \`bool\` field.\\"\\"\\"
+  """Filter by the object’s \`bool\` field."""
   bool: BooleanFilter
 
-  \\"\\"\\"Filter by the object’s \`bpchar4\` field.\\"\\"\\"
+  """Filter by the object’s \`bpchar4\` field."""
   bpchar4: StringFilter
 
-  \\"\\"\\"Filter by the object’s \`char4\` field.\\"\\"\\"
+  """Filter by the object’s \`char4\` field."""
   char4: StringFilter
 
-  \\"\\"\\"Filter by the object’s \`citext\` field.\\"\\"\\"
+  """Filter by the object’s \`citext\` field."""
   citext: StringFilter
 
-  \\"\\"\\"Filter by the object’s \`compositeColumn\` field.\\"\\"\\"
+  """Filter by the object’s \`compositeColumn\` field."""
   compositeColumn: CompositeFilter
 
-  \\"\\"\\"Filter by the object’s \`computed\` field.\\"\\"\\"
+  """Filter by the object’s \`computed\` field."""
   computed: StringFilter
 
-  \\"\\"\\"Filter by the object’s \`computedIntArray\` field.\\"\\"\\"
+  """Filter by the object’s \`computedIntArray\` field."""
   computedIntArray: IntListFilter
 
-  \\"\\"\\"Filter by the object’s \`computedTaggedFilterable\` field.\\"\\"\\"
+  """Filter by the object’s \`computedTaggedFilterable\` field."""
   computedTaggedFilterable: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`date\` field.\\"\\"\\"
+  """Filter by the object’s \`date\` field."""
   date: DateFilter
 
-  \\"\\"\\"Filter by the object’s \`float4\` field.\\"\\"\\"
+  """Filter by the object’s \`float4\` field."""
   float4: FloatFilter
 
-  \\"\\"\\"Filter by the object’s \`float8\` field.\\"\\"\\"
+  """Filter by the object’s \`float8\` field."""
   float8: FloatFilter
 
-  \\"\\"\\"Filter by the object’s \`forwardCompound1\` field.\\"\\"\\"
+  """Filter by the object’s \`forwardCompound1\` field."""
   forwardCompound1: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`forwardCompound2\` field.\\"\\"\\"
+  """Filter by the object’s \`forwardCompound2\` field."""
   forwardCompound2: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`forwardId\` field.\\"\\"\\"
+  """Filter by the object’s \`forwardId\` field."""
   forwardId: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`hstore\` field.\\"\\"\\"
+  """Filter by the object’s \`hstore\` field."""
   hstore: KeyValueHashFilter
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`inet\` field.\\"\\"\\"
+  """Filter by the object’s \`inet\` field."""
   inet: InternetAddressFilter
 
-  \\"\\"\\"Filter by the object’s \`int2\` field.\\"\\"\\"
+  """Filter by the object’s \`int2\` field."""
   int2: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`int4\` field.\\"\\"\\"
+  """Filter by the object’s \`int4\` field."""
   int4: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`int8\` field.\\"\\"\\"
+  """Filter by the object’s \`int8\` field."""
   int8: BigIntFilter
 
-  \\"\\"\\"Filter by the object’s \`interval\` field.\\"\\"\\"
+  """Filter by the object’s \`interval\` field."""
   interval: IntervalFilter
 
-  \\"\\"\\"Filter by the object’s \`jsonb\` field.\\"\\"\\"
+  """Filter by the object’s \`jsonb\` field."""
   jsonb: JSONFilter
 
-  \\"\\"\\"Filter by the object’s \`money\` field.\\"\\"\\"
+  """Filter by the object’s \`money\` field."""
   money: FloatFilter
 
-  \\"\\"\\"Filter by the object’s \`name\` field.\\"\\"\\"
+  """Filter by the object’s \`name\` field."""
   name: StringFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: FilterableFilter
 
-  \\"\\"\\"Filter by the object’s \`numeric\` field.\\"\\"\\"
+  """Filter by the object’s \`numeric\` field."""
   numeric: BigFloatFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [FilterableFilter!]
 
-  \\"\\"\\"Filter by the object’s \`parentId\` field.\\"\\"\\"
+  """Filter by the object’s \`parentId\` field."""
   parentId: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`text\` field.\\"\\"\\"
+  """Filter by the object’s \`text\` field."""
   text: StringFilter
 
-  \\"\\"\\"Filter by the object’s \`time\` field.\\"\\"\\"
+  """Filter by the object’s \`time\` field."""
   time: TimeFilter
 
-  \\"\\"\\"Filter by the object’s \`timestamp\` field.\\"\\"\\"
+  """Filter by the object’s \`timestamp\` field."""
   timestamp: DatetimeFilter
 
-  \\"\\"\\"Filter by the object’s \`timestamptz\` field.\\"\\"\\"
+  """Filter by the object’s \`timestamptz\` field."""
   timestamptz: DatetimeFilter
 
-  \\"\\"\\"Filter by the object’s \`timetz\` field.\\"\\"\\"
+  """Filter by the object’s \`timetz\` field."""
   timetz: TimeFilter
 
-  \\"\\"\\"Filter by the object’s \`uuid\` field.\\"\\"\\"
+  """Filter by the object’s \`uuid\` field."""
   uuid: UUIDFilter
 
-  \\"\\"\\"Filter by the object’s \`varbit\` field.\\"\\"\\"
+  """Filter by the object’s \`varbit\` field."""
   varbit: BitStringFilter
 
-  \\"\\"\\"Filter by the object’s \`varchar\` field.\\"\\"\\"
+  """Filter by the object’s \`varchar\` field."""
   varchar: StringFilter
 }
 
-\\"\\"\\"A connection to a list of \`Filterable\` values.\\"\\"\\"
+"""A connection to a list of \`Filterable\` values."""
 type FilterablesConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`Filterable\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [FilterablesEdge!]!
 
-  \\"\\"\\"A list of \`Filterable\` objects.\\"\\"\\"
+  """A list of \`Filterable\` objects."""
   nodes: [Filterable]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`Filterable\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`Filterable\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`Filterable\` edge in the connection.\\"\\"\\"
+"""A \`Filterable\` edge in the connection."""
 type FilterablesEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`Filterable\` at the end of the edge.\\"\\"\\"
+  """The \`Filterable\` at the end of the edge."""
   node: Filterable
 }
 
-\\"\\"\\"Methods to use when ordering \`Filterable\`.\\"\\"\\"
+"""Methods to use when ordering \`Filterable\`."""
 enum FilterablesOrderBy {
   BACKWARD_COMPOUND_1_ASC
   BACKWARD_COMPOUND_1_DESC
@@ -2911,188 +2911,188 @@ enum FilterablesOrderBy {
   XML_DESC
 }
 
-\\"\\"\\"
+"""
 A filter to be used against Float fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input FloatFilter {
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: Float
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: Float
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: Float
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: Float
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [Float!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: Float
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: Float
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: Float
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: Float
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [Float!]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against Float List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input FloatListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: Float
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: Float
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: Float
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: Float
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: Float
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: Float
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [Float]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [Float]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [Float]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [Float]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [Float]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [Float]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [Float]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [Float]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [Float]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [Float]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [Float]
 }
 
 type Forward implements Node {
-  \\"\\"\\"Reads a single \`Filterable\` that is related to this \`Forward\`.\\"\\"\\"
+  """Reads a single \`Filterable\` that is related to this \`Forward\`."""
   filterableByForwardId: Filterable
   id: Int!
   name: String!
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
 type ForwardCompound implements Node {
-  \\"\\"\\"Reads a single \`Filterable\` that is related to this \`ForwardCompound\`.\\"\\"\\"
+  """Reads a single \`Filterable\` that is related to this \`ForwardCompound\`."""
   filterableByForwardCompound1AndForwardCompound2: Filterable
   forwardCompound1: Int!
   forwardCompound2: Int!
   name: String
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`ForwardCompound\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input ForwardCompoundFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [ForwardCompoundFilter!]
 
-  \\"\\"\\"Filter by the object’s \`forwardCompound1\` field.\\"\\"\\"
+  """Filter by the object’s \`forwardCompound1\` field."""
   forwardCompound1: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`forwardCompound2\` field.\\"\\"\\"
+  """Filter by the object’s \`forwardCompound2\` field."""
   forwardCompound2: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`name\` field.\\"\\"\\"
+  """Filter by the object’s \`name\` field."""
   name: StringFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: ForwardCompoundFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [ForwardCompoundFilter!]
 }
 
-\\"\\"\\"A connection to a list of \`ForwardCompound\` values.\\"\\"\\"
+"""A connection to a list of \`ForwardCompound\` values."""
 type ForwardCompoundsConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`ForwardCompound\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [ForwardCompoundsEdge!]!
 
-  \\"\\"\\"A list of \`ForwardCompound\` objects.\\"\\"\\"
+  """A list of \`ForwardCompound\` objects."""
   nodes: [ForwardCompound]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"
+  """
   The count of *all* \`ForwardCompound\` you could get from the connection.
-  \\"\\"\\"
+  """
   totalCount: Int!
 }
 
-\\"\\"\\"A \`ForwardCompound\` edge in the connection.\\"\\"\\"
+"""A \`ForwardCompound\` edge in the connection."""
 type ForwardCompoundsEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`ForwardCompound\` at the end of the edge.\\"\\"\\"
+  """The \`ForwardCompound\` at the end of the edge."""
   node: ForwardCompound
 }
 
-\\"\\"\\"Methods to use when ordering \`ForwardCompound\`.\\"\\"\\"
+"""Methods to use when ordering \`ForwardCompound\`."""
 enum ForwardCompoundsOrderBy {
   FORWARD_COMPOUND_1_ASC
   FORWARD_COMPOUND_1_DESC
@@ -3105,53 +3105,53 @@ enum ForwardCompoundsOrderBy {
   PRIMARY_KEY_DESC
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`Forward\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input ForwardFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [ForwardFilter!]
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`name\` field.\\"\\"\\"
+  """Filter by the object’s \`name\` field."""
   name: StringFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: ForwardFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [ForwardFilter!]
 }
 
-\\"\\"\\"A connection to a list of \`Forward\` values.\\"\\"\\"
+"""A connection to a list of \`Forward\` values."""
 type ForwardsConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`Forward\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [ForwardsEdge!]!
 
-  \\"\\"\\"A list of \`Forward\` objects.\\"\\"\\"
+  """A list of \`Forward\` objects."""
   nodes: [Forward]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`Forward\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`Forward\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`Forward\` edge in the connection.\\"\\"\\"
+"""A \`Forward\` edge in the connection."""
 type ForwardsEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`Forward\` at the end of the edge.\\"\\"\\"
+  """The \`Forward\` at the end of the edge."""
   node: Forward
 }
 
-\\"\\"\\"Methods to use when ordering \`Forward\`.\\"\\"\\"
+"""Methods to use when ordering \`Forward\`."""
 enum ForwardsOrderBy {
   ID_ASC
   ID_DESC
@@ -3165,40 +3165,40 @@ enum ForwardsOrderBy {
 type FullyOmitted implements Node {
   id: Int!
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
   text: String
 }
 
-\\"\\"\\"A connection to a list of \`FullyOmitted\` values.\\"\\"\\"
+"""A connection to a list of \`FullyOmitted\` values."""
 type FullyOmittedsConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`FullyOmitted\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [FullyOmittedsEdge!]!
 
-  \\"\\"\\"A list of \`FullyOmitted\` objects.\\"\\"\\"
+  """A list of \`FullyOmitted\` objects."""
   nodes: [FullyOmitted]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`FullyOmitted\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`FullyOmitted\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`FullyOmitted\` edge in the connection.\\"\\"\\"
+"""A \`FullyOmitted\` edge in the connection."""
 type FullyOmittedsEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`FullyOmitted\` at the end of the edge.\\"\\"\\"
+  """The \`FullyOmitted\` at the end of the edge."""
   node: FullyOmitted
 }
 
-\\"\\"\\"Methods to use when ordering \`FullyOmitted\`.\\"\\"\\"
+"""Methods to use when ordering \`FullyOmitted\`."""
 enum FullyOmittedsOrderBy {
   ID_ASC
   ID_DESC
@@ -3209,746 +3209,746 @@ enum FullyOmittedsOrderBy {
   TEXT_DESC
 }
 
-\\"\\"\\"A connection to a list of \`FuncReturnsTableMultiColRecord\` values.\\"\\"\\"
+"""A connection to a list of \`FuncReturnsTableMultiColRecord\` values."""
 type FuncReturnsTableMultiColConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`FuncReturnsTableMultiColRecord\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [FuncReturnsTableMultiColEdge!]!
 
-  \\"\\"\\"A list of \`FuncReturnsTableMultiColRecord\` objects.\\"\\"\\"
+  """A list of \`FuncReturnsTableMultiColRecord\` objects."""
   nodes: [FuncReturnsTableMultiColRecord]!
 
-  \\"\\"\\"
+  """
   The count of *all* \`FuncReturnsTableMultiColRecord\` you could get from the connection.
-  \\"\\"\\"
+  """
   totalCount: Int!
 }
 
-\\"\\"\\"A \`FuncReturnsTableMultiColRecord\` edge in the connection.\\"\\"\\"
+"""A \`FuncReturnsTableMultiColRecord\` edge in the connection."""
 type FuncReturnsTableMultiColEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`FuncReturnsTableMultiColRecord\` at the end of the edge.\\"\\"\\"
+  """The \`FuncReturnsTableMultiColRecord\` at the end of the edge."""
   node: FuncReturnsTableMultiColRecord
 }
 
-\\"\\"\\"The return type of our \`funcReturnsTableMultiCol\` query.\\"\\"\\"
+"""The return type of our \`funcReturnsTableMultiCol\` query."""
 type FuncReturnsTableMultiColRecord {
   col1: Int
   col2: String
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`FuncReturnsTableMultiColRecord\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input FuncReturnsTableMultiColRecordFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [FuncReturnsTableMultiColRecordFilter!]
 
-  \\"\\"\\"Filter by the object’s \`col1\` field.\\"\\"\\"
+  """Filter by the object’s \`col1\` field."""
   col1: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`col2\` field.\\"\\"\\"
+  """Filter by the object’s \`col2\` field."""
   col2: StringFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: FuncReturnsTableMultiColRecordFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [FuncReturnsTableMultiColRecordFilter!]
 }
 
-\\"\\"\\"A connection to a list of \`Int\` values.\\"\\"\\"
+"""A connection to a list of \`Int\` values."""
 type FuncReturnsTableOneColConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`Int\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [FuncReturnsTableOneColEdge!]!
 
-  \\"\\"\\"A list of \`Int\` objects.\\"\\"\\"
+  """A list of \`Int\` objects."""
   nodes: [Int]!
 
-  \\"\\"\\"The count of *all* \`Int\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`Int\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`Int\` edge in the connection.\\"\\"\\"
+"""A \`Int\` edge in the connection."""
 type FuncReturnsTableOneColEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`Int\` at the end of the edge.\\"\\"\\"
+  """The \`Int\` at the end of the edge."""
   node: Int
 }
 
-\\"\\"\\"
+"""
 A connection to a list of \`FuncTaggedFilterableReturnsTableMultiColRecord\` values.
-\\"\\"\\"
+"""
 type FuncTaggedFilterableReturnsTableMultiColConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`FuncTaggedFilterableReturnsTableMultiColRecord\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [FuncTaggedFilterableReturnsTableMultiColEdge!]!
 
-  \\"\\"\\"A list of \`FuncTaggedFilterableReturnsTableMultiColRecord\` objects.\\"\\"\\"
+  """A list of \`FuncTaggedFilterableReturnsTableMultiColRecord\` objects."""
   nodes: [FuncTaggedFilterableReturnsTableMultiColRecord]!
 
-  \\"\\"\\"
+  """
   The count of *all* \`FuncTaggedFilterableReturnsTableMultiColRecord\` you could get from the connection.
-  \\"\\"\\"
+  """
   totalCount: Int!
 }
 
-\\"\\"\\"
+"""
 A \`FuncTaggedFilterableReturnsTableMultiColRecord\` edge in the connection.
-\\"\\"\\"
+"""
 type FuncTaggedFilterableReturnsTableMultiColEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"
+  """
   The \`FuncTaggedFilterableReturnsTableMultiColRecord\` at the end of the edge.
-  \\"\\"\\"
+  """
   node: FuncTaggedFilterableReturnsTableMultiColRecord
 }
 
-\\"\\"\\"
+"""
 The return type of our \`funcTaggedFilterableReturnsTableMultiCol\` query.
-\\"\\"\\"
+"""
 type FuncTaggedFilterableReturnsTableMultiColRecord {
   col1: Int
   col2: String
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`FuncTaggedFilterableReturnsTableMultiColRecord\`
 object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input FuncTaggedFilterableReturnsTableMultiColRecordFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [FuncTaggedFilterableReturnsTableMultiColRecordFilter!]
 
-  \\"\\"\\"Filter by the object’s \`col1\` field.\\"\\"\\"
+  """Filter by the object’s \`col1\` field."""
   col1: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`col2\` field.\\"\\"\\"
+  """Filter by the object’s \`col2\` field."""
   col2: StringFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: FuncTaggedFilterableReturnsTableMultiColRecordFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [FuncTaggedFilterableReturnsTableMultiColRecordFilter!]
 }
 
 scalar Int4Domain
 
-\\"\\"\\"
+"""
 A filter to be used against Int4Domain fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input Int4DomainFilter {
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: Int4Domain
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: Int4Domain
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: Int4Domain
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: Int4Domain
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [Int4Domain!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: Int4Domain
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: Int4Domain
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: Int4Domain
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: Int4Domain
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [Int4Domain!]
 }
 
-\\"\\"\\"An IPv4 or IPv6 host address, and optionally its subnet.\\"\\"\\"
+"""An IPv4 or IPv6 host address, and optionally its subnet."""
 scalar InternetAddress
 
-\\"\\"\\"
+"""
 A filter to be used against InternetAddress fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input InternetAddressFilter {
-  \\"\\"\\"Contained by the specified internet address.\\"\\"\\"
+  """Contained by the specified internet address."""
   containedBy: InternetAddress
 
-  \\"\\"\\"Contained by or equal to the specified internet address.\\"\\"\\"
+  """Contained by or equal to the specified internet address."""
   containedByOrEqualTo: InternetAddress
 
-  \\"\\"\\"Contains the specified internet address.\\"\\"\\"
+  """Contains the specified internet address."""
   contains: InternetAddress
 
-  \\"\\"\\"Contains or contained by the specified internet address.\\"\\"\\"
+  """Contains or contained by the specified internet address."""
   containsOrContainedBy: InternetAddress
 
-  \\"\\"\\"Contains or equal to the specified internet address.\\"\\"\\"
+  """Contains or equal to the specified internet address."""
   containsOrEqualTo: InternetAddress
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: InternetAddress
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: InternetAddress
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: InternetAddress
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: InternetAddress
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [InternetAddress!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: InternetAddress
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: InternetAddress
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: InternetAddress
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: InternetAddress
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [InternetAddress!]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against InternetAddress List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input InternetAddressListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: InternetAddress
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: InternetAddress
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: InternetAddress
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: InternetAddress
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: InternetAddress
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: InternetAddress
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [InternetAddress]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [InternetAddress]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [InternetAddress]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [InternetAddress]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [InternetAddress]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [InternetAddress]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [InternetAddress]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [InternetAddress]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [InternetAddress]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [InternetAddress]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [InternetAddress]
 }
 
-\\"\\"\\"
+"""
 An interval of time that has passed where the smallest distinct unit is a second.
-\\"\\"\\"
+"""
 type Interval {
-  \\"\\"\\"A quantity of days.\\"\\"\\"
+  """A quantity of days."""
   days: Int
 
-  \\"\\"\\"A quantity of hours.\\"\\"\\"
+  """A quantity of hours."""
   hours: Int
 
-  \\"\\"\\"A quantity of minutes.\\"\\"\\"
+  """A quantity of minutes."""
   minutes: Int
 
-  \\"\\"\\"A quantity of months.\\"\\"\\"
+  """A quantity of months."""
   months: Int
 
-  \\"\\"\\"
+  """
   A quantity of seconds. This is the only non-integer field, as all the other
   fields will dump their overflow into a smaller unit of time. Intervals don’t
   have a smaller unit than seconds.
-  \\"\\"\\"
+  """
   seconds: Float
 
-  \\"\\"\\"A quantity of years.\\"\\"\\"
+  """A quantity of years."""
   years: Int
 }
 
-\\"\\"\\"
+"""
 A filter to be used against Interval fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input IntervalFilter {
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: IntervalInput
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: IntervalInput
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: IntervalInput
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: IntervalInput
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [IntervalInput!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: IntervalInput
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: IntervalInput
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: IntervalInput
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: IntervalInput
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [IntervalInput!]
 }
 
-\\"\\"\\"
+"""
 An interval of time that has passed where the smallest distinct unit is a second.
-\\"\\"\\"
+"""
 input IntervalInput {
-  \\"\\"\\"A quantity of days.\\"\\"\\"
+  """A quantity of days."""
   days: Int
 
-  \\"\\"\\"A quantity of hours.\\"\\"\\"
+  """A quantity of hours."""
   hours: Int
 
-  \\"\\"\\"A quantity of minutes.\\"\\"\\"
+  """A quantity of minutes."""
   minutes: Int
 
-  \\"\\"\\"A quantity of months.\\"\\"\\"
+  """A quantity of months."""
   months: Int
 
-  \\"\\"\\"
+  """
   A quantity of seconds. This is the only non-integer field, as all the other
   fields will dump their overflow into a smaller unit of time. Intervals don’t
   have a smaller unit than seconds.
-  \\"\\"\\"
+  """
   seconds: Float
 
-  \\"\\"\\"A quantity of years.\\"\\"\\"
+  """A quantity of years."""
   years: Int
 }
 
-\\"\\"\\"
+"""
 A filter to be used against Interval List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input IntervalListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: IntervalInput
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: IntervalInput
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: IntervalInput
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: IntervalInput
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: IntervalInput
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: IntervalInput
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [IntervalInput]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [IntervalInput]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [IntervalInput]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [IntervalInput]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [IntervalInput]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [IntervalInput]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [IntervalInput]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [IntervalInput]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [IntervalInput]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [IntervalInput]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [IntervalInput]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against Int fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input IntFilter {
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: Int
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: Int
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: Int
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: Int
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [Int!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: Int
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: Int
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: Int
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: Int
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [Int!]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against Int List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input IntListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: Int
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: Int
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: Int
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: Int
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: Int
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: Int
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [Int]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [Int]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [Int]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [Int]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [Int]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [Int]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [Int]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [Int]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [Int]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [Int]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [Int]
 }
 
-\\"\\"\\"A range of \`Int\`.\\"\\"\\"
+"""A range of \`Int\`."""
 type IntRange {
-  \\"\\"\\"The ending bound of our range.\\"\\"\\"
+  """The ending bound of our range."""
   end: IntRangeBound
 
-  \\"\\"\\"The starting bound of our range.\\"\\"\\"
+  """The starting bound of our range."""
   start: IntRangeBound
 }
 
-\\"\\"\\"
+"""
 The value at one end of a range. A range can either include this value, or not.
-\\"\\"\\"
+"""
 type IntRangeBound {
-  \\"\\"\\"Whether or not the value of this bound is included in the range.\\"\\"\\"
+  """Whether or not the value of this bound is included in the range."""
   inclusive: Boolean!
 
-  \\"\\"\\"The value at one end of our range.\\"\\"\\"
+  """The value at one end of our range."""
   value: Int!
 }
 
-\\"\\"\\"
+"""
 The value at one end of a range. A range can either include this value, or not.
-\\"\\"\\"
+"""
 input IntRangeBoundInput {
-  \\"\\"\\"Whether or not the value of this bound is included in the range.\\"\\"\\"
+  """Whether or not the value of this bound is included in the range."""
   inclusive: Boolean!
 
-  \\"\\"\\"The value at one end of our range.\\"\\"\\"
+  """The value at one end of our range."""
   value: Int!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against IntRange fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input IntRangeFilter {
-  \\"\\"\\"Adjacent to the specified range.\\"\\"\\"
+  """Adjacent to the specified range."""
   adjacentTo: IntRangeInput
 
-  \\"\\"\\"Contained by the specified range.\\"\\"\\"
+  """Contained by the specified range."""
   containedBy: IntRangeInput
 
-  \\"\\"\\"Contains the specified range.\\"\\"\\"
+  """Contains the specified range."""
   contains: IntRangeInput
 
-  \\"\\"\\"Contains the specified value.\\"\\"\\"
+  """Contains the specified value."""
   containsElement: Int
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: IntRangeInput
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: IntRangeInput
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: IntRangeInput
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: IntRangeInput
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [IntRangeInput!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: IntRangeInput
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: IntRangeInput
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: IntRangeInput
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: IntRangeInput
 
-  \\"\\"\\"Does not extend left of the specified range.\\"\\"\\"
+  """Does not extend left of the specified range."""
   notExtendsLeftOf: IntRangeInput
 
-  \\"\\"\\"Does not extend right of the specified range.\\"\\"\\"
+  """Does not extend right of the specified range."""
   notExtendsRightOf: IntRangeInput
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [IntRangeInput!]
 
-  \\"\\"\\"Overlaps the specified range.\\"\\"\\"
+  """Overlaps the specified range."""
   overlaps: IntRangeInput
 
-  \\"\\"\\"Strictly left of the specified range.\\"\\"\\"
+  """Strictly left of the specified range."""
   strictlyLeftOf: IntRangeInput
 
-  \\"\\"\\"Strictly right of the specified range.\\"\\"\\"
+  """Strictly right of the specified range."""
   strictlyRightOf: IntRangeInput
 }
 
-\\"\\"\\"A range of \`Int\`.\\"\\"\\"
+"""A range of \`Int\`."""
 input IntRangeInput {
-  \\"\\"\\"The ending bound of our range.\\"\\"\\"
+  """The ending bound of our range."""
   end: IntRangeBoundInput
 
-  \\"\\"\\"The starting bound of our range.\\"\\"\\"
+  """The starting bound of our range."""
   start: IntRangeBoundInput
 }
 
-\\"\\"\\"
+"""
 A filter to be used against IntRange List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input IntRangeListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: IntRangeInput
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: IntRangeInput
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: IntRangeInput
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: IntRangeInput
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: IntRangeInput
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: IntRangeInput
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [IntRangeInput]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [IntRangeInput]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [IntRangeInput]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [IntRangeInput]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [IntRangeInput]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [IntRangeInput]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [IntRangeInput]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [IntRangeInput]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [IntRangeInput]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [IntRangeInput]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [IntRangeInput]
 }
 
-\\"\\"\\"
+"""
 A JavaScript object encoded in the JSON format as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf).
-\\"\\"\\"
+"""
 scalar JSON
 
 type JsonbTest implements Node {
@@ -3956,62 +3956,62 @@ type JsonbTest implements Node {
   jsonbWithArray: JSON
   jsonbWithObject: JSON
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`JsonbTest\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input JsonbTestFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [JsonbTestFilter!]
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`jsonbWithArray\` field.\\"\\"\\"
+  """Filter by the object’s \`jsonbWithArray\` field."""
   jsonbWithArray: JSONFilter
 
-  \\"\\"\\"Filter by the object’s \`jsonbWithObject\` field.\\"\\"\\"
+  """Filter by the object’s \`jsonbWithObject\` field."""
   jsonbWithObject: JSONFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: JsonbTestFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [JsonbTestFilter!]
 }
 
-\\"\\"\\"A connection to a list of \`JsonbTest\` values.\\"\\"\\"
+"""A connection to a list of \`JsonbTest\` values."""
 type JsonbTestsConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`JsonbTest\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [JsonbTestsEdge!]!
 
-  \\"\\"\\"A list of \`JsonbTest\` objects.\\"\\"\\"
+  """A list of \`JsonbTest\` objects."""
   nodes: [JsonbTest]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`JsonbTest\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`JsonbTest\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`JsonbTest\` edge in the connection.\\"\\"\\"
+"""A \`JsonbTest\` edge in the connection."""
 type JsonbTestsEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`JsonbTest\` at the end of the edge.\\"\\"\\"
+  """The \`JsonbTest\` at the end of the edge."""
   node: JsonbTest
 }
 
-\\"\\"\\"Methods to use when ordering \`JsonbTest\`.\\"\\"\\"
+"""Methods to use when ordering \`JsonbTest\`."""
 enum JsonbTestsOrderBy {
   ID_ASC
   ID_DESC
@@ -4024,188 +4024,188 @@ enum JsonbTestsOrderBy {
   PRIMARY_KEY_DESC
 }
 
-\\"\\"\\"
+"""
 A filter to be used against JSON fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input JSONFilter {
-  \\"\\"\\"Contained by the specified JSON.\\"\\"\\"
+  """Contained by the specified JSON."""
   containedBy: JSON
 
-  \\"\\"\\"Contains the specified JSON.\\"\\"\\"
+  """Contains the specified JSON."""
   contains: JSON
 
-  \\"\\"\\"Contains all of the specified keys.\\"\\"\\"
+  """Contains all of the specified keys."""
   containsAllKeys: [String!]
 
-  \\"\\"\\"Contains any of the specified keys.\\"\\"\\"
+  """Contains any of the specified keys."""
   containsAnyKeys: [String!]
 
-  \\"\\"\\"Contains the specified key.\\"\\"\\"
+  """Contains the specified key."""
   containsKey: String
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: JSON
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: JSON
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: JSON
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: JSON
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [JSON!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: JSON
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: JSON
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: JSON
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: JSON
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [JSON!]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against JSON List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input JSONListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: JSON
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: JSON
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: JSON
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: JSON
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: JSON
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: JSON
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [JSON]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [JSON]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [JSON]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [JSON]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [JSON]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [JSON]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [JSON]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [JSON]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [JSON]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [JSON]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [JSON]
 }
 
 type Junction implements Node {
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 
-  \\"\\"\\"Reads a single \`SideA\` that is related to this \`Junction\`.\\"\\"\\"
+  """Reads a single \`SideA\` that is related to this \`Junction\`."""
   sideABySideAId: SideA
   sideAId: Int!
 
-  \\"\\"\\"Reads a single \`SideB\` that is related to this \`Junction\`.\\"\\"\\"
+  """Reads a single \`SideB\` that is related to this \`Junction\`."""
   sideBBySideBId: SideB
   sideBId: Int!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`Junction\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input JunctionFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [JunctionFilter!]
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: JunctionFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [JunctionFilter!]
 
-  \\"\\"\\"Filter by the object’s \`sideAId\` field.\\"\\"\\"
+  """Filter by the object’s \`sideAId\` field."""
   sideAId: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`sideBId\` field.\\"\\"\\"
+  """Filter by the object’s \`sideBId\` field."""
   sideBId: IntFilter
 }
 
-\\"\\"\\"A connection to a list of \`Junction\` values.\\"\\"\\"
+"""A connection to a list of \`Junction\` values."""
 type JunctionsConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`Junction\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [JunctionsEdge!]!
 
-  \\"\\"\\"A list of \`Junction\` objects.\\"\\"\\"
+  """A list of \`Junction\` objects."""
   nodes: [Junction]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`Junction\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`Junction\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`Junction\` edge in the connection.\\"\\"\\"
+"""A \`Junction\` edge in the connection."""
 type JunctionsEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`Junction\` at the end of the edge.\\"\\"\\"
+  """The \`Junction\` at the end of the edge."""
   node: Junction
 }
 
-\\"\\"\\"Methods to use when ordering \`Junction\`.\\"\\"\\"
+"""Methods to use when ordering \`Junction\`."""
 enum JunctionsOrderBy {
   NATURAL
   PRIMARY_KEY_ASC
@@ -4216,116 +4216,116 @@ enum JunctionsOrderBy {
   SIDE_B_ID_DESC
 }
 
-\\"\\"\\"
+"""
 A set of key/value pairs, keys are strings, values may be a string or null. Exposed as a JSON object.
-\\"\\"\\"
+"""
 scalar KeyValueHash
 
-\\"\\"\\"
+"""
 A filter to be used against KeyValueHash fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input KeyValueHashFilter {
-  \\"\\"\\"Contained by the specified KeyValueHash.\\"\\"\\"
+  """Contained by the specified KeyValueHash."""
   containedBy: KeyValueHash
 
-  \\"\\"\\"Contains the specified KeyValueHash.\\"\\"\\"
+  """Contains the specified KeyValueHash."""
   contains: KeyValueHash
 
-  \\"\\"\\"Contains all of the specified keys.\\"\\"\\"
+  """Contains all of the specified keys."""
   containsAllKeys: [String!]
 
-  \\"\\"\\"Contains any of the specified keys.\\"\\"\\"
+  """Contains any of the specified keys."""
   containsAnyKeys: [String!]
 
-  \\"\\"\\"Contains the specified key.\\"\\"\\"
+  """Contains the specified key."""
   containsKey: String
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: KeyValueHash
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: KeyValueHash
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [KeyValueHash!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: KeyValueHash
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: KeyValueHash
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [KeyValueHash!]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against KeyValueHash List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input KeyValueHashListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: KeyValueHash
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: KeyValueHash
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: KeyValueHash
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: KeyValueHash
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: KeyValueHash
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: KeyValueHash
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [KeyValueHash]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [KeyValueHash]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [KeyValueHash]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [KeyValueHash]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [KeyValueHash]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [KeyValueHash]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [KeyValueHash]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [KeyValueHash]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [KeyValueHash]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [KeyValueHash]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [KeyValueHash]
 }
 
@@ -4335,219 +4335,219 @@ enum Mood {
   SAD
 }
 
-\\"\\"\\"
+"""
 A filter to be used against Mood fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input MoodFilter {
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: Mood
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: Mood
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: Mood
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: Mood
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [Mood!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: Mood
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: Mood
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: Mood
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: Mood
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [Mood!]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against Mood List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input MoodListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: Mood
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: Mood
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: Mood
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: Mood
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: Mood
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: Mood
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [Mood]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [Mood]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [Mood]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [Mood]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [Mood]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [Mood]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [Mood]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [Mood]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [Mood]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [Mood]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [Mood]
 }
 
-\\"\\"\\"An object with a globally unique \`ID\`.\\"\\"\\"
+"""An object with a globally unique \`ID\`."""
 interface Node {
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
-\\"\\"\\"Information about pagination in a connection.\\"\\"\\"
+"""Information about pagination in a connection."""
 type PageInfo {
-  \\"\\"\\"When paginating forwards, the cursor to continue.\\"\\"\\"
+  """When paginating forwards, the cursor to continue."""
   endCursor: Cursor
 
-  \\"\\"\\"When paginating forwards, are there more items?\\"\\"\\"
+  """When paginating forwards, are there more items?"""
   hasNextPage: Boolean!
 
-  \\"\\"\\"When paginating backwards, are there more items?\\"\\"\\"
+  """When paginating backwards, are there more items?"""
   hasPreviousPage: Boolean!
 
-  \\"\\"\\"When paginating backwards, the cursor to continue.\\"\\"\\"
+  """When paginating backwards, the cursor to continue."""
   startCursor: Cursor
 }
 
 type Parent implements Node {
-  \\"\\"\\"Reads and enables pagination through a set of \`Filterable\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Filterable\`."""
   filterablesByParentId(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: FilterableFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`Filterable\`.\\"\\"\\"
+    """The method to use when ordering \`Filterable\`."""
     orderBy: [FilterablesOrderBy!] = [PRIMARY_KEY_ASC]
   ): FilterablesConnection!
   id: Int!
   name: String!
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`Parent\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input ParentFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [ParentFilter!]
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`name\` field.\\"\\"\\"
+  """Filter by the object’s \`name\` field."""
   name: StringFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: ParentFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [ParentFilter!]
 }
 
-\\"\\"\\"A connection to a list of \`Parent\` values.\\"\\"\\"
+"""A connection to a list of \`Parent\` values."""
 type ParentsConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`Parent\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [ParentsEdge!]!
 
-  \\"\\"\\"A list of \`Parent\` objects.\\"\\"\\"
+  """A list of \`Parent\` objects."""
   nodes: [Parent]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`Parent\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`Parent\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`Parent\` edge in the connection.\\"\\"\\"
+"""A \`Parent\` edge in the connection."""
 type ParentsEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`Parent\` at the end of the edge.\\"\\"\\"
+  """The \`Parent\` at the end of the edge."""
   node: Parent
 }
 
-\\"\\"\\"Methods to use when ordering \`Parent\`.\\"\\"\\"
+"""Methods to use when ordering \`Parent\`."""
 enum ParentsOrderBy {
   ID_ASC
   ID_DESC
@@ -4562,704 +4562,704 @@ type Protected implements Node {
   id: Int!
   name: String
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
   otherId: Int
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`Protected\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input ProtectedFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [ProtectedFilter!]
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`name\` field.\\"\\"\\"
+  """Filter by the object’s \`name\` field."""
   name: StringFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: ProtectedFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [ProtectedFilter!]
 
-  \\"\\"\\"Filter by the object’s \`otherId\` field.\\"\\"\\"
+  """Filter by the object’s \`otherId\` field."""
   otherId: IntFilter
 }
 
-\\"\\"\\"A connection to a list of \`Protected\` values.\\"\\"\\"
+"""A connection to a list of \`Protected\` values."""
 type ProtectedsConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`Protected\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [ProtectedsEdge!]!
 
-  \\"\\"\\"A list of \`Protected\` objects.\\"\\"\\"
+  """A list of \`Protected\` objects."""
   nodes: [Protected]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`Protected\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`Protected\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`Protected\` edge in the connection.\\"\\"\\"
+"""A \`Protected\` edge in the connection."""
 type ProtectedsEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`Protected\` at the end of the edge.\\"\\"\\"
+  """The \`Protected\` at the end of the edge."""
   node: Protected
 }
 
-\\"\\"\\"The root query type which gives access points into the data universe.\\"\\"\\"
+"""The root query type which gives access points into the data universe."""
 type Query implements Node {
-  \\"\\"\\"Reads and enables pagination through a set of \`ArrayType\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`ArrayType\`."""
   allArrayTypes(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: ArrayTypeFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`ArrayType\`.\\"\\"\\"
+    """The method to use when ordering \`ArrayType\`."""
     orderBy: [ArrayTypesOrderBy!] = [PRIMARY_KEY_ASC]
   ): ArrayTypesConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`BackwardCompound\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`BackwardCompound\`."""
   allBackwardCompounds(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: BackwardCompoundFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`BackwardCompound\`.\\"\\"\\"
+    """The method to use when ordering \`BackwardCompound\`."""
     orderBy: [BackwardCompoundsOrderBy!] = [PRIMARY_KEY_ASC]
   ): BackwardCompoundsConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Backward\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Backward\`."""
   allBackwards(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: BackwardFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`Backward\`.\\"\\"\\"
+    """The method to use when ordering \`Backward\`."""
     orderBy: [BackwardsOrderBy!] = [PRIMARY_KEY_ASC]
   ): BackwardsConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`ChildNoRelatedFilter\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`ChildNoRelatedFilter\`."""
   allChildNoRelatedFilters(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: ChildNoRelatedFilterFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`ChildNoRelatedFilter\`.\\"\\"\\"
+    """The method to use when ordering \`ChildNoRelatedFilter\`."""
     orderBy: [ChildNoRelatedFiltersOrderBy!] = [PRIMARY_KEY_ASC]
   ): ChildNoRelatedFiltersConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Child\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Child\`."""
   allChildren(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: ChildFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`Child\`.\\"\\"\\"
+    """The method to use when ordering \`Child\`."""
     orderBy: [ChildrenOrderBy!] = [PRIMARY_KEY_ASC]
   ): ChildrenConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`DomainType\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`DomainType\`."""
   allDomainTypes(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: DomainTypeFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`DomainType\`.\\"\\"\\"
+    """The method to use when ordering \`DomainType\`."""
     orderBy: [DomainTypesOrderBy!] = [PRIMARY_KEY_ASC]
   ): DomainTypesConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`EnumArrayType\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`EnumArrayType\`."""
   allEnumArrayTypes(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: EnumArrayTypeFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`EnumArrayType\`.\\"\\"\\"
+    """The method to use when ordering \`EnumArrayType\`."""
     orderBy: [EnumArrayTypesOrderBy!] = [PRIMARY_KEY_ASC]
   ): EnumArrayTypesConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`EnumType\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`EnumType\`."""
   allEnumTypes(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: EnumTypeFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`EnumType\`.\\"\\"\\"
+    """The method to use when ordering \`EnumType\`."""
     orderBy: [EnumTypesOrderBy!] = [PRIMARY_KEY_ASC]
   ): EnumTypesConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Filterable\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Filterable\`."""
   allFilterables(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: FilterableFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`Filterable\`.\\"\\"\\"
+    """The method to use when ordering \`Filterable\`."""
     orderBy: [FilterablesOrderBy!] = [PRIMARY_KEY_ASC]
   ): FilterablesConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`ForwardCompound\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`ForwardCompound\`."""
   allForwardCompounds(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: ForwardCompoundFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`ForwardCompound\`.\\"\\"\\"
+    """The method to use when ordering \`ForwardCompound\`."""
     orderBy: [ForwardCompoundsOrderBy!] = [PRIMARY_KEY_ASC]
   ): ForwardCompoundsConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Forward\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Forward\`."""
   allForwards(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: ForwardFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`Forward\`.\\"\\"\\"
+    """The method to use when ordering \`Forward\`."""
     orderBy: [ForwardsOrderBy!] = [PRIMARY_KEY_ASC]
   ): ForwardsConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`FullyOmitted\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`FullyOmitted\`."""
   allFullyOmitteds(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`FullyOmitted\`.\\"\\"\\"
+    """The method to use when ordering \`FullyOmitted\`."""
     orderBy: [FullyOmittedsOrderBy!] = [PRIMARY_KEY_ASC]
   ): FullyOmittedsConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`JsonbTest\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`JsonbTest\`."""
   allJsonbTests(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: JsonbTestFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`JsonbTest\`.\\"\\"\\"
+    """The method to use when ordering \`JsonbTest\`."""
     orderBy: [JsonbTestsOrderBy!] = [PRIMARY_KEY_ASC]
   ): JsonbTestsConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Junction\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Junction\`."""
   allJunctions(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: JunctionFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`Junction\`.\\"\\"\\"
+    """The method to use when ordering \`Junction\`."""
     orderBy: [JunctionsOrderBy!] = [PRIMARY_KEY_ASC]
   ): JunctionsConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Parent\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Parent\`."""
   allParents(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: ParentFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`Parent\`.\\"\\"\\"
+    """The method to use when ordering \`Parent\`."""
     orderBy: [ParentsOrderBy!] = [PRIMARY_KEY_ASC]
   ): ParentsConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`RangeArrayType\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`RangeArrayType\`."""
   allRangeArrayTypes(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: RangeArrayTypeFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`RangeArrayType\`.\\"\\"\\"
+    """The method to use when ordering \`RangeArrayType\`."""
     orderBy: [RangeArrayTypesOrderBy!] = [PRIMARY_KEY_ASC]
   ): RangeArrayTypesConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`RangeType\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`RangeType\`."""
   allRangeTypes(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: RangeTypeFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`RangeType\`.\\"\\"\\"
+    """The method to use when ordering \`RangeType\`."""
     orderBy: [RangeTypesOrderBy!] = [PRIMARY_KEY_ASC]
   ): RangeTypesConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`SideA\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`SideA\`."""
   allSideAs(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: SideAFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`SideA\`.\\"\\"\\"
+    """The method to use when ordering \`SideA\`."""
     orderBy: [SideAsOrderBy!] = [PRIMARY_KEY_ASC]
   ): SideAsConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`SideB\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`SideB\`."""
   allSideBs(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: SideBFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`SideB\`.\\"\\"\\"
+    """The method to use when ordering \`SideB\`."""
     orderBy: [SideBsOrderBy!] = [PRIMARY_KEY_ASC]
   ): SideBsConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Unfilterable\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Unfilterable\`."""
   allUnfilterables(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`Unfilterable\`.\\"\\"\\"
+    """The method to use when ordering \`Unfilterable\`."""
     orderBy: [UnfilterablesOrderBy!] = [PRIMARY_KEY_ASC]
   ): UnfilterablesConnection
 
-  \\"\\"\\"Reads a single \`ArrayType\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`ArrayType\` using its globally unique \`ID\`."""
   arrayType(
-    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`ArrayType\`.\\"\\"\\"
+    """The globally unique \`ID\` to be used in selecting a single \`ArrayType\`."""
     nodeId: ID!
   ): ArrayType
   arrayTypeById(id: Int!): ArrayType
 
-  \\"\\"\\"Reads a single \`Backward\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`Backward\` using its globally unique \`ID\`."""
   backward(
-    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`Backward\`.\\"\\"\\"
+    """The globally unique \`ID\` to be used in selecting a single \`Backward\`."""
     nodeId: ID!
   ): Backward
   backwardByFilterableId(filterableId: Int!): Backward
   backwardById(id: Int!): Backward
 
-  \\"\\"\\"Reads a single \`BackwardCompound\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`BackwardCompound\` using its globally unique \`ID\`."""
   backwardCompound(
-    \\"\\"\\"
+    """
     The globally unique \`ID\` to be used in selecting a single \`BackwardCompound\`.
-    \\"\\"\\"
+    """
     nodeId: ID!
   ): BackwardCompound
   backwardCompoundByBackwardCompound1AndBackwardCompound2(backwardCompound1: Int!, backwardCompound2: Int!): BackwardCompound
 
-  \\"\\"\\"Reads a single \`Child\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`Child\` using its globally unique \`ID\`."""
   child(
-    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`Child\`.\\"\\"\\"
+    """The globally unique \`ID\` to be used in selecting a single \`Child\`."""
     nodeId: ID!
   ): Child
   childById(id: Int!): Child
 
-  \\"\\"\\"Reads a single \`ChildNoRelatedFilter\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`ChildNoRelatedFilter\` using its globally unique \`ID\`."""
   childNoRelatedFilter(
-    \\"\\"\\"
+    """
     The globally unique \`ID\` to be used in selecting a single \`ChildNoRelatedFilter\`.
-    \\"\\"\\"
+    """
     nodeId: ID!
   ): ChildNoRelatedFilter
   childNoRelatedFilterById(id: Int!): ChildNoRelatedFilter
 
-  \\"\\"\\"Reads a single \`DomainType\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`DomainType\` using its globally unique \`ID\`."""
   domainType(
-    \\"\\"\\"
+    """
     The globally unique \`ID\` to be used in selecting a single \`DomainType\`.
-    \\"\\"\\"
+    """
     nodeId: ID!
   ): DomainType
   domainTypeById(id: Int!): DomainType
 
-  \\"\\"\\"Reads a single \`EnumArrayType\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`EnumArrayType\` using its globally unique \`ID\`."""
   enumArrayType(
-    \\"\\"\\"
+    """
     The globally unique \`ID\` to be used in selecting a single \`EnumArrayType\`.
-    \\"\\"\\"
+    """
     nodeId: ID!
   ): EnumArrayType
   enumArrayTypeById(id: Int!): EnumArrayType
 
-  \\"\\"\\"Reads a single \`EnumType\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`EnumType\` using its globally unique \`ID\`."""
   enumType(
-    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`EnumType\`.\\"\\"\\"
+    """The globally unique \`ID\` to be used in selecting a single \`EnumType\`."""
     nodeId: ID!
   ): EnumType
   enumTypeById(id: Int!): EnumType
 
-  \\"\\"\\"Reads a single \`Filterable\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`Filterable\` using its globally unique \`ID\`."""
   filterable(
-    \\"\\"\\"
+    """
     The globally unique \`ID\` to be used in selecting a single \`Filterable\`.
-    \\"\\"\\"
+    """
     nodeId: ID!
   ): Filterable
   filterableByBackwardCompound1AndBackwardCompound2(backwardCompound1: Int!, backwardCompound2: Int!): Filterable
@@ -5267,247 +5267,247 @@ type Query implements Node {
   filterableByForwardId(forwardId: Int!): Filterable
   filterableById(id: Int!): Filterable
 
-  \\"\\"\\"Reads a single \`FilterableClosure\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`FilterableClosure\` using its globally unique \`ID\`."""
   filterableClosure(
-    \\"\\"\\"
+    """
     The globally unique \`ID\` to be used in selecting a single \`FilterableClosure\`.
-    \\"\\"\\"
+    """
     nodeId: ID!
   ): FilterableClosure
   filterableClosureById(id: Int!): FilterableClosure
 
-  \\"\\"\\"Reads a single \`Forward\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`Forward\` using its globally unique \`ID\`."""
   forward(
-    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`Forward\`.\\"\\"\\"
+    """The globally unique \`ID\` to be used in selecting a single \`Forward\`."""
     nodeId: ID!
   ): Forward
   forwardById(id: Int!): Forward
 
-  \\"\\"\\"Reads a single \`ForwardCompound\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`ForwardCompound\` using its globally unique \`ID\`."""
   forwardCompound(
-    \\"\\"\\"
+    """
     The globally unique \`ID\` to be used in selecting a single \`ForwardCompound\`.
-    \\"\\"\\"
+    """
     nodeId: ID!
   ): ForwardCompound
   forwardCompoundByForwardCompound1AndForwardCompound2(forwardCompound1: Int!, forwardCompound2: Int!): ForwardCompound
 
-  \\"\\"\\"Reads a single \`FullyOmitted\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`FullyOmitted\` using its globally unique \`ID\`."""
   fullyOmitted(
-    \\"\\"\\"
+    """
     The globally unique \`ID\` to be used in selecting a single \`FullyOmitted\`.
-    \\"\\"\\"
+    """
     nodeId: ID!
   ): FullyOmitted
   fullyOmittedById(id: Int!): FullyOmitted
   funcReturnsTableMultiCol(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: FuncReturnsTableMultiColRecordFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
     i: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
   ): FuncReturnsTableMultiColConnection!
   funcReturnsTableOneCol(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: IntFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
     i: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
   ): FuncReturnsTableOneColConnection!
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Filterable\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Filterable\`."""
   funcTaggedFilterableReturnsSetofFilterable(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: FilterableFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
   ): FilterablesConnection!
   funcTaggedFilterableReturnsTableMultiCol(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: FuncTaggedFilterableReturnsTableMultiColRecordFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
   ): FuncTaggedFilterableReturnsTableMultiColConnection!
 
-  \\"\\"\\"Reads a single \`JsonbTest\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`JsonbTest\` using its globally unique \`ID\`."""
   jsonbTest(
-    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`JsonbTest\`.\\"\\"\\"
+    """The globally unique \`ID\` to be used in selecting a single \`JsonbTest\`."""
     nodeId: ID!
   ): JsonbTest
   jsonbTestById(id: Int!): JsonbTest
 
-  \\"\\"\\"Reads a single \`Junction\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`Junction\` using its globally unique \`ID\`."""
   junction(
-    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`Junction\`.\\"\\"\\"
+    """The globally unique \`ID\` to be used in selecting a single \`Junction\`."""
     nodeId: ID!
   ): Junction
   junctionBySideAIdAndSideBId(sideAId: Int!, sideBId: Int!): Junction
 
-  \\"\\"\\"Fetches an object given its globally unique \`ID\`.\\"\\"\\"
+  """Fetches an object given its globally unique \`ID\`."""
   node(
-    \\"\\"\\"The globally unique \`ID\`.\\"\\"\\"
+    """The globally unique \`ID\`."""
     nodeId: ID!
   ): Node
 
-  \\"\\"\\"
+  """
   The root query type must be a \`Node\` to work well with Relay 1 mutations. This just resolves to \`query\`.
-  \\"\\"\\"
+  """
   nodeId: ID!
 
-  \\"\\"\\"Reads a single \`Parent\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`Parent\` using its globally unique \`ID\`."""
   parent(
-    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`Parent\`.\\"\\"\\"
+    """The globally unique \`ID\` to be used in selecting a single \`Parent\`."""
     nodeId: ID!
   ): Parent
   parentById(id: Int!): Parent
 
-  \\"\\"\\"Reads a single \`Protected\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`Protected\` using its globally unique \`ID\`."""
   protected(
-    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`Protected\`.\\"\\"\\"
+    """The globally unique \`ID\` to be used in selecting a single \`Protected\`."""
     nodeId: ID!
   ): Protected
   protectedById(id: Int!): Protected
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Protected\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Protected\`."""
   protectedsByOtherId(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: ProtectedFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
     otherId: Int
   ): ProtectedsConnection!
 
-  \\"\\"\\"
+  """
   Exposes the root query type nested one level down. This is helpful for Relay 1
   which can only query top level fields if they are in a particular form.
-  \\"\\"\\"
+  """
   query: Query!
 
-  \\"\\"\\"Reads a single \`RangeArrayType\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`RangeArrayType\` using its globally unique \`ID\`."""
   rangeArrayType(
-    \\"\\"\\"
+    """
     The globally unique \`ID\` to be used in selecting a single \`RangeArrayType\`.
-    \\"\\"\\"
+    """
     nodeId: ID!
   ): RangeArrayType
   rangeArrayTypeById(id: Int!): RangeArrayType
 
-  \\"\\"\\"Reads a single \`RangeType\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`RangeType\` using its globally unique \`ID\`."""
   rangeType(
-    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`RangeType\`.\\"\\"\\"
+    """The globally unique \`ID\` to be used in selecting a single \`RangeType\`."""
     nodeId: ID!
   ): RangeType
   rangeTypeById(id: Int!): RangeType
 
-  \\"\\"\\"Reads a single \`SideA\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`SideA\` using its globally unique \`ID\`."""
   sideA(
-    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`SideA\`.\\"\\"\\"
+    """The globally unique \`ID\` to be used in selecting a single \`SideA\`."""
     nodeId: ID!
   ): SideA
   sideAByAId(aId: Int!): SideA
 
-  \\"\\"\\"Reads a single \`SideB\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`SideB\` using its globally unique \`ID\`."""
   sideB(
-    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`SideB\`.\\"\\"\\"
+    """The globally unique \`ID\` to be used in selecting a single \`SideB\`."""
     nodeId: ID!
   ): SideB
   sideBByBId(bId: Int!): SideB
 
-  \\"\\"\\"Reads a single \`Unfilterable\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`Unfilterable\` using its globally unique \`ID\`."""
   unfilterable(
-    \\"\\"\\"
+    """
     The globally unique \`ID\` to be used in selecting a single \`Unfilterable\`.
-    \\"\\"\\"
+    """
     nodeId: ID!
   ): Unfilterable
   unfilterableById(id: Int!): Unfilterable
@@ -5519,77 +5519,77 @@ type RangeArrayType implements Node {
   int4RangeArray: [IntRange]
   int8RangeArray: [BigIntRange]
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
   numericRangeArray: [BigFloatRange]
   timestampRangeArray: [DatetimeRange]
   timestamptzRangeArray: [DatetimeRange]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`RangeArrayType\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input RangeArrayTypeFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [RangeArrayTypeFilter!]
 
-  \\"\\"\\"Filter by the object’s \`dateRangeArray\` field.\\"\\"\\"
+  """Filter by the object’s \`dateRangeArray\` field."""
   dateRangeArray: DateRangeListFilter
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`int4RangeArray\` field.\\"\\"\\"
+  """Filter by the object’s \`int4RangeArray\` field."""
   int4RangeArray: IntRangeListFilter
 
-  \\"\\"\\"Filter by the object’s \`int8RangeArray\` field.\\"\\"\\"
+  """Filter by the object’s \`int8RangeArray\` field."""
   int8RangeArray: BigIntRangeListFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: RangeArrayTypeFilter
 
-  \\"\\"\\"Filter by the object’s \`numericRangeArray\` field.\\"\\"\\"
+  """Filter by the object’s \`numericRangeArray\` field."""
   numericRangeArray: BigFloatRangeListFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [RangeArrayTypeFilter!]
 
-  \\"\\"\\"Filter by the object’s \`timestampRangeArray\` field.\\"\\"\\"
+  """Filter by the object’s \`timestampRangeArray\` field."""
   timestampRangeArray: DatetimeRangeListFilter
 
-  \\"\\"\\"Filter by the object’s \`timestamptzRangeArray\` field.\\"\\"\\"
+  """Filter by the object’s \`timestamptzRangeArray\` field."""
   timestamptzRangeArray: DatetimeRangeListFilter
 }
 
-\\"\\"\\"A connection to a list of \`RangeArrayType\` values.\\"\\"\\"
+"""A connection to a list of \`RangeArrayType\` values."""
 type RangeArrayTypesConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`RangeArrayType\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [RangeArrayTypesEdge!]!
 
-  \\"\\"\\"A list of \`RangeArrayType\` objects.\\"\\"\\"
+  """A list of \`RangeArrayType\` objects."""
   nodes: [RangeArrayType]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`RangeArrayType\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`RangeArrayType\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`RangeArrayType\` edge in the connection.\\"\\"\\"
+"""A \`RangeArrayType\` edge in the connection."""
 type RangeArrayTypesEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`RangeArrayType\` at the end of the edge.\\"\\"\\"
+  """The \`RangeArrayType\` at the end of the edge."""
   node: RangeArrayType
 }
 
-\\"\\"\\"Methods to use when ordering \`RangeArrayType\`.\\"\\"\\"
+"""Methods to use when ordering \`RangeArrayType\`."""
 enum RangeArrayTypesOrderBy {
   DATE_RANGE_ARRAY_ASC
   DATE_RANGE_ARRAY_DESC
@@ -5616,77 +5616,77 @@ type RangeType implements Node {
   int4Range: IntRange
   int8Range: BigIntRange
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
   numericRange: BigFloatRange
   timestampRange: DatetimeRange
   timestamptzRange: DatetimeRange
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`RangeType\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input RangeTypeFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [RangeTypeFilter!]
 
-  \\"\\"\\"Filter by the object’s \`dateRange\` field.\\"\\"\\"
+  """Filter by the object’s \`dateRange\` field."""
   dateRange: DateRangeFilter
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`int4Range\` field.\\"\\"\\"
+  """Filter by the object’s \`int4Range\` field."""
   int4Range: IntRangeFilter
 
-  \\"\\"\\"Filter by the object’s \`int8Range\` field.\\"\\"\\"
+  """Filter by the object’s \`int8Range\` field."""
   int8Range: BigIntRangeFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: RangeTypeFilter
 
-  \\"\\"\\"Filter by the object’s \`numericRange\` field.\\"\\"\\"
+  """Filter by the object’s \`numericRange\` field."""
   numericRange: BigFloatRangeFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [RangeTypeFilter!]
 
-  \\"\\"\\"Filter by the object’s \`timestampRange\` field.\\"\\"\\"
+  """Filter by the object’s \`timestampRange\` field."""
   timestampRange: DatetimeRangeFilter
 
-  \\"\\"\\"Filter by the object’s \`timestamptzRange\` field.\\"\\"\\"
+  """Filter by the object’s \`timestamptzRange\` field."""
   timestamptzRange: DatetimeRangeFilter
 }
 
-\\"\\"\\"A connection to a list of \`RangeType\` values.\\"\\"\\"
+"""A connection to a list of \`RangeType\` values."""
 type RangeTypesConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`RangeType\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [RangeTypesEdge!]!
 
-  \\"\\"\\"A list of \`RangeType\` objects.\\"\\"\\"
+  """A list of \`RangeType\` objects."""
   nodes: [RangeType]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`RangeType\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`RangeType\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`RangeType\` edge in the connection.\\"\\"\\"
+"""A \`RangeType\` edge in the connection."""
 type RangeTypesEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`RangeType\` at the end of the edge.\\"\\"\\"
+  """The \`RangeType\` at the end of the edge."""
   node: RangeType
 }
 
-\\"\\"\\"Methods to use when ordering \`RangeType\`.\\"\\"\\"
+"""Methods to use when ordering \`RangeType\`."""
 enum RangeTypesOrderBy {
   DATE_RANGE_ASC
   DATE_RANGE_DESC
@@ -5710,89 +5710,89 @@ enum RangeTypesOrderBy {
 type SideA implements Node {
   aId: Int!
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Junction\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Junction\`."""
   junctionsBySideAId(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: JunctionFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`Junction\`.\\"\\"\\"
+    """The method to use when ordering \`Junction\`."""
     orderBy: [JunctionsOrderBy!] = [PRIMARY_KEY_ASC]
   ): JunctionsConnection!
   name: String!
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`SideA\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input SideAFilter {
-  \\"\\"\\"Filter by the object’s \`aId\` field.\\"\\"\\"
+  """Filter by the object’s \`aId\` field."""
   aId: IntFilter
 
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [SideAFilter!]
 
-  \\"\\"\\"Filter by the object’s \`name\` field.\\"\\"\\"
+  """Filter by the object’s \`name\` field."""
   name: StringFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: SideAFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [SideAFilter!]
 }
 
-\\"\\"\\"A connection to a list of \`SideA\` values.\\"\\"\\"
+"""A connection to a list of \`SideA\` values."""
 type SideAsConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`SideA\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [SideAsEdge!]!
 
-  \\"\\"\\"A list of \`SideA\` objects.\\"\\"\\"
+  """A list of \`SideA\` objects."""
   nodes: [SideA]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`SideA\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`SideA\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`SideA\` edge in the connection.\\"\\"\\"
+"""A \`SideA\` edge in the connection."""
 type SideAsEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`SideA\` at the end of the edge.\\"\\"\\"
+  """The \`SideA\` at the end of the edge."""
   node: SideA
 }
 
-\\"\\"\\"Methods to use when ordering \`SideA\`.\\"\\"\\"
+"""Methods to use when ordering \`SideA\`."""
 enum SideAsOrderBy {
   A_ID_ASC
   A_ID_DESC
@@ -5806,89 +5806,89 @@ enum SideAsOrderBy {
 type SideB implements Node {
   bId: Int!
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Junction\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Junction\`."""
   junctionsBySideBId(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: JunctionFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`Junction\`.\\"\\"\\"
+    """The method to use when ordering \`Junction\`."""
     orderBy: [JunctionsOrderBy!] = [PRIMARY_KEY_ASC]
   ): JunctionsConnection!
   name: String!
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`SideB\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input SideBFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [SideBFilter!]
 
-  \\"\\"\\"Filter by the object’s \`bId\` field.\\"\\"\\"
+  """Filter by the object’s \`bId\` field."""
   bId: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`name\` field.\\"\\"\\"
+  """Filter by the object’s \`name\` field."""
   name: StringFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: SideBFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [SideBFilter!]
 }
 
-\\"\\"\\"A connection to a list of \`SideB\` values.\\"\\"\\"
+"""A connection to a list of \`SideB\` values."""
 type SideBsConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`SideB\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [SideBsEdge!]!
 
-  \\"\\"\\"A list of \`SideB\` objects.\\"\\"\\"
+  """A list of \`SideB\` objects."""
   nodes: [SideB]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`SideB\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`SideB\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`SideB\` edge in the connection.\\"\\"\\"
+"""A \`SideB\` edge in the connection."""
 type SideBsEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`SideB\` at the end of the edge.\\"\\"\\"
+  """The \`SideB\` at the end of the edge."""
   node: SideB
 }
 
-\\"\\"\\"Methods to use when ordering \`SideB\`.\\"\\"\\"
+"""Methods to use when ordering \`SideB\`."""
 enum SideBsOrderBy {
   B_ID_ASC
   B_ID_DESC
@@ -5899,382 +5899,382 @@ enum SideBsOrderBy {
   PRIMARY_KEY_DESC
 }
 
-\\"\\"\\"
+"""
 A filter to be used against String fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input StringFilter {
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: String
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value (case-insensitive).
-  \\"\\"\\"
+  """
   distinctFromInsensitive: String
 
-  \\"\\"\\"Ends with the specified string (case-sensitive).\\"\\"\\"
+  """Ends with the specified string (case-sensitive)."""
   endsWith: String
 
-  \\"\\"\\"Ends with the specified string (case-insensitive).\\"\\"\\"
+  """Ends with the specified string (case-insensitive)."""
   endsWithInsensitive: String
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: String
 
-  \\"\\"\\"Equal to the specified value (case-insensitive).\\"\\"\\"
+  """Equal to the specified value (case-insensitive)."""
   equalToInsensitive: String
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: String
 
-  \\"\\"\\"Greater than the specified value (case-insensitive).\\"\\"\\"
+  """Greater than the specified value (case-insensitive)."""
   greaterThanInsensitive: String
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: String
 
-  \\"\\"\\"Greater than or equal to the specified value (case-insensitive).\\"\\"\\"
+  """Greater than or equal to the specified value (case-insensitive)."""
   greaterThanOrEqualToInsensitive: String
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [String!]
 
-  \\"\\"\\"Included in the specified list (case-insensitive).\\"\\"\\"
-  inInsensitive: [String!]
-
-  \\"\\"\\"Contains the specified string (case-sensitive).\\"\\"\\"
+  """Contains the specified string (case-sensitive)."""
   includes: String
 
-  \\"\\"\\"Contains the specified string (case-insensitive).\\"\\"\\"
+  """Contains the specified string (case-insensitive)."""
   includesInsensitive: String
 
-  \\"\\"\\"
+  """Included in the specified list (case-insensitive)."""
+  inInsensitive: [String!]
+
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: String
 
-  \\"\\"\\"Less than the specified value (case-insensitive).\\"\\"\\"
+  """Less than the specified value (case-insensitive)."""
   lessThanInsensitive: String
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: String
 
-  \\"\\"\\"Less than or equal to the specified value (case-insensitive).\\"\\"\\"
+  """Less than or equal to the specified value (case-insensitive)."""
   lessThanOrEqualToInsensitive: String
 
-  \\"\\"\\"
+  """
   Matches the specified pattern (case-sensitive). An underscore (_) matches any
   single character; a percent sign (%) matches any sequence of zero or more characters.
-  \\"\\"\\"
+  """
   like: String
 
-  \\"\\"\\"
+  """
   Matches the specified pattern (case-insensitive). An underscore (_) matches
   any single character; a percent sign (%) matches any sequence of zero or more characters.
-  \\"\\"\\"
+  """
   likeInsensitive: String
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: String
 
-  \\"\\"\\"
+  """
   Equal to the specified value, treating null like an ordinary value (case-insensitive).
-  \\"\\"\\"
+  """
   notDistinctFromInsensitive: String
 
-  \\"\\"\\"Does not end with the specified string (case-sensitive).\\"\\"\\"
+  """Does not end with the specified string (case-sensitive)."""
   notEndsWith: String
 
-  \\"\\"\\"Does not end with the specified string (case-insensitive).\\"\\"\\"
+  """Does not end with the specified string (case-insensitive)."""
   notEndsWithInsensitive: String
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: String
 
-  \\"\\"\\"Not equal to the specified value (case-insensitive).\\"\\"\\"
+  """Not equal to the specified value (case-insensitive)."""
   notEqualToInsensitive: String
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [String!]
 
-  \\"\\"\\"Not included in the specified list (case-insensitive).\\"\\"\\"
-  notInInsensitive: [String!]
-
-  \\"\\"\\"Does not contain the specified string (case-sensitive).\\"\\"\\"
+  """Does not contain the specified string (case-sensitive)."""
   notIncludes: String
 
-  \\"\\"\\"Does not contain the specified string (case-insensitive).\\"\\"\\"
+  """Does not contain the specified string (case-insensitive)."""
   notIncludesInsensitive: String
 
-  \\"\\"\\"
+  """Not included in the specified list (case-insensitive)."""
+  notInInsensitive: [String!]
+
+  """
   Does not match the specified pattern (case-sensitive). An underscore (_)
   matches any single character; a percent sign (%) matches any sequence of zero
   or more characters.
-  \\"\\"\\"
+  """
   notLike: String
 
-  \\"\\"\\"
+  """
   Does not match the specified pattern (case-insensitive). An underscore (_)
   matches any single character; a percent sign (%) matches any sequence of zero
   or more characters.
-  \\"\\"\\"
+  """
   notLikeInsensitive: String
 
-  \\"\\"\\"Does not start with the specified string (case-sensitive).\\"\\"\\"
+  """Does not start with the specified string (case-sensitive)."""
   notStartsWith: String
 
-  \\"\\"\\"Does not start with the specified string (case-insensitive).\\"\\"\\"
+  """Does not start with the specified string (case-insensitive)."""
   notStartsWithInsensitive: String
 
-  \\"\\"\\"Starts with the specified string (case-sensitive).\\"\\"\\"
+  """Starts with the specified string (case-sensitive)."""
   startsWith: String
 
-  \\"\\"\\"Starts with the specified string (case-insensitive).\\"\\"\\"
+  """Starts with the specified string (case-insensitive)."""
   startsWithInsensitive: String
 }
 
-\\"\\"\\"
+"""
 A filter to be used against String List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input StringListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: String
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: String
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: String
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: String
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: String
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: String
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [String]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [String]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [String]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [String]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [String]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [String]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [String]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [String]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [String]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [String]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [String]
 }
 
-\\"\\"\\"
+"""
 The exact time of day, does not include the date. May or may not have a timezone offset.
-\\"\\"\\"
+"""
 scalar Time
 
-\\"\\"\\"
+"""
 A filter to be used against Time fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input TimeFilter {
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: Time
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: Time
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: Time
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: Time
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [Time!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: Time
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: Time
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: Time
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: Time
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [Time!]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against Time List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input TimeListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: Time
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: Time
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: Time
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: Time
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: Time
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: Time
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [Time]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [Time]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [Time]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [Time]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [Time]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [Time]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [Time]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [Time]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [Time]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [Time]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [Time]
 }
 
 type Unfilterable implements Node {
-  \\"\\"\\"Reads and enables pagination through a set of \`ChildNoRelatedFilter\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`ChildNoRelatedFilter\`."""
   childNoRelatedFiltersByUnfilterableId(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: ChildNoRelatedFilterFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`ChildNoRelatedFilter\`.\\"\\"\\"
+    """The method to use when ordering \`ChildNoRelatedFilter\`."""
     orderBy: [ChildNoRelatedFiltersOrderBy!] = [PRIMARY_KEY_ASC]
   ): ChildNoRelatedFiltersConnection!
   id: Int!
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
   text: String
 }
 
-\\"\\"\\"A connection to a list of \`Unfilterable\` values.\\"\\"\\"
+"""A connection to a list of \`Unfilterable\` values."""
 type UnfilterablesConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`Unfilterable\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [UnfilterablesEdge!]!
 
-  \\"\\"\\"A list of \`Unfilterable\` objects.\\"\\"\\"
+  """A list of \`Unfilterable\` objects."""
   nodes: [Unfilterable]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`Unfilterable\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`Unfilterable\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`Unfilterable\` edge in the connection.\\"\\"\\"
+"""A \`Unfilterable\` edge in the connection."""
 type UnfilterablesEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`Unfilterable\` at the end of the edge.\\"\\"\\"
+  """The \`Unfilterable\` at the end of the edge."""
   node: Unfilterable
 }
 
-\\"\\"\\"Methods to use when ordering \`Unfilterable\`.\\"\\"\\"
+"""Methods to use when ordering \`Unfilterable\`."""
 enum UnfilterablesOrderBy {
   ID_ASC
   ID_DESC
@@ -6285,114 +6285,114 @@ enum UnfilterablesOrderBy {
   TEXT_DESC
 }
 
-\\"\\"\\"
+"""
 A universally unique identifier as defined by [RFC 4122](https://tools.ietf.org/html/rfc4122).
-\\"\\"\\"
+"""
 scalar UUID
 
-\\"\\"\\"
+"""
 A filter to be used against UUID fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input UUIDFilter {
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: UUID
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: UUID
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: UUID
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: UUID
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [UUID!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: UUID
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: UUID
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: UUID
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: UUID
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [UUID!]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against UUID List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input UUIDListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: UUID
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: UUID
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: UUID
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: UUID
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: UUID
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: UUID
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [UUID]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [UUID]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [UUID]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [UUID]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [UUID]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [UUID]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [UUID]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [UUID]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [UUID]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [UUID]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [UUID]
 }
-"
+
 `;

--- a/__tests__/integration/schema/__snapshots__/ignoreIndexesFalse.test.ts.snap
+++ b/__tests__/integration/schema/__snapshots__/ignoreIndexesFalse.test.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`prints a schema with the filter plugin and the \`ignoreIndexes: false\` option 1`] = `
-"type ArrayType implements Node {
+type ArrayType implements Node {
   bit4Array: [BitString]
   boolArray: [Boolean]
   bpchar4Array: [String]
@@ -25,9 +25,9 @@ exports[`prints a schema with the filter plugin and the \`ignoreIndexes: false\`
   moneyArray: [Float]
   nameArray: [String]
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
   numericArray: [BigFloat]
   textArray: [String]
@@ -41,50 +41,50 @@ exports[`prints a schema with the filter plugin and the \`ignoreIndexes: false\`
   xmlArray: [String]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`ArrayType\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input ArrayTypeFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [ArrayTypeFilter!]
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: ArrayTypeFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [ArrayTypeFilter!]
 }
 
-\\"\\"\\"A connection to a list of \`ArrayType\` values.\\"\\"\\"
+"""A connection to a list of \`ArrayType\` values."""
 type ArrayTypesConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`ArrayType\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [ArrayTypesEdge!]!
 
-  \\"\\"\\"A list of \`ArrayType\` objects.\\"\\"\\"
+  """A list of \`ArrayType\` objects."""
   nodes: [ArrayType]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`ArrayType\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`ArrayType\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`ArrayType\` edge in the connection.\\"\\"\\"
+"""A \`ArrayType\` edge in the connection."""
 type ArrayTypesEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`ArrayType\` at the end of the edge.\\"\\"\\"
+  """The \`ArrayType\` at the end of the edge."""
   node: ArrayType
 }
 
-\\"\\"\\"Methods to use when ordering \`ArrayType\`.\\"\\"\\"
+"""Methods to use when ordering \`ArrayType\`."""
 enum ArrayTypesOrderBy {
   ID_ASC
   ID_DESC
@@ -94,15 +94,15 @@ enum ArrayTypesOrderBy {
 }
 
 type Backward implements Node {
-  \\"\\"\\"Reads a single \`Filterable\` that is related to this \`Backward\`.\\"\\"\\"
+  """Reads a single \`Filterable\` that is related to this \`Backward\`."""
   filterableByFilterableId: Filterable
   filterableId: Int
   id: Int!
   name: String!
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
@@ -110,64 +110,64 @@ type BackwardCompound implements Node {
   backwardCompound1: Int!
   backwardCompound2: Int!
 
-  \\"\\"\\"
+  """
   Reads a single \`Filterable\` that is related to this \`BackwardCompound\`.
-  \\"\\"\\"
+  """
   filterableByBackwardCompound1AndBackwardCompound2: Filterable
   name: String
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`BackwardCompound\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input BackwardCompoundFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [BackwardCompoundFilter!]
 
-  \\"\\"\\"Filter by the object’s \`backwardCompound1\` field.\\"\\"\\"
+  """Filter by the object’s \`backwardCompound1\` field."""
   backwardCompound1: IntFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: BackwardCompoundFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [BackwardCompoundFilter!]
 }
 
-\\"\\"\\"A connection to a list of \`BackwardCompound\` values.\\"\\"\\"
+"""A connection to a list of \`BackwardCompound\` values."""
 type BackwardCompoundsConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`BackwardCompound\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [BackwardCompoundsEdge!]!
 
-  \\"\\"\\"A list of \`BackwardCompound\` objects.\\"\\"\\"
+  """A list of \`BackwardCompound\` objects."""
   nodes: [BackwardCompound]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"
+  """
   The count of *all* \`BackwardCompound\` you could get from the connection.
-  \\"\\"\\"
+  """
   totalCount: Int!
 }
 
-\\"\\"\\"A \`BackwardCompound\` edge in the connection.\\"\\"\\"
+"""A \`BackwardCompound\` edge in the connection."""
 type BackwardCompoundsEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`BackwardCompound\` at the end of the edge.\\"\\"\\"
+  """The \`BackwardCompound\` at the end of the edge."""
   node: BackwardCompound
 }
 
-\\"\\"\\"Methods to use when ordering \`BackwardCompound\`.\\"\\"\\"
+"""Methods to use when ordering \`BackwardCompound\`."""
 enum BackwardCompoundsOrderBy {
   BACKWARD_COMPOUND_1_ASC
   BACKWARD_COMPOUND_1_DESC
@@ -176,53 +176,53 @@ enum BackwardCompoundsOrderBy {
   PRIMARY_KEY_DESC
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`Backward\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input BackwardFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [BackwardFilter!]
 
-  \\"\\"\\"Filter by the object’s \`filterableId\` field.\\"\\"\\"
+  """Filter by the object’s \`filterableId\` field."""
   filterableId: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: BackwardFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [BackwardFilter!]
 }
 
-\\"\\"\\"A connection to a list of \`Backward\` values.\\"\\"\\"
+"""A connection to a list of \`Backward\` values."""
 type BackwardsConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`Backward\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [BackwardsEdge!]!
 
-  \\"\\"\\"A list of \`Backward\` objects.\\"\\"\\"
+  """A list of \`Backward\` objects."""
   nodes: [Backward]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`Backward\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`Backward\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`Backward\` edge in the connection.\\"\\"\\"
+"""A \`Backward\` edge in the connection."""
 type BackwardsEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`Backward\` at the end of the edge.\\"\\"\\"
+  """The \`Backward\` at the end of the edge."""
   node: Backward
 }
 
-\\"\\"\\"Methods to use when ordering \`Backward\`.\\"\\"\\"
+"""Methods to use when ordering \`Backward\`."""
 enum BackwardsOrderBy {
   FILTERABLE_ID_ASC
   FILTERABLE_ID_DESC
@@ -233,59 +233,59 @@ enum BackwardsOrderBy {
   PRIMARY_KEY_DESC
 }
 
-\\"\\"\\"
+"""
 A floating point number that requires more precision than IEEE 754 binary 64
-\\"\\"\\"
+"""
 scalar BigFloat
 
-\\"\\"\\"A range of \`BigFloat\`.\\"\\"\\"
+"""A range of \`BigFloat\`."""
 type BigFloatRange {
-  \\"\\"\\"The ending bound of our range.\\"\\"\\"
+  """The ending bound of our range."""
   end: BigFloatRangeBound
 
-  \\"\\"\\"The starting bound of our range.\\"\\"\\"
+  """The starting bound of our range."""
   start: BigFloatRangeBound
 }
 
-\\"\\"\\"
+"""
 The value at one end of a range. A range can either include this value, or not.
-\\"\\"\\"
+"""
 type BigFloatRangeBound {
-  \\"\\"\\"Whether or not the value of this bound is included in the range.\\"\\"\\"
+  """Whether or not the value of this bound is included in the range."""
   inclusive: Boolean!
 
-  \\"\\"\\"The value at one end of our range.\\"\\"\\"
+  """The value at one end of our range."""
   value: BigFloat!
 }
 
-\\"\\"\\"
+"""
 A signed eight-byte integer. The upper big integer values are greater than the
 max value for a JavaScript number. Therefore all big integers will be output as
 strings and not numbers.
-\\"\\"\\"
+"""
 scalar BigInt
 
-\\"\\"\\"A range of \`BigInt\`.\\"\\"\\"
+"""A range of \`BigInt\`."""
 type BigIntRange {
-  \\"\\"\\"The ending bound of our range.\\"\\"\\"
+  """The ending bound of our range."""
   end: BigIntRangeBound
 
-  \\"\\"\\"The starting bound of our range.\\"\\"\\"
+  """The starting bound of our range."""
   start: BigIntRangeBound
 }
 
-\\"\\"\\"
+"""
 The value at one end of a range. A range can either include this value, or not.
-\\"\\"\\"
+"""
 type BigIntRangeBound {
-  \\"\\"\\"Whether or not the value of this bound is included in the range.\\"\\"\\"
+  """Whether or not the value of this bound is included in the range."""
   inclusive: Boolean!
 
-  \\"\\"\\"The value at one end of our range.\\"\\"\\"
+  """The value at one end of our range."""
   value: BigInt!
 }
 
-\\"\\"\\"A string representing a series of binary bits\\"\\"\\"
+"""A string representing a series of binary bits"""
 scalar BitString
 
 scalar Char4Domain
@@ -295,26 +295,26 @@ type Child implements Node {
   id: Int!
   name: String!
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`Child\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input ChildFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [ChildFilter!]
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: ChildFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [ChildFilter!]
 }
 
@@ -323,59 +323,59 @@ type ChildNoRelatedFilter implements Node {
   id: Int!
   name: String!
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
   unfilterableId: Int
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`ChildNoRelatedFilter\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input ChildNoRelatedFilterFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [ChildNoRelatedFilterFilter!]
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: ChildNoRelatedFilterFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [ChildNoRelatedFilterFilter!]
 }
 
-\\"\\"\\"A connection to a list of \`ChildNoRelatedFilter\` values.\\"\\"\\"
+"""A connection to a list of \`ChildNoRelatedFilter\` values."""
 type ChildNoRelatedFiltersConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`ChildNoRelatedFilter\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [ChildNoRelatedFiltersEdge!]!
 
-  \\"\\"\\"A list of \`ChildNoRelatedFilter\` objects.\\"\\"\\"
+  """A list of \`ChildNoRelatedFilter\` objects."""
   nodes: [ChildNoRelatedFilter]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"
+  """
   The count of *all* \`ChildNoRelatedFilter\` you could get from the connection.
-  \\"\\"\\"
+  """
   totalCount: Int!
 }
 
-\\"\\"\\"A \`ChildNoRelatedFilter\` edge in the connection.\\"\\"\\"
+"""A \`ChildNoRelatedFilter\` edge in the connection."""
 type ChildNoRelatedFiltersEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`ChildNoRelatedFilter\` at the end of the edge.\\"\\"\\"
+  """The \`ChildNoRelatedFilter\` at the end of the edge."""
   node: ChildNoRelatedFilter
 }
 
-\\"\\"\\"Methods to use when ordering \`ChildNoRelatedFilter\`.\\"\\"\\"
+"""Methods to use when ordering \`ChildNoRelatedFilter\`."""
 enum ChildNoRelatedFiltersOrderBy {
   ID_ASC
   ID_DESC
@@ -384,33 +384,33 @@ enum ChildNoRelatedFiltersOrderBy {
   PRIMARY_KEY_DESC
 }
 
-\\"\\"\\"A connection to a list of \`Child\` values.\\"\\"\\"
+"""A connection to a list of \`Child\` values."""
 type ChildrenConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`Child\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [ChildrenEdge!]!
 
-  \\"\\"\\"A list of \`Child\` objects.\\"\\"\\"
+  """A list of \`Child\` objects."""
   nodes: [Child]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`Child\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`Child\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`Child\` edge in the connection.\\"\\"\\"
+"""A \`Child\` edge in the connection."""
 type ChildrenEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`Child\` at the end of the edge.\\"\\"\\"
+  """The \`Child\` at the end of the edge."""
   node: Child
 }
 
-\\"\\"\\"Methods to use when ordering \`Child\`.\\"\\"\\"
+"""Methods to use when ordering \`Child\`."""
 enum ChildrenOrderBy {
   ID_ASC
   ID_DESC
@@ -424,57 +424,57 @@ type Composite {
   b: String
 }
 
-\\"\\"\\"A location in a connection that can be used for resuming pagination.\\"\\"\\"
+"""A location in a connection that can be used for resuming pagination."""
 scalar Cursor
 
-\\"\\"\\"The day, does not include a time.\\"\\"\\"
+"""The day, does not include a time."""
 scalar Date
 
 scalar DateDomain
 
-\\"\\"\\"A range of \`Date\`.\\"\\"\\"
+"""A range of \`Date\`."""
 type DateRange {
-  \\"\\"\\"The ending bound of our range.\\"\\"\\"
+  """The ending bound of our range."""
   end: DateRangeBound
 
-  \\"\\"\\"The starting bound of our range.\\"\\"\\"
+  """The starting bound of our range."""
   start: DateRangeBound
 }
 
-\\"\\"\\"
+"""
 The value at one end of a range. A range can either include this value, or not.
-\\"\\"\\"
+"""
 type DateRangeBound {
-  \\"\\"\\"Whether or not the value of this bound is included in the range.\\"\\"\\"
+  """Whether or not the value of this bound is included in the range."""
   inclusive: Boolean!
 
-  \\"\\"\\"The value at one end of our range.\\"\\"\\"
+  """The value at one end of our range."""
   value: Date!
 }
 
-\\"\\"\\"
+"""
 A point in time as described by the [ISO
 8601](https://en.wikipedia.org/wiki/ISO_8601) standard. May or may not include a timezone.
-\\"\\"\\"
+"""
 scalar Datetime
 
-\\"\\"\\"A range of \`Datetime\`.\\"\\"\\"
+"""A range of \`Datetime\`."""
 type DatetimeRange {
-  \\"\\"\\"The ending bound of our range.\\"\\"\\"
+  """The ending bound of our range."""
   end: DatetimeRangeBound
 
-  \\"\\"\\"The starting bound of our range.\\"\\"\\"
+  """The starting bound of our range."""
   start: DatetimeRangeBound
 }
 
-\\"\\"\\"
+"""
 The value at one end of a range. A range can either include this value, or not.
-\\"\\"\\"
+"""
 type DatetimeRangeBound {
-  \\"\\"\\"Whether or not the value of this bound is included in the range.\\"\\"\\"
+  """Whether or not the value of this bound is included in the range."""
   inclusive: Boolean!
 
-  \\"\\"\\"The value at one end of our range.\\"\\"\\"
+  """The value at one end of our range."""
   value: Datetime!
 }
 
@@ -484,56 +484,56 @@ type DomainType implements Node {
   id: Int!
   int4Domain: Int4Domain
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`DomainType\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input DomainTypeFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [DomainTypeFilter!]
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: DomainTypeFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [DomainTypeFilter!]
 }
 
-\\"\\"\\"A connection to a list of \`DomainType\` values.\\"\\"\\"
+"""A connection to a list of \`DomainType\` values."""
 type DomainTypesConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`DomainType\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [DomainTypesEdge!]!
 
-  \\"\\"\\"A list of \`DomainType\` objects.\\"\\"\\"
+  """A list of \`DomainType\` objects."""
   nodes: [DomainType]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`DomainType\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`DomainType\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`DomainType\` edge in the connection.\\"\\"\\"
+"""A \`DomainType\` edge in the connection."""
 type DomainTypesEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`DomainType\` at the end of the edge.\\"\\"\\"
+  """The \`DomainType\` at the end of the edge."""
   node: DomainType
 }
 
-\\"\\"\\"Methods to use when ordering \`DomainType\`.\\"\\"\\"
+"""Methods to use when ordering \`DomainType\`."""
 enum DomainTypesOrderBy {
   ID_ASC
   ID_DESC
@@ -546,56 +546,56 @@ type EnumArrayType implements Node {
   enumArray: [Mood]
   id: Int!
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`EnumArrayType\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input EnumArrayTypeFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [EnumArrayTypeFilter!]
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: EnumArrayTypeFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [EnumArrayTypeFilter!]
 }
 
-\\"\\"\\"A connection to a list of \`EnumArrayType\` values.\\"\\"\\"
+"""A connection to a list of \`EnumArrayType\` values."""
 type EnumArrayTypesConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`EnumArrayType\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [EnumArrayTypesEdge!]!
 
-  \\"\\"\\"A list of \`EnumArrayType\` objects.\\"\\"\\"
+  """A list of \`EnumArrayType\` objects."""
   nodes: [EnumArrayType]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`EnumArrayType\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`EnumArrayType\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`EnumArrayType\` edge in the connection.\\"\\"\\"
+"""A \`EnumArrayType\` edge in the connection."""
 type EnumArrayTypesEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`EnumArrayType\` at the end of the edge.\\"\\"\\"
+  """The \`EnumArrayType\` at the end of the edge."""
   node: EnumArrayType
 }
 
-\\"\\"\\"Methods to use when ordering \`EnumArrayType\`.\\"\\"\\"
+"""Methods to use when ordering \`EnumArrayType\`."""
 enum EnumArrayTypesOrderBy {
   ID_ASC
   ID_DESC
@@ -608,56 +608,56 @@ type EnumType implements Node {
   enum: Mood
   id: Int!
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`EnumType\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input EnumTypeFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [EnumTypeFilter!]
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: EnumTypeFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [EnumTypeFilter!]
 }
 
-\\"\\"\\"A connection to a list of \`EnumType\` values.\\"\\"\\"
+"""A connection to a list of \`EnumType\` values."""
 type EnumTypesConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`EnumType\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [EnumTypesEdge!]!
 
-  \\"\\"\\"A list of \`EnumType\` objects.\\"\\"\\"
+  """A list of \`EnumType\` objects."""
   nodes: [EnumType]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`EnumType\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`EnumType\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`EnumType\` edge in the connection.\\"\\"\\"
+"""A \`EnumType\` edge in the connection."""
 type EnumTypesEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`EnumType\` at the end of the edge.\\"\\"\\"
+  """The \`EnumType\` at the end of the edge."""
   node: EnumType
 }
 
-\\"\\"\\"Methods to use when ordering \`EnumType\`.\\"\\"\\"
+"""Methods to use when ordering \`EnumType\`."""
 enum EnumTypesOrderBy {
   ID_ASC
   ID_DESC
@@ -667,14 +667,14 @@ enum EnumTypesOrderBy {
 }
 
 type Filterable implements Node {
-  \\"\\"\\"Reads a single \`Backward\` that is related to this \`Filterable\`.\\"\\"\\"
+  """Reads a single \`Backward\` that is related to this \`Filterable\`."""
   backwardByFilterableId: Backward
   backwardCompound1: Int
   backwardCompound2: Int
 
-  \\"\\"\\"
+  """
   Reads a single \`BackwardCompound\` that is related to this \`Filterable\`.
-  \\"\\"\\"
+  """
   backwardCompoundByBackwardCompound1AndBackwardCompound2: BackwardCompound
   bit4: BitString
   bool: Boolean
@@ -689,43 +689,43 @@ type Filterable implements Node {
   computedChild: Child
   computedIntArray: [Int]
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Child\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Child\`."""
   computedSetofChild(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
   ): ChildrenConnection!
   computedSetofInt(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
   ): FilterableComputedSetofIntConnection!
   computedTaggedFilterable: Int
@@ -734,13 +734,13 @@ type Filterable implements Node {
   float4: Float
   float8: Float
 
-  \\"\\"\\"Reads a single \`Forward\` that is related to this \`Filterable\`.\\"\\"\\"
+  """Reads a single \`Forward\` that is related to this \`Filterable\`."""
   forwardByForwardId: Forward
   forwardColumn: Forward
   forwardCompound1: Int
   forwardCompound2: Int
 
-  \\"\\"\\"Reads a single \`ForwardCompound\` that is related to this \`Filterable\`.\\"\\"\\"
+  """Reads a single \`ForwardCompound\` that is related to this \`Filterable\`."""
   forwardCompoundByForwardCompound1AndForwardCompound2: ForwardCompound
   forwardId: Int
   hstore: KeyValueHash
@@ -756,9 +756,9 @@ type Filterable implements Node {
   money: Float
   name: String
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
   numeric: BigFloat
   parentId: Int
@@ -780,91 +780,91 @@ type FilterableClosure implements Node {
   descendantId: Int!
   id: Int!
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
-\\"\\"\\"A connection to a list of \`Int\` values.\\"\\"\\"
+"""A connection to a list of \`Int\` values."""
 type FilterableComputedSetofIntConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`Int\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [FilterableComputedSetofIntEdge!]!
 
-  \\"\\"\\"A list of \`Int\` objects.\\"\\"\\"
+  """A list of \`Int\` objects."""
   nodes: [Int]!
 
-  \\"\\"\\"The count of *all* \`Int\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`Int\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`Int\` edge in the connection.\\"\\"\\"
+"""A \`Int\` edge in the connection."""
 type FilterableComputedSetofIntEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`Int\` at the end of the edge.\\"\\"\\"
+  """The \`Int\` at the end of the edge."""
   node: Int
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`Filterable\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input FilterableFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [FilterableFilter!]
 
-  \\"\\"\\"Filter by the object’s \`backwardCompound1\` field.\\"\\"\\"
+  """Filter by the object’s \`backwardCompound1\` field."""
   backwardCompound1: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`computedTaggedFilterable\` field.\\"\\"\\"
+  """Filter by the object’s \`computedTaggedFilterable\` field."""
   computedTaggedFilterable: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`forwardCompound1\` field.\\"\\"\\"
+  """Filter by the object’s \`forwardCompound1\` field."""
   forwardCompound1: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`forwardId\` field.\\"\\"\\"
+  """Filter by the object’s \`forwardId\` field."""
   forwardId: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: FilterableFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [FilterableFilter!]
 }
 
-\\"\\"\\"A connection to a list of \`Filterable\` values.\\"\\"\\"
+"""A connection to a list of \`Filterable\` values."""
 type FilterablesConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`Filterable\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [FilterablesEdge!]!
 
-  \\"\\"\\"A list of \`Filterable\` objects.\\"\\"\\"
+  """A list of \`Filterable\` objects."""
   nodes: [Filterable]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`Filterable\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`Filterable\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`Filterable\` edge in the connection.\\"\\"\\"
+"""A \`Filterable\` edge in the connection."""
 type FilterablesEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`Filterable\` at the end of the edge.\\"\\"\\"
+  """The \`Filterable\` at the end of the edge."""
   node: Filterable
 }
 
-\\"\\"\\"Methods to use when ordering \`Filterable\`.\\"\\"\\"
+"""Methods to use when ordering \`Filterable\`."""
 enum FilterablesOrderBy {
   BACKWARD_COMPOUND_1_ASC
   BACKWARD_COMPOUND_1_DESC
@@ -880,76 +880,76 @@ enum FilterablesOrderBy {
 }
 
 type Forward implements Node {
-  \\"\\"\\"Reads a single \`Filterable\` that is related to this \`Forward\`.\\"\\"\\"
+  """Reads a single \`Filterable\` that is related to this \`Forward\`."""
   filterableByForwardId: Filterable
   id: Int!
   name: String!
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
 type ForwardCompound implements Node {
-  \\"\\"\\"Reads a single \`Filterable\` that is related to this \`ForwardCompound\`.\\"\\"\\"
+  """Reads a single \`Filterable\` that is related to this \`ForwardCompound\`."""
   filterableByForwardCompound1AndForwardCompound2: Filterable
   forwardCompound1: Int!
   forwardCompound2: Int!
   name: String
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`ForwardCompound\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input ForwardCompoundFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [ForwardCompoundFilter!]
 
-  \\"\\"\\"Filter by the object’s \`forwardCompound1\` field.\\"\\"\\"
+  """Filter by the object’s \`forwardCompound1\` field."""
   forwardCompound1: IntFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: ForwardCompoundFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [ForwardCompoundFilter!]
 }
 
-\\"\\"\\"A connection to a list of \`ForwardCompound\` values.\\"\\"\\"
+"""A connection to a list of \`ForwardCompound\` values."""
 type ForwardCompoundsConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`ForwardCompound\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [ForwardCompoundsEdge!]!
 
-  \\"\\"\\"A list of \`ForwardCompound\` objects.\\"\\"\\"
+  """A list of \`ForwardCompound\` objects."""
   nodes: [ForwardCompound]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"
+  """
   The count of *all* \`ForwardCompound\` you could get from the connection.
-  \\"\\"\\"
+  """
   totalCount: Int!
 }
 
-\\"\\"\\"A \`ForwardCompound\` edge in the connection.\\"\\"\\"
+"""A \`ForwardCompound\` edge in the connection."""
 type ForwardCompoundsEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`ForwardCompound\` at the end of the edge.\\"\\"\\"
+  """The \`ForwardCompound\` at the end of the edge."""
   node: ForwardCompound
 }
 
-\\"\\"\\"Methods to use when ordering \`ForwardCompound\`.\\"\\"\\"
+"""Methods to use when ordering \`ForwardCompound\`."""
 enum ForwardCompoundsOrderBy {
   FORWARD_COMPOUND_1_ASC
   FORWARD_COMPOUND_1_DESC
@@ -958,50 +958,50 @@ enum ForwardCompoundsOrderBy {
   PRIMARY_KEY_DESC
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`Forward\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input ForwardFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [ForwardFilter!]
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: ForwardFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [ForwardFilter!]
 }
 
-\\"\\"\\"A connection to a list of \`Forward\` values.\\"\\"\\"
+"""A connection to a list of \`Forward\` values."""
 type ForwardsConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`Forward\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [ForwardsEdge!]!
 
-  \\"\\"\\"A list of \`Forward\` objects.\\"\\"\\"
+  """A list of \`Forward\` objects."""
   nodes: [Forward]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`Forward\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`Forward\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`Forward\` edge in the connection.\\"\\"\\"
+"""A \`Forward\` edge in the connection."""
 type ForwardsEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`Forward\` at the end of the edge.\\"\\"\\"
+  """The \`Forward\` at the end of the edge."""
   node: Forward
 }
 
-\\"\\"\\"Methods to use when ordering \`Forward\`.\\"\\"\\"
+"""Methods to use when ordering \`Forward\`."""
 enum ForwardsOrderBy {
   ID_ASC
   ID_DESC
@@ -1013,40 +1013,40 @@ enum ForwardsOrderBy {
 type FullyOmitted implements Node {
   id: Int!
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
   text: String
 }
 
-\\"\\"\\"A connection to a list of \`FullyOmitted\` values.\\"\\"\\"
+"""A connection to a list of \`FullyOmitted\` values."""
 type FullyOmittedsConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`FullyOmitted\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [FullyOmittedsEdge!]!
 
-  \\"\\"\\"A list of \`FullyOmitted\` objects.\\"\\"\\"
+  """A list of \`FullyOmitted\` objects."""
   nodes: [FullyOmitted]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`FullyOmitted\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`FullyOmitted\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`FullyOmitted\` edge in the connection.\\"\\"\\"
+"""A \`FullyOmitted\` edge in the connection."""
 type FullyOmittedsEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`FullyOmitted\` at the end of the edge.\\"\\"\\"
+  """The \`FullyOmitted\` at the end of the edge."""
   node: FullyOmitted
 }
 
-\\"\\"\\"Methods to use when ordering \`FullyOmitted\`.\\"\\"\\"
+"""Methods to use when ordering \`FullyOmitted\`."""
 enum FullyOmittedsOrderBy {
   ID_ASC
   ID_DESC
@@ -1055,217 +1055,217 @@ enum FullyOmittedsOrderBy {
   PRIMARY_KEY_DESC
 }
 
-\\"\\"\\"A connection to a list of \`FuncReturnsTableMultiColRecord\` values.\\"\\"\\"
+"""A connection to a list of \`FuncReturnsTableMultiColRecord\` values."""
 type FuncReturnsTableMultiColConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`FuncReturnsTableMultiColRecord\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [FuncReturnsTableMultiColEdge!]!
 
-  \\"\\"\\"A list of \`FuncReturnsTableMultiColRecord\` objects.\\"\\"\\"
+  """A list of \`FuncReturnsTableMultiColRecord\` objects."""
   nodes: [FuncReturnsTableMultiColRecord]!
 
-  \\"\\"\\"
+  """
   The count of *all* \`FuncReturnsTableMultiColRecord\` you could get from the connection.
-  \\"\\"\\"
+  """
   totalCount: Int!
 }
 
-\\"\\"\\"A \`FuncReturnsTableMultiColRecord\` edge in the connection.\\"\\"\\"
+"""A \`FuncReturnsTableMultiColRecord\` edge in the connection."""
 type FuncReturnsTableMultiColEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`FuncReturnsTableMultiColRecord\` at the end of the edge.\\"\\"\\"
+  """The \`FuncReturnsTableMultiColRecord\` at the end of the edge."""
   node: FuncReturnsTableMultiColRecord
 }
 
-\\"\\"\\"The return type of our \`funcReturnsTableMultiCol\` query.\\"\\"\\"
+"""The return type of our \`funcReturnsTableMultiCol\` query."""
 type FuncReturnsTableMultiColRecord {
   col1: Int
   col2: String
 }
 
-\\"\\"\\"A connection to a list of \`Int\` values.\\"\\"\\"
+"""A connection to a list of \`Int\` values."""
 type FuncReturnsTableOneColConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`Int\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [FuncReturnsTableOneColEdge!]!
 
-  \\"\\"\\"A list of \`Int\` objects.\\"\\"\\"
+  """A list of \`Int\` objects."""
   nodes: [Int]!
 
-  \\"\\"\\"The count of *all* \`Int\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`Int\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`Int\` edge in the connection.\\"\\"\\"
+"""A \`Int\` edge in the connection."""
 type FuncReturnsTableOneColEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`Int\` at the end of the edge.\\"\\"\\"
+  """The \`Int\` at the end of the edge."""
   node: Int
 }
 
-\\"\\"\\"
+"""
 A connection to a list of \`FuncTaggedFilterableReturnsTableMultiColRecord\` values.
-\\"\\"\\"
+"""
 type FuncTaggedFilterableReturnsTableMultiColConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`FuncTaggedFilterableReturnsTableMultiColRecord\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [FuncTaggedFilterableReturnsTableMultiColEdge!]!
 
-  \\"\\"\\"A list of \`FuncTaggedFilterableReturnsTableMultiColRecord\` objects.\\"\\"\\"
+  """A list of \`FuncTaggedFilterableReturnsTableMultiColRecord\` objects."""
   nodes: [FuncTaggedFilterableReturnsTableMultiColRecord]!
 
-  \\"\\"\\"
+  """
   The count of *all* \`FuncTaggedFilterableReturnsTableMultiColRecord\` you could get from the connection.
-  \\"\\"\\"
+  """
   totalCount: Int!
 }
 
-\\"\\"\\"
+"""
 A \`FuncTaggedFilterableReturnsTableMultiColRecord\` edge in the connection.
-\\"\\"\\"
+"""
 type FuncTaggedFilterableReturnsTableMultiColEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"
+  """
   The \`FuncTaggedFilterableReturnsTableMultiColRecord\` at the end of the edge.
-  \\"\\"\\"
+  """
   node: FuncTaggedFilterableReturnsTableMultiColRecord
 }
 
-\\"\\"\\"
+"""
 The return type of our \`funcTaggedFilterableReturnsTableMultiCol\` query.
-\\"\\"\\"
+"""
 type FuncTaggedFilterableReturnsTableMultiColRecord {
   col1: Int
   col2: String
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`FuncTaggedFilterableReturnsTableMultiColRecord\`
 object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input FuncTaggedFilterableReturnsTableMultiColRecordFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [FuncTaggedFilterableReturnsTableMultiColRecordFilter!]
 
-  \\"\\"\\"Filter by the object’s \`col1\` field.\\"\\"\\"
+  """Filter by the object’s \`col1\` field."""
   col1: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`col2\` field.\\"\\"\\"
+  """Filter by the object’s \`col2\` field."""
   col2: StringFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: FuncTaggedFilterableReturnsTableMultiColRecordFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [FuncTaggedFilterableReturnsTableMultiColRecordFilter!]
 }
 
 scalar Int4Domain
 
-\\"\\"\\"An IPv4 or IPv6 host address, and optionally its subnet.\\"\\"\\"
+"""An IPv4 or IPv6 host address, and optionally its subnet."""
 scalar InternetAddress
 
-\\"\\"\\"
+"""
 An interval of time that has passed where the smallest distinct unit is a second.
-\\"\\"\\"
+"""
 type Interval {
-  \\"\\"\\"A quantity of days.\\"\\"\\"
+  """A quantity of days."""
   days: Int
 
-  \\"\\"\\"A quantity of hours.\\"\\"\\"
+  """A quantity of hours."""
   hours: Int
 
-  \\"\\"\\"A quantity of minutes.\\"\\"\\"
+  """A quantity of minutes."""
   minutes: Int
 
-  \\"\\"\\"A quantity of months.\\"\\"\\"
+  """A quantity of months."""
   months: Int
 
-  \\"\\"\\"
+  """
   A quantity of seconds. This is the only non-integer field, as all the other
   fields will dump their overflow into a smaller unit of time. Intervals don’t
   have a smaller unit than seconds.
-  \\"\\"\\"
+  """
   seconds: Float
 
-  \\"\\"\\"A quantity of years.\\"\\"\\"
+  """A quantity of years."""
   years: Int
 }
 
-\\"\\"\\"
+"""
 A filter to be used against Int fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input IntFilter {
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: Int
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: Int
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: Int
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: Int
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [Int!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: Int
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: Int
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: Int
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: Int
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [Int!]
 }
 
-\\"\\"\\"A range of \`Int\`.\\"\\"\\"
+"""A range of \`Int\`."""
 type IntRange {
-  \\"\\"\\"The ending bound of our range.\\"\\"\\"
+  """The ending bound of our range."""
   end: IntRangeBound
 
-  \\"\\"\\"The starting bound of our range.\\"\\"\\"
+  """The starting bound of our range."""
   start: IntRangeBound
 }
 
-\\"\\"\\"
+"""
 The value at one end of a range. A range can either include this value, or not.
-\\"\\"\\"
+"""
 type IntRangeBound {
-  \\"\\"\\"Whether or not the value of this bound is included in the range.\\"\\"\\"
+  """Whether or not the value of this bound is included in the range."""
   inclusive: Boolean!
 
-  \\"\\"\\"The value at one end of our range.\\"\\"\\"
+  """The value at one end of our range."""
   value: Int!
 }
 
-\\"\\"\\"
+"""
 A JavaScript object encoded in the JSON format as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf).
-\\"\\"\\"
+"""
 scalar JSON
 
 type JsonbTest implements Node {
@@ -1273,56 +1273,56 @@ type JsonbTest implements Node {
   jsonbWithArray: JSON
   jsonbWithObject: JSON
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`JsonbTest\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input JsonbTestFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [JsonbTestFilter!]
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: JsonbTestFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [JsonbTestFilter!]
 }
 
-\\"\\"\\"A connection to a list of \`JsonbTest\` values.\\"\\"\\"
+"""A connection to a list of \`JsonbTest\` values."""
 type JsonbTestsConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`JsonbTest\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [JsonbTestsEdge!]!
 
-  \\"\\"\\"A list of \`JsonbTest\` objects.\\"\\"\\"
+  """A list of \`JsonbTest\` objects."""
   nodes: [JsonbTest]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`JsonbTest\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`JsonbTest\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`JsonbTest\` edge in the connection.\\"\\"\\"
+"""A \`JsonbTest\` edge in the connection."""
 type JsonbTestsEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`JsonbTest\` at the end of the edge.\\"\\"\\"
+  """The \`JsonbTest\` at the end of the edge."""
   node: JsonbTest
 }
 
-\\"\\"\\"Methods to use when ordering \`JsonbTest\`.\\"\\"\\"
+"""Methods to use when ordering \`JsonbTest\`."""
 enum JsonbTestsOrderBy {
   ID_ASC
   ID_DESC
@@ -1332,61 +1332,61 @@ enum JsonbTestsOrderBy {
 }
 
 type Junction implements Node {
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 
-  \\"\\"\\"Reads a single \`SideA\` that is related to this \`Junction\`.\\"\\"\\"
+  """Reads a single \`SideA\` that is related to this \`Junction\`."""
   sideABySideAId: SideA
   sideAId: Int!
   sideBId: Int!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`Junction\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input JunctionFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [JunctionFilter!]
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: JunctionFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [JunctionFilter!]
 
-  \\"\\"\\"Filter by the object’s \`sideAId\` field.\\"\\"\\"
+  """Filter by the object’s \`sideAId\` field."""
   sideAId: IntFilter
 }
 
-\\"\\"\\"A connection to a list of \`Junction\` values.\\"\\"\\"
+"""A connection to a list of \`Junction\` values."""
 type JunctionsConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`Junction\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [JunctionsEdge!]!
 
-  \\"\\"\\"A list of \`Junction\` objects.\\"\\"\\"
+  """A list of \`Junction\` objects."""
   nodes: [Junction]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`Junction\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`Junction\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`Junction\` edge in the connection.\\"\\"\\"
+"""A \`Junction\` edge in the connection."""
 type JunctionsEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`Junction\` at the end of the edge.\\"\\"\\"
+  """The \`Junction\` at the end of the edge."""
   node: Junction
 }
 
-\\"\\"\\"Methods to use when ordering \`Junction\`.\\"\\"\\"
+"""Methods to use when ordering \`Junction\`."""
 enum JunctionsOrderBy {
   NATURAL
   PRIMARY_KEY_ASC
@@ -1395,9 +1395,9 @@ enum JunctionsOrderBy {
   SIDE_A_ID_DESC
 }
 
-\\"\\"\\"
+"""
 A set of key/value pairs, keys are strings, values may be a string or null. Exposed as a JSON object.
-\\"\\"\\"
+"""
 scalar KeyValueHash
 
 enum Mood {
@@ -1406,26 +1406,26 @@ enum Mood {
   SAD
 }
 
-\\"\\"\\"An object with a globally unique \`ID\`.\\"\\"\\"
+"""An object with a globally unique \`ID\`."""
 interface Node {
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
-\\"\\"\\"Information about pagination in a connection.\\"\\"\\"
+"""Information about pagination in a connection."""
 type PageInfo {
-  \\"\\"\\"When paginating forwards, the cursor to continue.\\"\\"\\"
+  """When paginating forwards, the cursor to continue."""
   endCursor: Cursor
 
-  \\"\\"\\"When paginating forwards, are there more items?\\"\\"\\"
+  """When paginating forwards, are there more items?"""
   hasNextPage: Boolean!
 
-  \\"\\"\\"When paginating backwards, are there more items?\\"\\"\\"
+  """When paginating backwards, are there more items?"""
   hasPreviousPage: Boolean!
 
-  \\"\\"\\"When paginating backwards, the cursor to continue.\\"\\"\\"
+  """When paginating backwards, the cursor to continue."""
   startCursor: Cursor
 }
 
@@ -1433,56 +1433,56 @@ type Parent implements Node {
   id: Int!
   name: String!
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`Parent\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input ParentFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [ParentFilter!]
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: ParentFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [ParentFilter!]
 }
 
-\\"\\"\\"A connection to a list of \`Parent\` values.\\"\\"\\"
+"""A connection to a list of \`Parent\` values."""
 type ParentsConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`Parent\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [ParentsEdge!]!
 
-  \\"\\"\\"A list of \`Parent\` objects.\\"\\"\\"
+  """A list of \`Parent\` objects."""
   nodes: [Parent]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`Parent\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`Parent\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`Parent\` edge in the connection.\\"\\"\\"
+"""A \`Parent\` edge in the connection."""
 type ParentsEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`Parent\` at the end of the edge.\\"\\"\\"
+  """The \`Parent\` at the end of the edge."""
   node: Parent
 }
 
-\\"\\"\\"Methods to use when ordering \`Parent\`.\\"\\"\\"
+"""Methods to use when ordering \`Parent\`."""
 enum ParentsOrderBy {
   ID_ASC
   ID_DESC
@@ -1495,681 +1495,681 @@ type Protected implements Node {
   id: Int!
   name: String
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
   otherId: Int
 }
 
-\\"\\"\\"A connection to a list of \`Protected\` values.\\"\\"\\"
+"""A connection to a list of \`Protected\` values."""
 type ProtectedsConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`Protected\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [ProtectedsEdge!]!
 
-  \\"\\"\\"A list of \`Protected\` objects.\\"\\"\\"
+  """A list of \`Protected\` objects."""
   nodes: [Protected]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`Protected\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`Protected\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`Protected\` edge in the connection.\\"\\"\\"
+"""A \`Protected\` edge in the connection."""
 type ProtectedsEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`Protected\` at the end of the edge.\\"\\"\\"
+  """The \`Protected\` at the end of the edge."""
   node: Protected
 }
 
-\\"\\"\\"The root query type which gives access points into the data universe.\\"\\"\\"
+"""The root query type which gives access points into the data universe."""
 type Query implements Node {
-  \\"\\"\\"Reads and enables pagination through a set of \`ArrayType\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`ArrayType\`."""
   allArrayTypes(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: ArrayTypeFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`ArrayType\`.\\"\\"\\"
+    """The method to use when ordering \`ArrayType\`."""
     orderBy: [ArrayTypesOrderBy!] = [PRIMARY_KEY_ASC]
   ): ArrayTypesConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`BackwardCompound\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`BackwardCompound\`."""
   allBackwardCompounds(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: BackwardCompoundFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`BackwardCompound\`.\\"\\"\\"
+    """The method to use when ordering \`BackwardCompound\`."""
     orderBy: [BackwardCompoundsOrderBy!] = [PRIMARY_KEY_ASC]
   ): BackwardCompoundsConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Backward\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Backward\`."""
   allBackwards(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: BackwardFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`Backward\`.\\"\\"\\"
+    """The method to use when ordering \`Backward\`."""
     orderBy: [BackwardsOrderBy!] = [PRIMARY_KEY_ASC]
   ): BackwardsConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`ChildNoRelatedFilter\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`ChildNoRelatedFilter\`."""
   allChildNoRelatedFilters(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: ChildNoRelatedFilterFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`ChildNoRelatedFilter\`.\\"\\"\\"
+    """The method to use when ordering \`ChildNoRelatedFilter\`."""
     orderBy: [ChildNoRelatedFiltersOrderBy!] = [PRIMARY_KEY_ASC]
   ): ChildNoRelatedFiltersConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Child\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Child\`."""
   allChildren(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: ChildFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`Child\`.\\"\\"\\"
+    """The method to use when ordering \`Child\`."""
     orderBy: [ChildrenOrderBy!] = [PRIMARY_KEY_ASC]
   ): ChildrenConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`DomainType\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`DomainType\`."""
   allDomainTypes(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: DomainTypeFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`DomainType\`.\\"\\"\\"
+    """The method to use when ordering \`DomainType\`."""
     orderBy: [DomainTypesOrderBy!] = [PRIMARY_KEY_ASC]
   ): DomainTypesConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`EnumArrayType\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`EnumArrayType\`."""
   allEnumArrayTypes(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: EnumArrayTypeFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`EnumArrayType\`.\\"\\"\\"
+    """The method to use when ordering \`EnumArrayType\`."""
     orderBy: [EnumArrayTypesOrderBy!] = [PRIMARY_KEY_ASC]
   ): EnumArrayTypesConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`EnumType\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`EnumType\`."""
   allEnumTypes(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: EnumTypeFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`EnumType\`.\\"\\"\\"
+    """The method to use when ordering \`EnumType\`."""
     orderBy: [EnumTypesOrderBy!] = [PRIMARY_KEY_ASC]
   ): EnumTypesConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Filterable\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Filterable\`."""
   allFilterables(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: FilterableFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`Filterable\`.\\"\\"\\"
+    """The method to use when ordering \`Filterable\`."""
     orderBy: [FilterablesOrderBy!] = [PRIMARY_KEY_ASC]
   ): FilterablesConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`ForwardCompound\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`ForwardCompound\`."""
   allForwardCompounds(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: ForwardCompoundFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`ForwardCompound\`.\\"\\"\\"
+    """The method to use when ordering \`ForwardCompound\`."""
     orderBy: [ForwardCompoundsOrderBy!] = [PRIMARY_KEY_ASC]
   ): ForwardCompoundsConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Forward\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Forward\`."""
   allForwards(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: ForwardFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`Forward\`.\\"\\"\\"
+    """The method to use when ordering \`Forward\`."""
     orderBy: [ForwardsOrderBy!] = [PRIMARY_KEY_ASC]
   ): ForwardsConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`FullyOmitted\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`FullyOmitted\`."""
   allFullyOmitteds(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`FullyOmitted\`.\\"\\"\\"
+    """The method to use when ordering \`FullyOmitted\`."""
     orderBy: [FullyOmittedsOrderBy!] = [PRIMARY_KEY_ASC]
   ): FullyOmittedsConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`JsonbTest\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`JsonbTest\`."""
   allJsonbTests(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: JsonbTestFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`JsonbTest\`.\\"\\"\\"
+    """The method to use when ordering \`JsonbTest\`."""
     orderBy: [JsonbTestsOrderBy!] = [PRIMARY_KEY_ASC]
   ): JsonbTestsConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Junction\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Junction\`."""
   allJunctions(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: JunctionFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`Junction\`.\\"\\"\\"
+    """The method to use when ordering \`Junction\`."""
     orderBy: [JunctionsOrderBy!] = [PRIMARY_KEY_ASC]
   ): JunctionsConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Parent\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Parent\`."""
   allParents(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: ParentFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`Parent\`.\\"\\"\\"
+    """The method to use when ordering \`Parent\`."""
     orderBy: [ParentsOrderBy!] = [PRIMARY_KEY_ASC]
   ): ParentsConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`RangeArrayType\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`RangeArrayType\`."""
   allRangeArrayTypes(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: RangeArrayTypeFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`RangeArrayType\`.\\"\\"\\"
+    """The method to use when ordering \`RangeArrayType\`."""
     orderBy: [RangeArrayTypesOrderBy!] = [PRIMARY_KEY_ASC]
   ): RangeArrayTypesConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`RangeType\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`RangeType\`."""
   allRangeTypes(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: RangeTypeFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`RangeType\`.\\"\\"\\"
+    """The method to use when ordering \`RangeType\`."""
     orderBy: [RangeTypesOrderBy!] = [PRIMARY_KEY_ASC]
   ): RangeTypesConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`SideA\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`SideA\`."""
   allSideAs(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: SideAFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`SideA\`.\\"\\"\\"
+    """The method to use when ordering \`SideA\`."""
     orderBy: [SideAsOrderBy!] = [PRIMARY_KEY_ASC]
   ): SideAsConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`SideB\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`SideB\`."""
   allSideBs(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: SideBFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`SideB\`.\\"\\"\\"
+    """The method to use when ordering \`SideB\`."""
     orderBy: [SideBsOrderBy!] = [PRIMARY_KEY_ASC]
   ): SideBsConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Unfilterable\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Unfilterable\`."""
   allUnfilterables(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`Unfilterable\`.\\"\\"\\"
+    """The method to use when ordering \`Unfilterable\`."""
     orderBy: [UnfilterablesOrderBy!] = [PRIMARY_KEY_ASC]
   ): UnfilterablesConnection
 
-  \\"\\"\\"Reads a single \`ArrayType\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`ArrayType\` using its globally unique \`ID\`."""
   arrayType(
-    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`ArrayType\`.\\"\\"\\"
+    """The globally unique \`ID\` to be used in selecting a single \`ArrayType\`."""
     nodeId: ID!
   ): ArrayType
   arrayTypeById(id: Int!): ArrayType
 
-  \\"\\"\\"Reads a single \`Backward\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`Backward\` using its globally unique \`ID\`."""
   backward(
-    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`Backward\`.\\"\\"\\"
+    """The globally unique \`ID\` to be used in selecting a single \`Backward\`."""
     nodeId: ID!
   ): Backward
   backwardByFilterableId(filterableId: Int!): Backward
   backwardById(id: Int!): Backward
 
-  \\"\\"\\"Reads a single \`BackwardCompound\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`BackwardCompound\` using its globally unique \`ID\`."""
   backwardCompound(
-    \\"\\"\\"
+    """
     The globally unique \`ID\` to be used in selecting a single \`BackwardCompound\`.
-    \\"\\"\\"
+    """
     nodeId: ID!
   ): BackwardCompound
   backwardCompoundByBackwardCompound1AndBackwardCompound2(backwardCompound1: Int!, backwardCompound2: Int!): BackwardCompound
 
-  \\"\\"\\"Reads a single \`Child\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`Child\` using its globally unique \`ID\`."""
   child(
-    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`Child\`.\\"\\"\\"
+    """The globally unique \`ID\` to be used in selecting a single \`Child\`."""
     nodeId: ID!
   ): Child
   childById(id: Int!): Child
 
-  \\"\\"\\"Reads a single \`ChildNoRelatedFilter\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`ChildNoRelatedFilter\` using its globally unique \`ID\`."""
   childNoRelatedFilter(
-    \\"\\"\\"
+    """
     The globally unique \`ID\` to be used in selecting a single \`ChildNoRelatedFilter\`.
-    \\"\\"\\"
+    """
     nodeId: ID!
   ): ChildNoRelatedFilter
   childNoRelatedFilterById(id: Int!): ChildNoRelatedFilter
 
-  \\"\\"\\"Reads a single \`DomainType\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`DomainType\` using its globally unique \`ID\`."""
   domainType(
-    \\"\\"\\"
+    """
     The globally unique \`ID\` to be used in selecting a single \`DomainType\`.
-    \\"\\"\\"
+    """
     nodeId: ID!
   ): DomainType
   domainTypeById(id: Int!): DomainType
 
-  \\"\\"\\"Reads a single \`EnumArrayType\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`EnumArrayType\` using its globally unique \`ID\`."""
   enumArrayType(
-    \\"\\"\\"
+    """
     The globally unique \`ID\` to be used in selecting a single \`EnumArrayType\`.
-    \\"\\"\\"
+    """
     nodeId: ID!
   ): EnumArrayType
   enumArrayTypeById(id: Int!): EnumArrayType
 
-  \\"\\"\\"Reads a single \`EnumType\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`EnumType\` using its globally unique \`ID\`."""
   enumType(
-    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`EnumType\`.\\"\\"\\"
+    """The globally unique \`ID\` to be used in selecting a single \`EnumType\`."""
     nodeId: ID!
   ): EnumType
   enumTypeById(id: Int!): EnumType
 
-  \\"\\"\\"Reads a single \`Filterable\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`Filterable\` using its globally unique \`ID\`."""
   filterable(
-    \\"\\"\\"
+    """
     The globally unique \`ID\` to be used in selecting a single \`Filterable\`.
-    \\"\\"\\"
+    """
     nodeId: ID!
   ): Filterable
   filterableByBackwardCompound1AndBackwardCompound2(backwardCompound1: Int!, backwardCompound2: Int!): Filterable
@@ -2177,232 +2177,232 @@ type Query implements Node {
   filterableByForwardId(forwardId: Int!): Filterable
   filterableById(id: Int!): Filterable
 
-  \\"\\"\\"Reads a single \`FilterableClosure\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`FilterableClosure\` using its globally unique \`ID\`."""
   filterableClosure(
-    \\"\\"\\"
+    """
     The globally unique \`ID\` to be used in selecting a single \`FilterableClosure\`.
-    \\"\\"\\"
+    """
     nodeId: ID!
   ): FilterableClosure
   filterableClosureById(id: Int!): FilterableClosure
 
-  \\"\\"\\"Reads a single \`Forward\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`Forward\` using its globally unique \`ID\`."""
   forward(
-    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`Forward\`.\\"\\"\\"
+    """The globally unique \`ID\` to be used in selecting a single \`Forward\`."""
     nodeId: ID!
   ): Forward
   forwardById(id: Int!): Forward
 
-  \\"\\"\\"Reads a single \`ForwardCompound\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`ForwardCompound\` using its globally unique \`ID\`."""
   forwardCompound(
-    \\"\\"\\"
+    """
     The globally unique \`ID\` to be used in selecting a single \`ForwardCompound\`.
-    \\"\\"\\"
+    """
     nodeId: ID!
   ): ForwardCompound
   forwardCompoundByForwardCompound1AndForwardCompound2(forwardCompound1: Int!, forwardCompound2: Int!): ForwardCompound
 
-  \\"\\"\\"Reads a single \`FullyOmitted\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`FullyOmitted\` using its globally unique \`ID\`."""
   fullyOmitted(
-    \\"\\"\\"
+    """
     The globally unique \`ID\` to be used in selecting a single \`FullyOmitted\`.
-    \\"\\"\\"
+    """
     nodeId: ID!
   ): FullyOmitted
   fullyOmittedById(id: Int!): FullyOmitted
   funcReturnsTableMultiCol(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
     i: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
   ): FuncReturnsTableMultiColConnection!
   funcReturnsTableOneCol(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
     i: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
   ): FuncReturnsTableOneColConnection!
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Filterable\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Filterable\`."""
   funcTaggedFilterableReturnsSetofFilterable(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: FilterableFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
   ): FilterablesConnection!
   funcTaggedFilterableReturnsTableMultiCol(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: FuncTaggedFilterableReturnsTableMultiColRecordFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
   ): FuncTaggedFilterableReturnsTableMultiColConnection!
 
-  \\"\\"\\"Reads a single \`JsonbTest\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`JsonbTest\` using its globally unique \`ID\`."""
   jsonbTest(
-    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`JsonbTest\`.\\"\\"\\"
+    """The globally unique \`ID\` to be used in selecting a single \`JsonbTest\`."""
     nodeId: ID!
   ): JsonbTest
   jsonbTestById(id: Int!): JsonbTest
 
-  \\"\\"\\"Reads a single \`Junction\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`Junction\` using its globally unique \`ID\`."""
   junction(
-    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`Junction\`.\\"\\"\\"
+    """The globally unique \`ID\` to be used in selecting a single \`Junction\`."""
     nodeId: ID!
   ): Junction
   junctionBySideAIdAndSideBId(sideAId: Int!, sideBId: Int!): Junction
 
-  \\"\\"\\"Fetches an object given its globally unique \`ID\`.\\"\\"\\"
+  """Fetches an object given its globally unique \`ID\`."""
   node(
-    \\"\\"\\"The globally unique \`ID\`.\\"\\"\\"
+    """The globally unique \`ID\`."""
     nodeId: ID!
   ): Node
 
-  \\"\\"\\"
+  """
   The root query type must be a \`Node\` to work well with Relay 1 mutations. This just resolves to \`query\`.
-  \\"\\"\\"
+  """
   nodeId: ID!
 
-  \\"\\"\\"Reads a single \`Parent\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`Parent\` using its globally unique \`ID\`."""
   parent(
-    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`Parent\`.\\"\\"\\"
+    """The globally unique \`ID\` to be used in selecting a single \`Parent\`."""
     nodeId: ID!
   ): Parent
   parentById(id: Int!): Parent
 
-  \\"\\"\\"Reads a single \`Protected\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`Protected\` using its globally unique \`ID\`."""
   protected(
-    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`Protected\`.\\"\\"\\"
+    """The globally unique \`ID\` to be used in selecting a single \`Protected\`."""
     nodeId: ID!
   ): Protected
   protectedById(id: Int!): Protected
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Protected\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Protected\`."""
   protectedsByOtherId(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
     otherId: Int
   ): ProtectedsConnection!
 
-  \\"\\"\\"
+  """
   Exposes the root query type nested one level down. This is helpful for Relay 1
   which can only query top level fields if they are in a particular form.
-  \\"\\"\\"
+  """
   query: Query!
 
-  \\"\\"\\"Reads a single \`RangeArrayType\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`RangeArrayType\` using its globally unique \`ID\`."""
   rangeArrayType(
-    \\"\\"\\"
+    """
     The globally unique \`ID\` to be used in selecting a single \`RangeArrayType\`.
-    \\"\\"\\"
+    """
     nodeId: ID!
   ): RangeArrayType
   rangeArrayTypeById(id: Int!): RangeArrayType
 
-  \\"\\"\\"Reads a single \`RangeType\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`RangeType\` using its globally unique \`ID\`."""
   rangeType(
-    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`RangeType\`.\\"\\"\\"
+    """The globally unique \`ID\` to be used in selecting a single \`RangeType\`."""
     nodeId: ID!
   ): RangeType
   rangeTypeById(id: Int!): RangeType
 
-  \\"\\"\\"Reads a single \`SideA\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`SideA\` using its globally unique \`ID\`."""
   sideA(
-    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`SideA\`.\\"\\"\\"
+    """The globally unique \`ID\` to be used in selecting a single \`SideA\`."""
     nodeId: ID!
   ): SideA
   sideAByAId(aId: Int!): SideA
 
-  \\"\\"\\"Reads a single \`SideB\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`SideB\` using its globally unique \`ID\`."""
   sideB(
-    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`SideB\`.\\"\\"\\"
+    """The globally unique \`ID\` to be used in selecting a single \`SideB\`."""
     nodeId: ID!
   ): SideB
   sideBByBId(bId: Int!): SideB
 
-  \\"\\"\\"Reads a single \`Unfilterable\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`Unfilterable\` using its globally unique \`ID\`."""
   unfilterable(
-    \\"\\"\\"
+    """
     The globally unique \`ID\` to be used in selecting a single \`Unfilterable\`.
-    \\"\\"\\"
+    """
     nodeId: ID!
   ): Unfilterable
   unfilterableById(id: Int!): Unfilterable
@@ -2414,59 +2414,59 @@ type RangeArrayType implements Node {
   int4RangeArray: [IntRange]
   int8RangeArray: [BigIntRange]
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
   numericRangeArray: [BigFloatRange]
   timestampRangeArray: [DatetimeRange]
   timestamptzRangeArray: [DatetimeRange]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`RangeArrayType\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input RangeArrayTypeFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [RangeArrayTypeFilter!]
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: RangeArrayTypeFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [RangeArrayTypeFilter!]
 }
 
-\\"\\"\\"A connection to a list of \`RangeArrayType\` values.\\"\\"\\"
+"""A connection to a list of \`RangeArrayType\` values."""
 type RangeArrayTypesConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`RangeArrayType\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [RangeArrayTypesEdge!]!
 
-  \\"\\"\\"A list of \`RangeArrayType\` objects.\\"\\"\\"
+  """A list of \`RangeArrayType\` objects."""
   nodes: [RangeArrayType]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`RangeArrayType\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`RangeArrayType\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`RangeArrayType\` edge in the connection.\\"\\"\\"
+"""A \`RangeArrayType\` edge in the connection."""
 type RangeArrayTypesEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`RangeArrayType\` at the end of the edge.\\"\\"\\"
+  """The \`RangeArrayType\` at the end of the edge."""
   node: RangeArrayType
 }
 
-\\"\\"\\"Methods to use when ordering \`RangeArrayType\`.\\"\\"\\"
+"""Methods to use when ordering \`RangeArrayType\`."""
 enum RangeArrayTypesOrderBy {
   ID_ASC
   ID_DESC
@@ -2481,59 +2481,59 @@ type RangeType implements Node {
   int4Range: IntRange
   int8Range: BigIntRange
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
   numericRange: BigFloatRange
   timestampRange: DatetimeRange
   timestamptzRange: DatetimeRange
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`RangeType\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input RangeTypeFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [RangeTypeFilter!]
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: RangeTypeFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [RangeTypeFilter!]
 }
 
-\\"\\"\\"A connection to a list of \`RangeType\` values.\\"\\"\\"
+"""A connection to a list of \`RangeType\` values."""
 type RangeTypesConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`RangeType\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [RangeTypesEdge!]!
 
-  \\"\\"\\"A list of \`RangeType\` objects.\\"\\"\\"
+  """A list of \`RangeType\` objects."""
   nodes: [RangeType]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`RangeType\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`RangeType\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`RangeType\` edge in the connection.\\"\\"\\"
+"""A \`RangeType\` edge in the connection."""
 type RangeTypesEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`RangeType\` at the end of the edge.\\"\\"\\"
+  """The \`RangeType\` at the end of the edge."""
   node: RangeType
 }
 
-\\"\\"\\"Methods to use when ordering \`RangeType\`.\\"\\"\\"
+"""Methods to use when ordering \`RangeType\`."""
 enum RangeTypesOrderBy {
   ID_ASC
   ID_DESC
@@ -2545,86 +2545,86 @@ enum RangeTypesOrderBy {
 type SideA implements Node {
   aId: Int!
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Junction\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Junction\`."""
   junctionsBySideAId(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: JunctionFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`Junction\`.\\"\\"\\"
+    """The method to use when ordering \`Junction\`."""
     orderBy: [JunctionsOrderBy!] = [PRIMARY_KEY_ASC]
   ): JunctionsConnection!
   name: String!
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`SideA\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input SideAFilter {
-  \\"\\"\\"Filter by the object’s \`aId\` field.\\"\\"\\"
+  """Filter by the object’s \`aId\` field."""
   aId: IntFilter
 
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [SideAFilter!]
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: SideAFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [SideAFilter!]
 }
 
-\\"\\"\\"A connection to a list of \`SideA\` values.\\"\\"\\"
+"""A connection to a list of \`SideA\` values."""
 type SideAsConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`SideA\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [SideAsEdge!]!
 
-  \\"\\"\\"A list of \`SideA\` objects.\\"\\"\\"
+  """A list of \`SideA\` objects."""
   nodes: [SideA]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`SideA\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`SideA\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`SideA\` edge in the connection.\\"\\"\\"
+"""A \`SideA\` edge in the connection."""
 type SideAsEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`SideA\` at the end of the edge.\\"\\"\\"
+  """The \`SideA\` at the end of the edge."""
   node: SideA
 }
 
-\\"\\"\\"Methods to use when ordering \`SideA\`.\\"\\"\\"
+"""Methods to use when ordering \`SideA\`."""
 enum SideAsOrderBy {
   A_ID_ASC
   A_ID_DESC
@@ -2637,56 +2637,56 @@ type SideB implements Node {
   bId: Int!
   name: String!
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`SideB\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input SideBFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [SideBFilter!]
 
-  \\"\\"\\"Filter by the object’s \`bId\` field.\\"\\"\\"
+  """Filter by the object’s \`bId\` field."""
   bId: IntFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: SideBFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [SideBFilter!]
 }
 
-\\"\\"\\"A connection to a list of \`SideB\` values.\\"\\"\\"
+"""A connection to a list of \`SideB\` values."""
 type SideBsConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`SideB\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [SideBsEdge!]!
 
-  \\"\\"\\"A list of \`SideB\` objects.\\"\\"\\"
+  """A list of \`SideB\` objects."""
   nodes: [SideB]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`SideB\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`SideB\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`SideB\` edge in the connection.\\"\\"\\"
+"""A \`SideB\` edge in the connection."""
 type SideBsEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`SideB\` at the end of the edge.\\"\\"\\"
+  """The \`SideB\` at the end of the edge."""
   node: SideB
 }
 
-\\"\\"\\"Methods to use when ordering \`SideB\`.\\"\\"\\"
+"""Methods to use when ordering \`SideB\`."""
 enum SideBsOrderBy {
   B_ID_ASC
   B_ID_DESC
@@ -2695,186 +2695,186 @@ enum SideBsOrderBy {
   PRIMARY_KEY_DESC
 }
 
-\\"\\"\\"
+"""
 A filter to be used against String fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input StringFilter {
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: String
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value (case-insensitive).
-  \\"\\"\\"
+  """
   distinctFromInsensitive: String
 
-  \\"\\"\\"Ends with the specified string (case-sensitive).\\"\\"\\"
+  """Ends with the specified string (case-sensitive)."""
   endsWith: String
 
-  \\"\\"\\"Ends with the specified string (case-insensitive).\\"\\"\\"
+  """Ends with the specified string (case-insensitive)."""
   endsWithInsensitive: String
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: String
 
-  \\"\\"\\"Equal to the specified value (case-insensitive).\\"\\"\\"
+  """Equal to the specified value (case-insensitive)."""
   equalToInsensitive: String
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: String
 
-  \\"\\"\\"Greater than the specified value (case-insensitive).\\"\\"\\"
+  """Greater than the specified value (case-insensitive)."""
   greaterThanInsensitive: String
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: String
 
-  \\"\\"\\"Greater than or equal to the specified value (case-insensitive).\\"\\"\\"
+  """Greater than or equal to the specified value (case-insensitive)."""
   greaterThanOrEqualToInsensitive: String
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [String!]
 
-  \\"\\"\\"Included in the specified list (case-insensitive).\\"\\"\\"
-  inInsensitive: [String!]
-
-  \\"\\"\\"Contains the specified string (case-sensitive).\\"\\"\\"
+  """Contains the specified string (case-sensitive)."""
   includes: String
 
-  \\"\\"\\"Contains the specified string (case-insensitive).\\"\\"\\"
+  """Contains the specified string (case-insensitive)."""
   includesInsensitive: String
 
-  \\"\\"\\"
+  """Included in the specified list (case-insensitive)."""
+  inInsensitive: [String!]
+
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: String
 
-  \\"\\"\\"Less than the specified value (case-insensitive).\\"\\"\\"
+  """Less than the specified value (case-insensitive)."""
   lessThanInsensitive: String
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: String
 
-  \\"\\"\\"Less than or equal to the specified value (case-insensitive).\\"\\"\\"
+  """Less than or equal to the specified value (case-insensitive)."""
   lessThanOrEqualToInsensitive: String
 
-  \\"\\"\\"
+  """
   Matches the specified pattern (case-sensitive). An underscore (_) matches any
   single character; a percent sign (%) matches any sequence of zero or more characters.
-  \\"\\"\\"
+  """
   like: String
 
-  \\"\\"\\"
+  """
   Matches the specified pattern (case-insensitive). An underscore (_) matches
   any single character; a percent sign (%) matches any sequence of zero or more characters.
-  \\"\\"\\"
+  """
   likeInsensitive: String
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: String
 
-  \\"\\"\\"
+  """
   Equal to the specified value, treating null like an ordinary value (case-insensitive).
-  \\"\\"\\"
+  """
   notDistinctFromInsensitive: String
 
-  \\"\\"\\"Does not end with the specified string (case-sensitive).\\"\\"\\"
+  """Does not end with the specified string (case-sensitive)."""
   notEndsWith: String
 
-  \\"\\"\\"Does not end with the specified string (case-insensitive).\\"\\"\\"
+  """Does not end with the specified string (case-insensitive)."""
   notEndsWithInsensitive: String
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: String
 
-  \\"\\"\\"Not equal to the specified value (case-insensitive).\\"\\"\\"
+  """Not equal to the specified value (case-insensitive)."""
   notEqualToInsensitive: String
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [String!]
 
-  \\"\\"\\"Not included in the specified list (case-insensitive).\\"\\"\\"
-  notInInsensitive: [String!]
-
-  \\"\\"\\"Does not contain the specified string (case-sensitive).\\"\\"\\"
+  """Does not contain the specified string (case-sensitive)."""
   notIncludes: String
 
-  \\"\\"\\"Does not contain the specified string (case-insensitive).\\"\\"\\"
+  """Does not contain the specified string (case-insensitive)."""
   notIncludesInsensitive: String
 
-  \\"\\"\\"
+  """Not included in the specified list (case-insensitive)."""
+  notInInsensitive: [String!]
+
+  """
   Does not match the specified pattern (case-sensitive). An underscore (_)
   matches any single character; a percent sign (%) matches any sequence of zero
   or more characters.
-  \\"\\"\\"
+  """
   notLike: String
 
-  \\"\\"\\"
+  """
   Does not match the specified pattern (case-insensitive). An underscore (_)
   matches any single character; a percent sign (%) matches any sequence of zero
   or more characters.
-  \\"\\"\\"
+  """
   notLikeInsensitive: String
 
-  \\"\\"\\"Does not start with the specified string (case-sensitive).\\"\\"\\"
+  """Does not start with the specified string (case-sensitive)."""
   notStartsWith: String
 
-  \\"\\"\\"Does not start with the specified string (case-insensitive).\\"\\"\\"
+  """Does not start with the specified string (case-insensitive)."""
   notStartsWithInsensitive: String
 
-  \\"\\"\\"Starts with the specified string (case-sensitive).\\"\\"\\"
+  """Starts with the specified string (case-sensitive)."""
   startsWith: String
 
-  \\"\\"\\"Starts with the specified string (case-insensitive).\\"\\"\\"
+  """Starts with the specified string (case-insensitive)."""
   startsWithInsensitive: String
 }
 
-\\"\\"\\"
+"""
 The exact time of day, does not include the date. May or may not have a timezone offset.
-\\"\\"\\"
+"""
 scalar Time
 
 type Unfilterable implements Node {
   id: Int!
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
   text: String
 }
 
-\\"\\"\\"A connection to a list of \`Unfilterable\` values.\\"\\"\\"
+"""A connection to a list of \`Unfilterable\` values."""
 type UnfilterablesConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`Unfilterable\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [UnfilterablesEdge!]!
 
-  \\"\\"\\"A list of \`Unfilterable\` objects.\\"\\"\\"
+  """A list of \`Unfilterable\` objects."""
   nodes: [Unfilterable]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`Unfilterable\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`Unfilterable\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`Unfilterable\` edge in the connection.\\"\\"\\"
+"""A \`Unfilterable\` edge in the connection."""
 type UnfilterablesEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`Unfilterable\` at the end of the edge.\\"\\"\\"
+  """The \`Unfilterable\` at the end of the edge."""
   node: Unfilterable
 }
 
-\\"\\"\\"Methods to use when ordering \`Unfilterable\`.\\"\\"\\"
+"""Methods to use when ordering \`Unfilterable\`."""
 enum UnfilterablesOrderBy {
   ID_ASC
   ID_DESC
@@ -2883,9 +2883,9 @@ enum UnfilterablesOrderBy {
   PRIMARY_KEY_DESC
 }
 
-\\"\\"\\"
+"""
 A universally unique identifier as defined by [RFC 4122](https://tools.ietf.org/html/rfc4122).
-\\"\\"\\"
+"""
 scalar UUID
-"
+
 `;

--- a/__tests__/integration/schema/__snapshots__/logicalOperatorsFalse.test.ts.snap
+++ b/__tests__/integration/schema/__snapshots__/logicalOperatorsFalse.test.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`prints a schema with the filter plugin and the \`connectionFilterLogicalOperators: false\` option 1`] = `
-"type ArrayType implements Node {
+type ArrayType implements Node {
   bit4Array: [BitString]
   boolArray: [Boolean]
   bpchar4Array: [String]
@@ -25,9 +25,9 @@ exports[`prints a schema with the filter plugin and the \`connectionFilterLogica
   moneyArray: [Float]
   nameArray: [String]
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
   numericArray: [BigFloat]
   textArray: [String]
@@ -41,119 +41,119 @@ exports[`prints a schema with the filter plugin and the \`connectionFilterLogica
   xmlArray: [String]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`ArrayType\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input ArrayTypeFilter {
-  \\"\\"\\"Filter by the object’s \`bit4Array\` field.\\"\\"\\"
+  """Filter by the object’s \`bit4Array\` field."""
   bit4Array: BitStringListFilter
 
-  \\"\\"\\"Filter by the object’s \`boolArray\` field.\\"\\"\\"
+  """Filter by the object’s \`boolArray\` field."""
   boolArray: BooleanListFilter
 
-  \\"\\"\\"Filter by the object’s \`bpchar4Array\` field.\\"\\"\\"
+  """Filter by the object’s \`bpchar4Array\` field."""
   bpchar4Array: StringListFilter
 
-  \\"\\"\\"Filter by the object’s \`char4Array\` field.\\"\\"\\"
+  """Filter by the object’s \`char4Array\` field."""
   char4Array: StringListFilter
 
-  \\"\\"\\"Filter by the object’s \`citextArray\` field.\\"\\"\\"
+  """Filter by the object’s \`citextArray\` field."""
   citextArray: StringListFilter
 
-  \\"\\"\\"Filter by the object’s \`dateArray\` field.\\"\\"\\"
+  """Filter by the object’s \`dateArray\` field."""
   dateArray: DateListFilter
 
-  \\"\\"\\"Filter by the object’s \`float4Array\` field.\\"\\"\\"
+  """Filter by the object’s \`float4Array\` field."""
   float4Array: FloatListFilter
 
-  \\"\\"\\"Filter by the object’s \`float8Array\` field.\\"\\"\\"
+  """Filter by the object’s \`float8Array\` field."""
   float8Array: FloatListFilter
 
-  \\"\\"\\"Filter by the object’s \`hstoreArray\` field.\\"\\"\\"
+  """Filter by the object’s \`hstoreArray\` field."""
   hstoreArray: KeyValueHashListFilter
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`inetArray\` field.\\"\\"\\"
+  """Filter by the object’s \`inetArray\` field."""
   inetArray: InternetAddressListFilter
 
-  \\"\\"\\"Filter by the object’s \`int2Array\` field.\\"\\"\\"
+  """Filter by the object’s \`int2Array\` field."""
   int2Array: IntListFilter
 
-  \\"\\"\\"Filter by the object’s \`int4Array\` field.\\"\\"\\"
+  """Filter by the object’s \`int4Array\` field."""
   int4Array: IntListFilter
 
-  \\"\\"\\"Filter by the object’s \`int8Array\` field.\\"\\"\\"
+  """Filter by the object’s \`int8Array\` field."""
   int8Array: BigIntListFilter
 
-  \\"\\"\\"Filter by the object’s \`intervalArray\` field.\\"\\"\\"
+  """Filter by the object’s \`intervalArray\` field."""
   intervalArray: IntervalListFilter
 
-  \\"\\"\\"Filter by the object’s \`jsonbArray\` field.\\"\\"\\"
+  """Filter by the object’s \`jsonbArray\` field."""
   jsonbArray: JSONListFilter
 
-  \\"\\"\\"Filter by the object’s \`moneyArray\` field.\\"\\"\\"
+  """Filter by the object’s \`moneyArray\` field."""
   moneyArray: FloatListFilter
 
-  \\"\\"\\"Filter by the object’s \`nameArray\` field.\\"\\"\\"
+  """Filter by the object’s \`nameArray\` field."""
   nameArray: StringListFilter
 
-  \\"\\"\\"Filter by the object’s \`numericArray\` field.\\"\\"\\"
+  """Filter by the object’s \`numericArray\` field."""
   numericArray: BigFloatListFilter
 
-  \\"\\"\\"Filter by the object’s \`textArray\` field.\\"\\"\\"
+  """Filter by the object’s \`textArray\` field."""
   textArray: StringListFilter
 
-  \\"\\"\\"Filter by the object’s \`timeArray\` field.\\"\\"\\"
+  """Filter by the object’s \`timeArray\` field."""
   timeArray: TimeListFilter
 
-  \\"\\"\\"Filter by the object’s \`timestampArray\` field.\\"\\"\\"
+  """Filter by the object’s \`timestampArray\` field."""
   timestampArray: DatetimeListFilter
 
-  \\"\\"\\"Filter by the object’s \`timestamptzArray\` field.\\"\\"\\"
+  """Filter by the object’s \`timestamptzArray\` field."""
   timestamptzArray: DatetimeListFilter
 
-  \\"\\"\\"Filter by the object’s \`timetzArray\` field.\\"\\"\\"
+  """Filter by the object’s \`timetzArray\` field."""
   timetzArray: TimeListFilter
 
-  \\"\\"\\"Filter by the object’s \`uuidArray\` field.\\"\\"\\"
+  """Filter by the object’s \`uuidArray\` field."""
   uuidArray: UUIDListFilter
 
-  \\"\\"\\"Filter by the object’s \`varbitArray\` field.\\"\\"\\"
+  """Filter by the object’s \`varbitArray\` field."""
   varbitArray: BitStringListFilter
 
-  \\"\\"\\"Filter by the object’s \`varcharArray\` field.\\"\\"\\"
+  """Filter by the object’s \`varcharArray\` field."""
   varcharArray: StringListFilter
 }
 
-\\"\\"\\"A connection to a list of \`ArrayType\` values.\\"\\"\\"
+"""A connection to a list of \`ArrayType\` values."""
 type ArrayTypesConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`ArrayType\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [ArrayTypesEdge!]!
 
-  \\"\\"\\"A list of \`ArrayType\` objects.\\"\\"\\"
+  """A list of \`ArrayType\` objects."""
   nodes: [ArrayType]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`ArrayType\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`ArrayType\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`ArrayType\` edge in the connection.\\"\\"\\"
+"""A \`ArrayType\` edge in the connection."""
 type ArrayTypesEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`ArrayType\` at the end of the edge.\\"\\"\\"
+  """The \`ArrayType\` at the end of the edge."""
   node: ArrayType
 }
 
-\\"\\"\\"Methods to use when ordering \`ArrayType\`.\\"\\"\\"
+"""Methods to use when ordering \`ArrayType\`."""
 enum ArrayTypesOrderBy {
   BIT4_ARRAY_ASC
   BIT4_ARRAY_DESC
@@ -225,15 +225,15 @@ enum ArrayTypesOrderBy {
 }
 
 type Backward implements Node {
-  \\"\\"\\"Reads a single \`Filterable\` that is related to this \`Backward\`.\\"\\"\\"
+  """Reads a single \`Filterable\` that is related to this \`Backward\`."""
   filterableByFilterableId: Filterable
   filterableId: Int
   id: Int!
   name: String!
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
@@ -241,61 +241,61 @@ type BackwardCompound implements Node {
   backwardCompound1: Int!
   backwardCompound2: Int!
 
-  \\"\\"\\"
+  """
   Reads a single \`Filterable\` that is related to this \`BackwardCompound\`.
-  \\"\\"\\"
+  """
   filterableByBackwardCompound1AndBackwardCompound2: Filterable
   name: String
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`BackwardCompound\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input BackwardCompoundFilter {
-  \\"\\"\\"Filter by the object’s \`backwardCompound1\` field.\\"\\"\\"
+  """Filter by the object’s \`backwardCompound1\` field."""
   backwardCompound1: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`backwardCompound2\` field.\\"\\"\\"
+  """Filter by the object’s \`backwardCompound2\` field."""
   backwardCompound2: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`name\` field.\\"\\"\\"
+  """Filter by the object’s \`name\` field."""
   name: StringFilter
 }
 
-\\"\\"\\"A connection to a list of \`BackwardCompound\` values.\\"\\"\\"
+"""A connection to a list of \`BackwardCompound\` values."""
 type BackwardCompoundsConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`BackwardCompound\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [BackwardCompoundsEdge!]!
 
-  \\"\\"\\"A list of \`BackwardCompound\` objects.\\"\\"\\"
+  """A list of \`BackwardCompound\` objects."""
   nodes: [BackwardCompound]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"
+  """
   The count of *all* \`BackwardCompound\` you could get from the connection.
-  \\"\\"\\"
+  """
   totalCount: Int!
 }
 
-\\"\\"\\"A \`BackwardCompound\` edge in the connection.\\"\\"\\"
+"""A \`BackwardCompound\` edge in the connection."""
 type BackwardCompoundsEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`BackwardCompound\` at the end of the edge.\\"\\"\\"
+  """The \`BackwardCompound\` at the end of the edge."""
   node: BackwardCompound
 }
 
-\\"\\"\\"Methods to use when ordering \`BackwardCompound\`.\\"\\"\\"
+"""Methods to use when ordering \`BackwardCompound\`."""
 enum BackwardCompoundsOrderBy {
   BACKWARD_COMPOUND_1_ASC
   BACKWARD_COMPOUND_1_DESC
@@ -308,47 +308,47 @@ enum BackwardCompoundsOrderBy {
   PRIMARY_KEY_DESC
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`Backward\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input BackwardFilter {
-  \\"\\"\\"Filter by the object’s \`filterableId\` field.\\"\\"\\"
+  """Filter by the object’s \`filterableId\` field."""
   filterableId: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`name\` field.\\"\\"\\"
+  """Filter by the object’s \`name\` field."""
   name: StringFilter
 }
 
-\\"\\"\\"A connection to a list of \`Backward\` values.\\"\\"\\"
+"""A connection to a list of \`Backward\` values."""
 type BackwardsConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`Backward\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [BackwardsEdge!]!
 
-  \\"\\"\\"A list of \`Backward\` objects.\\"\\"\\"
+  """A list of \`Backward\` objects."""
   nodes: [Backward]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`Backward\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`Backward\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`Backward\` edge in the connection.\\"\\"\\"
+"""A \`Backward\` edge in the connection."""
 type BackwardsEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`Backward\` at the end of the edge.\\"\\"\\"
+  """The \`Backward\` at the end of the edge."""
   node: Backward
 }
 
-\\"\\"\\"Methods to use when ordering \`Backward\`.\\"\\"\\"
+"""Methods to use when ordering \`Backward\`."""
 enum BackwardsOrderBy {
   FILTERABLE_ID_ASC
   FILTERABLE_ID_DESC
@@ -361,1019 +361,1019 @@ enum BackwardsOrderBy {
   PRIMARY_KEY_DESC
 }
 
-\\"\\"\\"
+"""
 A floating point number that requires more precision than IEEE 754 binary 64
-\\"\\"\\"
+"""
 scalar BigFloat
 
-\\"\\"\\"
+"""
 A filter to be used against BigFloat fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input BigFloatFilter {
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: BigFloat
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: BigFloat
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: BigFloat
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: BigFloat
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [BigFloat!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: BigFloat
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: BigFloat
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: BigFloat
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: BigFloat
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [BigFloat!]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against BigFloat List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input BigFloatListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: BigFloat
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: BigFloat
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: BigFloat
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: BigFloat
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: BigFloat
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: BigFloat
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [BigFloat]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [BigFloat]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [BigFloat]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [BigFloat]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [BigFloat]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [BigFloat]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [BigFloat]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [BigFloat]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [BigFloat]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [BigFloat]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [BigFloat]
 }
 
-\\"\\"\\"A range of \`BigFloat\`.\\"\\"\\"
+"""A range of \`BigFloat\`."""
 type BigFloatRange {
-  \\"\\"\\"The ending bound of our range.\\"\\"\\"
+  """The ending bound of our range."""
   end: BigFloatRangeBound
 
-  \\"\\"\\"The starting bound of our range.\\"\\"\\"
+  """The starting bound of our range."""
   start: BigFloatRangeBound
 }
 
-\\"\\"\\"
+"""
 The value at one end of a range. A range can either include this value, or not.
-\\"\\"\\"
+"""
 type BigFloatRangeBound {
-  \\"\\"\\"Whether or not the value of this bound is included in the range.\\"\\"\\"
+  """Whether or not the value of this bound is included in the range."""
   inclusive: Boolean!
 
-  \\"\\"\\"The value at one end of our range.\\"\\"\\"
+  """The value at one end of our range."""
   value: BigFloat!
 }
 
-\\"\\"\\"
+"""
 The value at one end of a range. A range can either include this value, or not.
-\\"\\"\\"
+"""
 input BigFloatRangeBoundInput {
-  \\"\\"\\"Whether or not the value of this bound is included in the range.\\"\\"\\"
+  """Whether or not the value of this bound is included in the range."""
   inclusive: Boolean!
 
-  \\"\\"\\"The value at one end of our range.\\"\\"\\"
+  """The value at one end of our range."""
   value: BigFloat!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against BigFloatRange fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input BigFloatRangeFilter {
-  \\"\\"\\"Adjacent to the specified range.\\"\\"\\"
+  """Adjacent to the specified range."""
   adjacentTo: BigFloatRangeInput
 
-  \\"\\"\\"Contained by the specified range.\\"\\"\\"
+  """Contained by the specified range."""
   containedBy: BigFloatRangeInput
 
-  \\"\\"\\"Contains the specified range.\\"\\"\\"
+  """Contains the specified range."""
   contains: BigFloatRangeInput
 
-  \\"\\"\\"Contains the specified value.\\"\\"\\"
+  """Contains the specified value."""
   containsElement: BigFloat
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: BigFloatRangeInput
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: BigFloatRangeInput
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: BigFloatRangeInput
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: BigFloatRangeInput
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [BigFloatRangeInput!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: BigFloatRangeInput
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: BigFloatRangeInput
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: BigFloatRangeInput
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: BigFloatRangeInput
 
-  \\"\\"\\"Does not extend left of the specified range.\\"\\"\\"
+  """Does not extend left of the specified range."""
   notExtendsLeftOf: BigFloatRangeInput
 
-  \\"\\"\\"Does not extend right of the specified range.\\"\\"\\"
+  """Does not extend right of the specified range."""
   notExtendsRightOf: BigFloatRangeInput
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [BigFloatRangeInput!]
 
-  \\"\\"\\"Overlaps the specified range.\\"\\"\\"
+  """Overlaps the specified range."""
   overlaps: BigFloatRangeInput
 
-  \\"\\"\\"Strictly left of the specified range.\\"\\"\\"
+  """Strictly left of the specified range."""
   strictlyLeftOf: BigFloatRangeInput
 
-  \\"\\"\\"Strictly right of the specified range.\\"\\"\\"
+  """Strictly right of the specified range."""
   strictlyRightOf: BigFloatRangeInput
 }
 
-\\"\\"\\"A range of \`BigFloat\`.\\"\\"\\"
+"""A range of \`BigFloat\`."""
 input BigFloatRangeInput {
-  \\"\\"\\"The ending bound of our range.\\"\\"\\"
+  """The ending bound of our range."""
   end: BigFloatRangeBoundInput
 
-  \\"\\"\\"The starting bound of our range.\\"\\"\\"
+  """The starting bound of our range."""
   start: BigFloatRangeBoundInput
 }
 
-\\"\\"\\"
+"""
 A filter to be used against BigFloatRange List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input BigFloatRangeListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: BigFloatRangeInput
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: BigFloatRangeInput
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: BigFloatRangeInput
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: BigFloatRangeInput
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: BigFloatRangeInput
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: BigFloatRangeInput
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [BigFloatRangeInput]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [BigFloatRangeInput]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [BigFloatRangeInput]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [BigFloatRangeInput]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [BigFloatRangeInput]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [BigFloatRangeInput]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [BigFloatRangeInput]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [BigFloatRangeInput]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [BigFloatRangeInput]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [BigFloatRangeInput]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [BigFloatRangeInput]
 }
 
-\\"\\"\\"
+"""
 A signed eight-byte integer. The upper big integer values are greater than the
 max value for a JavaScript number. Therefore all big integers will be output as
 strings and not numbers.
-\\"\\"\\"
+"""
 scalar BigInt
 
-\\"\\"\\"
+"""
 A filter to be used against BigInt fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input BigIntFilter {
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: BigInt
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: BigInt
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: BigInt
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: BigInt
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [BigInt!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: BigInt
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: BigInt
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: BigInt
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: BigInt
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [BigInt!]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against BigInt List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input BigIntListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: BigInt
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: BigInt
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: BigInt
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: BigInt
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: BigInt
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: BigInt
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [BigInt]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [BigInt]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [BigInt]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [BigInt]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [BigInt]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [BigInt]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [BigInt]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [BigInt]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [BigInt]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [BigInt]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [BigInt]
 }
 
-\\"\\"\\"A range of \`BigInt\`.\\"\\"\\"
+"""A range of \`BigInt\`."""
 type BigIntRange {
-  \\"\\"\\"The ending bound of our range.\\"\\"\\"
+  """The ending bound of our range."""
   end: BigIntRangeBound
 
-  \\"\\"\\"The starting bound of our range.\\"\\"\\"
+  """The starting bound of our range."""
   start: BigIntRangeBound
 }
 
-\\"\\"\\"
+"""
 The value at one end of a range. A range can either include this value, or not.
-\\"\\"\\"
+"""
 type BigIntRangeBound {
-  \\"\\"\\"Whether or not the value of this bound is included in the range.\\"\\"\\"
+  """Whether or not the value of this bound is included in the range."""
   inclusive: Boolean!
 
-  \\"\\"\\"The value at one end of our range.\\"\\"\\"
+  """The value at one end of our range."""
   value: BigInt!
 }
 
-\\"\\"\\"
+"""
 The value at one end of a range. A range can either include this value, or not.
-\\"\\"\\"
+"""
 input BigIntRangeBoundInput {
-  \\"\\"\\"Whether or not the value of this bound is included in the range.\\"\\"\\"
+  """Whether or not the value of this bound is included in the range."""
   inclusive: Boolean!
 
-  \\"\\"\\"The value at one end of our range.\\"\\"\\"
+  """The value at one end of our range."""
   value: BigInt!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against BigIntRange fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input BigIntRangeFilter {
-  \\"\\"\\"Adjacent to the specified range.\\"\\"\\"
+  """Adjacent to the specified range."""
   adjacentTo: BigIntRangeInput
 
-  \\"\\"\\"Contained by the specified range.\\"\\"\\"
+  """Contained by the specified range."""
   containedBy: BigIntRangeInput
 
-  \\"\\"\\"Contains the specified range.\\"\\"\\"
+  """Contains the specified range."""
   contains: BigIntRangeInput
 
-  \\"\\"\\"Contains the specified value.\\"\\"\\"
+  """Contains the specified value."""
   containsElement: BigInt
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: BigIntRangeInput
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: BigIntRangeInput
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: BigIntRangeInput
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: BigIntRangeInput
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [BigIntRangeInput!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: BigIntRangeInput
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: BigIntRangeInput
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: BigIntRangeInput
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: BigIntRangeInput
 
-  \\"\\"\\"Does not extend left of the specified range.\\"\\"\\"
+  """Does not extend left of the specified range."""
   notExtendsLeftOf: BigIntRangeInput
 
-  \\"\\"\\"Does not extend right of the specified range.\\"\\"\\"
+  """Does not extend right of the specified range."""
   notExtendsRightOf: BigIntRangeInput
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [BigIntRangeInput!]
 
-  \\"\\"\\"Overlaps the specified range.\\"\\"\\"
+  """Overlaps the specified range."""
   overlaps: BigIntRangeInput
 
-  \\"\\"\\"Strictly left of the specified range.\\"\\"\\"
+  """Strictly left of the specified range."""
   strictlyLeftOf: BigIntRangeInput
 
-  \\"\\"\\"Strictly right of the specified range.\\"\\"\\"
+  """Strictly right of the specified range."""
   strictlyRightOf: BigIntRangeInput
 }
 
-\\"\\"\\"A range of \`BigInt\`.\\"\\"\\"
+"""A range of \`BigInt\`."""
 input BigIntRangeInput {
-  \\"\\"\\"The ending bound of our range.\\"\\"\\"
+  """The ending bound of our range."""
   end: BigIntRangeBoundInput
 
-  \\"\\"\\"The starting bound of our range.\\"\\"\\"
+  """The starting bound of our range."""
   start: BigIntRangeBoundInput
 }
 
-\\"\\"\\"
+"""
 A filter to be used against BigIntRange List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input BigIntRangeListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: BigIntRangeInput
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: BigIntRangeInput
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: BigIntRangeInput
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: BigIntRangeInput
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: BigIntRangeInput
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: BigIntRangeInput
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [BigIntRangeInput]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [BigIntRangeInput]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [BigIntRangeInput]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [BigIntRangeInput]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [BigIntRangeInput]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [BigIntRangeInput]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [BigIntRangeInput]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [BigIntRangeInput]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [BigIntRangeInput]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [BigIntRangeInput]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [BigIntRangeInput]
 }
 
-\\"\\"\\"A string representing a series of binary bits\\"\\"\\"
+"""A string representing a series of binary bits"""
 scalar BitString
 
-\\"\\"\\"
+"""
 A filter to be used against BitString fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input BitStringFilter {
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: BitString
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: BitString
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: BitString
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: BitString
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [BitString!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: BitString
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: BitString
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: BitString
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: BitString
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [BitString!]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against BitString List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input BitStringListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: BitString
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: BitString
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: BitString
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: BitString
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: BitString
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: BitString
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [BitString]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [BitString]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [BitString]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [BitString]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [BitString]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [BitString]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [BitString]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [BitString]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [BitString]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [BitString]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [BitString]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against Boolean fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input BooleanFilter {
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: Boolean
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: Boolean
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: Boolean
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: Boolean
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [Boolean!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: Boolean
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: Boolean
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: Boolean
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: Boolean
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [Boolean!]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against Boolean List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input BooleanListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: Boolean
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: Boolean
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: Boolean
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: Boolean
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: Boolean
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: Boolean
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [Boolean]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [Boolean]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [Boolean]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [Boolean]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [Boolean]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [Boolean]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [Boolean]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [Boolean]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [Boolean]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [Boolean]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [Boolean]
 }
 
 scalar Char4Domain
 
-\\"\\"\\"
+"""
 A filter to be used against Char4Domain fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input Char4DomainFilter {
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: Char4Domain
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value (case-insensitive).
-  \\"\\"\\"
+  """
   distinctFromInsensitive: Char4Domain
 
-  \\"\\"\\"Ends with the specified string (case-sensitive).\\"\\"\\"
+  """Ends with the specified string (case-sensitive)."""
   endsWith: Char4Domain
 
-  \\"\\"\\"Ends with the specified string (case-insensitive).\\"\\"\\"
+  """Ends with the specified string (case-insensitive)."""
   endsWithInsensitive: Char4Domain
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: Char4Domain
 
-  \\"\\"\\"Equal to the specified value (case-insensitive).\\"\\"\\"
+  """Equal to the specified value (case-insensitive)."""
   equalToInsensitive: Char4Domain
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: Char4Domain
 
-  \\"\\"\\"Greater than the specified value (case-insensitive).\\"\\"\\"
+  """Greater than the specified value (case-insensitive)."""
   greaterThanInsensitive: Char4Domain
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: Char4Domain
 
-  \\"\\"\\"Greater than or equal to the specified value (case-insensitive).\\"\\"\\"
+  """Greater than or equal to the specified value (case-insensitive)."""
   greaterThanOrEqualToInsensitive: Char4Domain
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [Char4Domain!]
 
-  \\"\\"\\"Included in the specified list (case-insensitive).\\"\\"\\"
-  inInsensitive: [Char4Domain!]
-
-  \\"\\"\\"Contains the specified string (case-sensitive).\\"\\"\\"
+  """Contains the specified string (case-sensitive)."""
   includes: Char4Domain
 
-  \\"\\"\\"Contains the specified string (case-insensitive).\\"\\"\\"
+  """Contains the specified string (case-insensitive)."""
   includesInsensitive: Char4Domain
 
-  \\"\\"\\"
+  """Included in the specified list (case-insensitive)."""
+  inInsensitive: [Char4Domain!]
+
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: Char4Domain
 
-  \\"\\"\\"Less than the specified value (case-insensitive).\\"\\"\\"
+  """Less than the specified value (case-insensitive)."""
   lessThanInsensitive: Char4Domain
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: Char4Domain
 
-  \\"\\"\\"Less than or equal to the specified value (case-insensitive).\\"\\"\\"
+  """Less than or equal to the specified value (case-insensitive)."""
   lessThanOrEqualToInsensitive: Char4Domain
 
-  \\"\\"\\"
+  """
   Matches the specified pattern (case-sensitive). An underscore (_) matches any
   single character; a percent sign (%) matches any sequence of zero or more characters.
-  \\"\\"\\"
+  """
   like: Char4Domain
 
-  \\"\\"\\"
+  """
   Matches the specified pattern (case-insensitive). An underscore (_) matches
   any single character; a percent sign (%) matches any sequence of zero or more characters.
-  \\"\\"\\"
+  """
   likeInsensitive: Char4Domain
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: Char4Domain
 
-  \\"\\"\\"
+  """
   Equal to the specified value, treating null like an ordinary value (case-insensitive).
-  \\"\\"\\"
+  """
   notDistinctFromInsensitive: Char4Domain
 
-  \\"\\"\\"Does not end with the specified string (case-sensitive).\\"\\"\\"
+  """Does not end with the specified string (case-sensitive)."""
   notEndsWith: Char4Domain
 
-  \\"\\"\\"Does not end with the specified string (case-insensitive).\\"\\"\\"
+  """Does not end with the specified string (case-insensitive)."""
   notEndsWithInsensitive: Char4Domain
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: Char4Domain
 
-  \\"\\"\\"Not equal to the specified value (case-insensitive).\\"\\"\\"
+  """Not equal to the specified value (case-insensitive)."""
   notEqualToInsensitive: Char4Domain
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [Char4Domain!]
 
-  \\"\\"\\"Not included in the specified list (case-insensitive).\\"\\"\\"
-  notInInsensitive: [Char4Domain!]
-
-  \\"\\"\\"Does not contain the specified string (case-sensitive).\\"\\"\\"
+  """Does not contain the specified string (case-sensitive)."""
   notIncludes: Char4Domain
 
-  \\"\\"\\"Does not contain the specified string (case-insensitive).\\"\\"\\"
+  """Does not contain the specified string (case-insensitive)."""
   notIncludesInsensitive: Char4Domain
 
-  \\"\\"\\"
+  """Not included in the specified list (case-insensitive)."""
+  notInInsensitive: [Char4Domain!]
+
+  """
   Does not match the specified pattern (case-sensitive). An underscore (_)
   matches any single character; a percent sign (%) matches any sequence of zero
   or more characters.
-  \\"\\"\\"
+  """
   notLike: Char4Domain
 
-  \\"\\"\\"
+  """
   Does not match the specified pattern (case-insensitive). An underscore (_)
   matches any single character; a percent sign (%) matches any sequence of zero
   or more characters.
-  \\"\\"\\"
+  """
   notLikeInsensitive: Char4Domain
 
-  \\"\\"\\"Does not start with the specified string (case-sensitive).\\"\\"\\"
+  """Does not start with the specified string (case-sensitive)."""
   notStartsWith: Char4Domain
 
-  \\"\\"\\"Does not start with the specified string (case-insensitive).\\"\\"\\"
+  """Does not start with the specified string (case-insensitive)."""
   notStartsWithInsensitive: Char4Domain
 
-  \\"\\"\\"Starts with the specified string (case-sensitive).\\"\\"\\"
+  """Starts with the specified string (case-sensitive)."""
   startsWith: Char4Domain
 
-  \\"\\"\\"Starts with the specified string (case-insensitive).\\"\\"\\"
+  """Starts with the specified string (case-insensitive)."""
   startsWithInsensitive: Char4Domain
 }
 
 type Child implements Node {
-  \\"\\"\\"Reads a single \`Filterable\` that is related to this \`Child\`.\\"\\"\\"
+  """Reads a single \`Filterable\` that is related to this \`Child\`."""
   filterableByFilterableId: Filterable
   filterableId: Int
   id: Int!
   name: String!
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`Child\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input ChildFilter {
-  \\"\\"\\"Filter by the object’s \`filterableId\` field.\\"\\"\\"
+  """Filter by the object’s \`filterableId\` field."""
   filterableId: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`name\` field.\\"\\"\\"
+  """Filter by the object’s \`name\` field."""
   name: StringFilter
 }
 
 type ChildNoRelatedFilter implements Node {
-  \\"\\"\\"
+  """
   Reads a single \`Filterable\` that is related to this \`ChildNoRelatedFilter\`.
-  \\"\\"\\"
+  """
   filterableByFilterableId: Filterable
   filterableId: Int
   id: Int!
   name: String!
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 
-  \\"\\"\\"
+  """
   Reads a single \`Unfilterable\` that is related to this \`ChildNoRelatedFilter\`.
-  \\"\\"\\"
+  """
   unfilterableByUnfilterableId: Unfilterable
   unfilterableId: Int
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`ChildNoRelatedFilter\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input ChildNoRelatedFilterFilter {
-  \\"\\"\\"Filter by the object’s \`filterableId\` field.\\"\\"\\"
+  """Filter by the object’s \`filterableId\` field."""
   filterableId: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`name\` field.\\"\\"\\"
+  """Filter by the object’s \`name\` field."""
   name: StringFilter
 
-  \\"\\"\\"Filter by the object’s \`unfilterableId\` field.\\"\\"\\"
+  """Filter by the object’s \`unfilterableId\` field."""
   unfilterableId: IntFilter
 }
 
-\\"\\"\\"A connection to a list of \`ChildNoRelatedFilter\` values.\\"\\"\\"
+"""A connection to a list of \`ChildNoRelatedFilter\` values."""
 type ChildNoRelatedFiltersConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`ChildNoRelatedFilter\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [ChildNoRelatedFiltersEdge!]!
 
-  \\"\\"\\"A list of \`ChildNoRelatedFilter\` objects.\\"\\"\\"
+  """A list of \`ChildNoRelatedFilter\` objects."""
   nodes: [ChildNoRelatedFilter]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"
+  """
   The count of *all* \`ChildNoRelatedFilter\` you could get from the connection.
-  \\"\\"\\"
+  """
   totalCount: Int!
 }
 
-\\"\\"\\"A \`ChildNoRelatedFilter\` edge in the connection.\\"\\"\\"
+"""A \`ChildNoRelatedFilter\` edge in the connection."""
 type ChildNoRelatedFiltersEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`ChildNoRelatedFilter\` at the end of the edge.\\"\\"\\"
+  """The \`ChildNoRelatedFilter\` at the end of the edge."""
   node: ChildNoRelatedFilter
 }
 
-\\"\\"\\"Methods to use when ordering \`ChildNoRelatedFilter\`.\\"\\"\\"
+"""Methods to use when ordering \`ChildNoRelatedFilter\`."""
 enum ChildNoRelatedFiltersOrderBy {
   FILTERABLE_ID_ASC
   FILTERABLE_ID_DESC
@@ -1388,33 +1388,33 @@ enum ChildNoRelatedFiltersOrderBy {
   UNFILTERABLE_ID_DESC
 }
 
-\\"\\"\\"A connection to a list of \`Child\` values.\\"\\"\\"
+"""A connection to a list of \`Child\` values."""
 type ChildrenConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`Child\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [ChildrenEdge!]!
 
-  \\"\\"\\"A list of \`Child\` objects.\\"\\"\\"
+  """A list of \`Child\` objects."""
   nodes: [Child]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`Child\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`Child\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`Child\` edge in the connection.\\"\\"\\"
+"""A \`Child\` edge in the connection."""
 type ChildrenEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`Child\` at the end of the edge.\\"\\"\\"
+  """The \`Child\` at the end of the edge."""
   node: Child
 }
 
-\\"\\"\\"Methods to use when ordering \`Child\`.\\"\\"\\"
+"""Methods to use when ordering \`Child\`."""
 enum ChildrenOrderBy {
   FILTERABLE_ID_ASC
   FILTERABLE_ID_DESC
@@ -1432,624 +1432,624 @@ type Composite {
   b: String
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`Composite\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input CompositeFilter {
-  \\"\\"\\"Filter by the object’s \`a\` field.\\"\\"\\"
+  """Filter by the object’s \`a\` field."""
   a: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`b\` field.\\"\\"\\"
+  """Filter by the object’s \`b\` field."""
   b: StringFilter
 }
 
-\\"\\"\\"A location in a connection that can be used for resuming pagination.\\"\\"\\"
+"""A location in a connection that can be used for resuming pagination."""
 scalar Cursor
 
-\\"\\"\\"The day, does not include a time.\\"\\"\\"
+"""The day, does not include a time."""
 scalar Date
 
 scalar DateDomain
 
-\\"\\"\\"
+"""
 A filter to be used against DateDomain fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input DateDomainFilter {
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: DateDomain
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: DateDomain
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: DateDomain
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: DateDomain
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [DateDomain!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: DateDomain
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: DateDomain
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: DateDomain
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: DateDomain
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [DateDomain!]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against Date fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input DateFilter {
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: Date
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: Date
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: Date
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: Date
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [Date!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: Date
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: Date
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: Date
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: Date
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [Date!]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against Date List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input DateListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: Date
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: Date
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: Date
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: Date
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: Date
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: Date
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [Date]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [Date]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [Date]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [Date]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [Date]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [Date]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [Date]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [Date]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [Date]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [Date]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [Date]
 }
 
-\\"\\"\\"A range of \`Date\`.\\"\\"\\"
+"""A range of \`Date\`."""
 type DateRange {
-  \\"\\"\\"The ending bound of our range.\\"\\"\\"
+  """The ending bound of our range."""
   end: DateRangeBound
 
-  \\"\\"\\"The starting bound of our range.\\"\\"\\"
+  """The starting bound of our range."""
   start: DateRangeBound
 }
 
-\\"\\"\\"
+"""
 The value at one end of a range. A range can either include this value, or not.
-\\"\\"\\"
+"""
 type DateRangeBound {
-  \\"\\"\\"Whether or not the value of this bound is included in the range.\\"\\"\\"
+  """Whether or not the value of this bound is included in the range."""
   inclusive: Boolean!
 
-  \\"\\"\\"The value at one end of our range.\\"\\"\\"
+  """The value at one end of our range."""
   value: Date!
 }
 
-\\"\\"\\"
+"""
 The value at one end of a range. A range can either include this value, or not.
-\\"\\"\\"
+"""
 input DateRangeBoundInput {
-  \\"\\"\\"Whether or not the value of this bound is included in the range.\\"\\"\\"
+  """Whether or not the value of this bound is included in the range."""
   inclusive: Boolean!
 
-  \\"\\"\\"The value at one end of our range.\\"\\"\\"
+  """The value at one end of our range."""
   value: Date!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against DateRange fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input DateRangeFilter {
-  \\"\\"\\"Adjacent to the specified range.\\"\\"\\"
+  """Adjacent to the specified range."""
   adjacentTo: DateRangeInput
 
-  \\"\\"\\"Contained by the specified range.\\"\\"\\"
+  """Contained by the specified range."""
   containedBy: DateRangeInput
 
-  \\"\\"\\"Contains the specified range.\\"\\"\\"
+  """Contains the specified range."""
   contains: DateRangeInput
 
-  \\"\\"\\"Contains the specified value.\\"\\"\\"
+  """Contains the specified value."""
   containsElement: Date
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: DateRangeInput
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: DateRangeInput
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: DateRangeInput
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: DateRangeInput
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [DateRangeInput!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: DateRangeInput
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: DateRangeInput
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: DateRangeInput
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: DateRangeInput
 
-  \\"\\"\\"Does not extend left of the specified range.\\"\\"\\"
+  """Does not extend left of the specified range."""
   notExtendsLeftOf: DateRangeInput
 
-  \\"\\"\\"Does not extend right of the specified range.\\"\\"\\"
+  """Does not extend right of the specified range."""
   notExtendsRightOf: DateRangeInput
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [DateRangeInput!]
 
-  \\"\\"\\"Overlaps the specified range.\\"\\"\\"
+  """Overlaps the specified range."""
   overlaps: DateRangeInput
 
-  \\"\\"\\"Strictly left of the specified range.\\"\\"\\"
+  """Strictly left of the specified range."""
   strictlyLeftOf: DateRangeInput
 
-  \\"\\"\\"Strictly right of the specified range.\\"\\"\\"
+  """Strictly right of the specified range."""
   strictlyRightOf: DateRangeInput
 }
 
-\\"\\"\\"A range of \`Date\`.\\"\\"\\"
+"""A range of \`Date\`."""
 input DateRangeInput {
-  \\"\\"\\"The ending bound of our range.\\"\\"\\"
+  """The ending bound of our range."""
   end: DateRangeBoundInput
 
-  \\"\\"\\"The starting bound of our range.\\"\\"\\"
+  """The starting bound of our range."""
   start: DateRangeBoundInput
 }
 
-\\"\\"\\"
+"""
 A filter to be used against DateRange List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input DateRangeListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: DateRangeInput
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: DateRangeInput
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: DateRangeInput
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: DateRangeInput
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: DateRangeInput
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: DateRangeInput
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [DateRangeInput]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [DateRangeInput]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [DateRangeInput]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [DateRangeInput]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [DateRangeInput]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [DateRangeInput]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [DateRangeInput]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [DateRangeInput]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [DateRangeInput]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [DateRangeInput]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [DateRangeInput]
 }
 
-\\"\\"\\"
+"""
 A point in time as described by the [ISO
 8601](https://en.wikipedia.org/wiki/ISO_8601) standard. May or may not include a timezone.
-\\"\\"\\"
+"""
 scalar Datetime
 
-\\"\\"\\"
+"""
 A filter to be used against Datetime fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input DatetimeFilter {
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: Datetime
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: Datetime
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: Datetime
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: Datetime
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [Datetime!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: Datetime
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: Datetime
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: Datetime
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: Datetime
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [Datetime!]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against Datetime List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input DatetimeListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: Datetime
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: Datetime
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: Datetime
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: Datetime
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: Datetime
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: Datetime
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [Datetime]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [Datetime]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [Datetime]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [Datetime]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [Datetime]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [Datetime]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [Datetime]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [Datetime]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [Datetime]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [Datetime]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [Datetime]
 }
 
-\\"\\"\\"A range of \`Datetime\`.\\"\\"\\"
+"""A range of \`Datetime\`."""
 type DatetimeRange {
-  \\"\\"\\"The ending bound of our range.\\"\\"\\"
+  """The ending bound of our range."""
   end: DatetimeRangeBound
 
-  \\"\\"\\"The starting bound of our range.\\"\\"\\"
+  """The starting bound of our range."""
   start: DatetimeRangeBound
 }
 
-\\"\\"\\"
+"""
 The value at one end of a range. A range can either include this value, or not.
-\\"\\"\\"
+"""
 type DatetimeRangeBound {
-  \\"\\"\\"Whether or not the value of this bound is included in the range.\\"\\"\\"
+  """Whether or not the value of this bound is included in the range."""
   inclusive: Boolean!
 
-  \\"\\"\\"The value at one end of our range.\\"\\"\\"
+  """The value at one end of our range."""
   value: Datetime!
 }
 
-\\"\\"\\"
+"""
 The value at one end of a range. A range can either include this value, or not.
-\\"\\"\\"
+"""
 input DatetimeRangeBoundInput {
-  \\"\\"\\"Whether or not the value of this bound is included in the range.\\"\\"\\"
+  """Whether or not the value of this bound is included in the range."""
   inclusive: Boolean!
 
-  \\"\\"\\"The value at one end of our range.\\"\\"\\"
+  """The value at one end of our range."""
   value: Datetime!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against DatetimeRange fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input DatetimeRangeFilter {
-  \\"\\"\\"Adjacent to the specified range.\\"\\"\\"
+  """Adjacent to the specified range."""
   adjacentTo: DatetimeRangeInput
 
-  \\"\\"\\"Contained by the specified range.\\"\\"\\"
+  """Contained by the specified range."""
   containedBy: DatetimeRangeInput
 
-  \\"\\"\\"Contains the specified range.\\"\\"\\"
+  """Contains the specified range."""
   contains: DatetimeRangeInput
 
-  \\"\\"\\"Contains the specified value.\\"\\"\\"
+  """Contains the specified value."""
   containsElement: Datetime
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: DatetimeRangeInput
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: DatetimeRangeInput
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: DatetimeRangeInput
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: DatetimeRangeInput
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [DatetimeRangeInput!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: DatetimeRangeInput
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: DatetimeRangeInput
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: DatetimeRangeInput
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: DatetimeRangeInput
 
-  \\"\\"\\"Does not extend left of the specified range.\\"\\"\\"
+  """Does not extend left of the specified range."""
   notExtendsLeftOf: DatetimeRangeInput
 
-  \\"\\"\\"Does not extend right of the specified range.\\"\\"\\"
+  """Does not extend right of the specified range."""
   notExtendsRightOf: DatetimeRangeInput
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [DatetimeRangeInput!]
 
-  \\"\\"\\"Overlaps the specified range.\\"\\"\\"
+  """Overlaps the specified range."""
   overlaps: DatetimeRangeInput
 
-  \\"\\"\\"Strictly left of the specified range.\\"\\"\\"
+  """Strictly left of the specified range."""
   strictlyLeftOf: DatetimeRangeInput
 
-  \\"\\"\\"Strictly right of the specified range.\\"\\"\\"
+  """Strictly right of the specified range."""
   strictlyRightOf: DatetimeRangeInput
 }
 
-\\"\\"\\"A range of \`Datetime\`.\\"\\"\\"
+"""A range of \`Datetime\`."""
 input DatetimeRangeInput {
-  \\"\\"\\"The ending bound of our range.\\"\\"\\"
+  """The ending bound of our range."""
   end: DatetimeRangeBoundInput
 
-  \\"\\"\\"The starting bound of our range.\\"\\"\\"
+  """The starting bound of our range."""
   start: DatetimeRangeBoundInput
 }
 
-\\"\\"\\"
+"""
 A filter to be used against DatetimeRange List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input DatetimeRangeListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: DatetimeRangeInput
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: DatetimeRangeInput
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: DatetimeRangeInput
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: DatetimeRangeInput
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: DatetimeRangeInput
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: DatetimeRangeInput
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [DatetimeRangeInput]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [DatetimeRangeInput]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [DatetimeRangeInput]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [DatetimeRangeInput]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [DatetimeRangeInput]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [DatetimeRangeInput]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [DatetimeRangeInput]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [DatetimeRangeInput]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [DatetimeRangeInput]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [DatetimeRangeInput]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [DatetimeRangeInput]
 }
 
@@ -2059,56 +2059,56 @@ type DomainType implements Node {
   id: Int!
   int4Domain: Int4Domain
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`DomainType\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input DomainTypeFilter {
-  \\"\\"\\"Filter by the object’s \`char4Domain\` field.\\"\\"\\"
+  """Filter by the object’s \`char4Domain\` field."""
   char4Domain: Char4DomainFilter
 
-  \\"\\"\\"Filter by the object’s \`dateDomain\` field.\\"\\"\\"
+  """Filter by the object’s \`dateDomain\` field."""
   dateDomain: DateDomainFilter
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`int4Domain\` field.\\"\\"\\"
+  """Filter by the object’s \`int4Domain\` field."""
   int4Domain: Int4DomainFilter
 }
 
-\\"\\"\\"A connection to a list of \`DomainType\` values.\\"\\"\\"
+"""A connection to a list of \`DomainType\` values."""
 type DomainTypesConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`DomainType\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [DomainTypesEdge!]!
 
-  \\"\\"\\"A list of \`DomainType\` objects.\\"\\"\\"
+  """A list of \`DomainType\` objects."""
   nodes: [DomainType]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`DomainType\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`DomainType\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`DomainType\` edge in the connection.\\"\\"\\"
+"""A \`DomainType\` edge in the connection."""
 type DomainTypesEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`DomainType\` at the end of the edge.\\"\\"\\"
+  """The \`DomainType\` at the end of the edge."""
   node: DomainType
 }
 
-\\"\\"\\"Methods to use when ordering \`DomainType\`.\\"\\"\\"
+"""Methods to use when ordering \`DomainType\`."""
 enum DomainTypesOrderBy {
   CHAR4_DOMAIN_ASC
   CHAR4_DOMAIN_DESC
@@ -2127,50 +2127,50 @@ type EnumArrayType implements Node {
   enumArray: [Mood]
   id: Int!
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`EnumArrayType\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input EnumArrayTypeFilter {
-  \\"\\"\\"Filter by the object’s \`enumArray\` field.\\"\\"\\"
+  """Filter by the object’s \`enumArray\` field."""
   enumArray: MoodListFilter
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 }
 
-\\"\\"\\"A connection to a list of \`EnumArrayType\` values.\\"\\"\\"
+"""A connection to a list of \`EnumArrayType\` values."""
 type EnumArrayTypesConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`EnumArrayType\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [EnumArrayTypesEdge!]!
 
-  \\"\\"\\"A list of \`EnumArrayType\` objects.\\"\\"\\"
+  """A list of \`EnumArrayType\` objects."""
   nodes: [EnumArrayType]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`EnumArrayType\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`EnumArrayType\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`EnumArrayType\` edge in the connection.\\"\\"\\"
+"""A \`EnumArrayType\` edge in the connection."""
 type EnumArrayTypesEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`EnumArrayType\` at the end of the edge.\\"\\"\\"
+  """The \`EnumArrayType\` at the end of the edge."""
   node: EnumArrayType
 }
 
-\\"\\"\\"Methods to use when ordering \`EnumArrayType\`.\\"\\"\\"
+"""Methods to use when ordering \`EnumArrayType\`."""
 enum EnumArrayTypesOrderBy {
   ENUM_ARRAY_ASC
   ENUM_ARRAY_DESC
@@ -2185,50 +2185,50 @@ type EnumType implements Node {
   enum: Mood
   id: Int!
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`EnumType\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input EnumTypeFilter {
-  \\"\\"\\"Filter by the object’s \`enum\` field.\\"\\"\\"
+  """Filter by the object’s \`enum\` field."""
   enum: MoodFilter
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 }
 
-\\"\\"\\"A connection to a list of \`EnumType\` values.\\"\\"\\"
+"""A connection to a list of \`EnumType\` values."""
 type EnumTypesConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`EnumType\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [EnumTypesEdge!]!
 
-  \\"\\"\\"A list of \`EnumType\` objects.\\"\\"\\"
+  """A list of \`EnumType\` objects."""
   nodes: [EnumType]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`EnumType\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`EnumType\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`EnumType\` edge in the connection.\\"\\"\\"
+"""A \`EnumType\` edge in the connection."""
 type EnumTypesEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`EnumType\` at the end of the edge.\\"\\"\\"
+  """The \`EnumType\` at the end of the edge."""
   node: EnumType
 }
 
-\\"\\"\\"Methods to use when ordering \`EnumType\`.\\"\\"\\"
+"""Methods to use when ordering \`EnumType\`."""
 enum EnumTypesOrderBy {
   ENUM_ASC
   ENUM_DESC
@@ -2240,14 +2240,14 @@ enum EnumTypesOrderBy {
 }
 
 type Filterable implements Node {
-  \\"\\"\\"Reads a single \`Backward\` that is related to this \`Filterable\`.\\"\\"\\"
+  """Reads a single \`Backward\` that is related to this \`Filterable\`."""
   backwardByFilterableId: Backward
   backwardCompound1: Int
   backwardCompound2: Int
 
-  \\"\\"\\"
+  """
   Reads a single \`BackwardCompound\` that is related to this \`Filterable\`.
-  \\"\\"\\"
+  """
   backwardCompoundByBackwardCompound1AndBackwardCompound2: BackwardCompound
   bit4: BitString
   bool: Boolean
@@ -2255,61 +2255,61 @@ type Filterable implements Node {
   bytea: String
   char4: String
 
-  \\"\\"\\"Reads and enables pagination through a set of \`ChildNoRelatedFilter\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`ChildNoRelatedFilter\`."""
   childNoRelatedFiltersByFilterableId(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: ChildNoRelatedFilterFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`ChildNoRelatedFilter\`.\\"\\"\\"
+    """The method to use when ordering \`ChildNoRelatedFilter\`."""
     orderBy: [ChildNoRelatedFiltersOrderBy!] = [PRIMARY_KEY_ASC]
   ): ChildNoRelatedFiltersConnection!
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Child\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Child\`."""
   childrenByFilterableId(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: ChildFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`Child\`.\\"\\"\\"
+    """The method to use when ordering \`Child\`."""
     orderBy: [ChildrenOrderBy!] = [PRIMARY_KEY_ASC]
   ): ChildrenConnection!
   cidr: String
@@ -2320,126 +2320,126 @@ type Filterable implements Node {
   computedChild: Child
   computedIntArray: [Int]
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Child\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Child\`."""
   computedSetofChild(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: ChildFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
   ): ChildrenConnection!
   computedSetofInt(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: IntFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
   ): FilterableComputedSetofIntConnection!
   computedTaggedFilterable: Int
   computedWithRequiredArg(i: Int!): Int
   date: Date
 
-  \\"\\"\\"Reads and enables pagination through a set of \`FilterableClosure\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`FilterableClosure\`."""
   filterableClosuresByAncestorId(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: FilterableClosureFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`FilterableClosure\`.\\"\\"\\"
+    """The method to use when ordering \`FilterableClosure\`."""
     orderBy: [FilterableClosuresOrderBy!] = [PRIMARY_KEY_ASC]
   ): FilterableClosuresConnection!
 
-  \\"\\"\\"Reads and enables pagination through a set of \`FilterableClosure\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`FilterableClosure\`."""
   filterableClosuresByDescendantId(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: FilterableClosureFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`FilterableClosure\`.\\"\\"\\"
+    """The method to use when ordering \`FilterableClosure\`."""
     orderBy: [FilterableClosuresOrderBy!] = [PRIMARY_KEY_ASC]
   ): FilterableClosuresConnection!
   float4: Float
   float8: Float
 
-  \\"\\"\\"Reads a single \`Forward\` that is related to this \`Filterable\`.\\"\\"\\"
+  """Reads a single \`Forward\` that is related to this \`Filterable\`."""
   forwardByForwardId: Forward
   forwardColumn: Forward
   forwardCompound1: Int
   forwardCompound2: Int
 
-  \\"\\"\\"Reads a single \`ForwardCompound\` that is related to this \`Filterable\`.\\"\\"\\"
+  """Reads a single \`ForwardCompound\` that is related to this \`Filterable\`."""
   forwardCompoundByForwardCompound1AndForwardCompound2: ForwardCompound
   forwardId: Int
   hstore: KeyValueHash
@@ -2455,13 +2455,13 @@ type Filterable implements Node {
   money: Float
   name: String
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
   numeric: BigFloat
 
-  \\"\\"\\"Reads a single \`Parent\` that is related to this \`Filterable\`.\\"\\"\\"
+  """Reads a single \`Parent\` that is related to this \`Filterable\`."""
   parentByParentId: Parent
   parentId: Int
   text: String
@@ -2481,69 +2481,69 @@ type FilterableClosure implements Node {
   depth: Int!
   descendantId: Int!
 
-  \\"\\"\\"
+  """
   Reads a single \`Filterable\` that is related to this \`FilterableClosure\`.
-  \\"\\"\\"
+  """
   filterableByAncestorId: Filterable
 
-  \\"\\"\\"
+  """
   Reads a single \`Filterable\` that is related to this \`FilterableClosure\`.
-  \\"\\"\\"
+  """
   filterableByDescendantId: Filterable
   id: Int!
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`FilterableClosure\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input FilterableClosureFilter {
-  \\"\\"\\"Filter by the object’s \`ancestorId\` field.\\"\\"\\"
+  """Filter by the object’s \`ancestorId\` field."""
   ancestorId: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`depth\` field.\\"\\"\\"
+  """Filter by the object’s \`depth\` field."""
   depth: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`descendantId\` field.\\"\\"\\"
+  """Filter by the object’s \`descendantId\` field."""
   descendantId: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 }
 
-\\"\\"\\"A connection to a list of \`FilterableClosure\` values.\\"\\"\\"
+"""A connection to a list of \`FilterableClosure\` values."""
 type FilterableClosuresConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`FilterableClosure\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [FilterableClosuresEdge!]!
 
-  \\"\\"\\"A list of \`FilterableClosure\` objects.\\"\\"\\"
+  """A list of \`FilterableClosure\` objects."""
   nodes: [FilterableClosure]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"
+  """
   The count of *all* \`FilterableClosure\` you could get from the connection.
-  \\"\\"\\"
+  """
   totalCount: Int!
 }
 
-\\"\\"\\"A \`FilterableClosure\` edge in the connection.\\"\\"\\"
+"""A \`FilterableClosure\` edge in the connection."""
 type FilterableClosuresEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`FilterableClosure\` at the end of the edge.\\"\\"\\"
+  """The \`FilterableClosure\` at the end of the edge."""
   node: FilterableClosure
 }
 
-\\"\\"\\"Methods to use when ordering \`FilterableClosure\`.\\"\\"\\"
+"""Methods to use when ordering \`FilterableClosure\`."""
 enum FilterableClosuresOrderBy {
   ANCESTOR_ID_ASC
   ANCESTOR_ID_DESC
@@ -2558,172 +2558,172 @@ enum FilterableClosuresOrderBy {
   PRIMARY_KEY_DESC
 }
 
-\\"\\"\\"A connection to a list of \`Int\` values.\\"\\"\\"
+"""A connection to a list of \`Int\` values."""
 type FilterableComputedSetofIntConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`Int\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [FilterableComputedSetofIntEdge!]!
 
-  \\"\\"\\"A list of \`Int\` objects.\\"\\"\\"
+  """A list of \`Int\` objects."""
   nodes: [Int]!
 
-  \\"\\"\\"The count of *all* \`Int\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`Int\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`Int\` edge in the connection.\\"\\"\\"
+"""A \`Int\` edge in the connection."""
 type FilterableComputedSetofIntEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`Int\` at the end of the edge.\\"\\"\\"
+  """The \`Int\` at the end of the edge."""
   node: Int
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`Filterable\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input FilterableFilter {
-  \\"\\"\\"Filter by the object’s \`backwardCompound1\` field.\\"\\"\\"
+  """Filter by the object’s \`backwardCompound1\` field."""
   backwardCompound1: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`backwardCompound2\` field.\\"\\"\\"
+  """Filter by the object’s \`backwardCompound2\` field."""
   backwardCompound2: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`bit4\` field.\\"\\"\\"
+  """Filter by the object’s \`bit4\` field."""
   bit4: BitStringFilter
 
-  \\"\\"\\"Filter by the object’s \`bool\` field.\\"\\"\\"
+  """Filter by the object’s \`bool\` field."""
   bool: BooleanFilter
 
-  \\"\\"\\"Filter by the object’s \`bpchar4\` field.\\"\\"\\"
+  """Filter by the object’s \`bpchar4\` field."""
   bpchar4: StringFilter
 
-  \\"\\"\\"Filter by the object’s \`char4\` field.\\"\\"\\"
+  """Filter by the object’s \`char4\` field."""
   char4: StringFilter
 
-  \\"\\"\\"Filter by the object’s \`citext\` field.\\"\\"\\"
+  """Filter by the object’s \`citext\` field."""
   citext: StringFilter
 
-  \\"\\"\\"Filter by the object’s \`compositeColumn\` field.\\"\\"\\"
+  """Filter by the object’s \`compositeColumn\` field."""
   compositeColumn: CompositeFilter
 
-  \\"\\"\\"Filter by the object’s \`computed\` field.\\"\\"\\"
+  """Filter by the object’s \`computed\` field."""
   computed: StringFilter
 
-  \\"\\"\\"Filter by the object’s \`computedIntArray\` field.\\"\\"\\"
+  """Filter by the object’s \`computedIntArray\` field."""
   computedIntArray: IntListFilter
 
-  \\"\\"\\"Filter by the object’s \`computedTaggedFilterable\` field.\\"\\"\\"
+  """Filter by the object’s \`computedTaggedFilterable\` field."""
   computedTaggedFilterable: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`date\` field.\\"\\"\\"
+  """Filter by the object’s \`date\` field."""
   date: DateFilter
 
-  \\"\\"\\"Filter by the object’s \`float4\` field.\\"\\"\\"
+  """Filter by the object’s \`float4\` field."""
   float4: FloatFilter
 
-  \\"\\"\\"Filter by the object’s \`float8\` field.\\"\\"\\"
+  """Filter by the object’s \`float8\` field."""
   float8: FloatFilter
 
-  \\"\\"\\"Filter by the object’s \`forwardCompound1\` field.\\"\\"\\"
+  """Filter by the object’s \`forwardCompound1\` field."""
   forwardCompound1: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`forwardCompound2\` field.\\"\\"\\"
+  """Filter by the object’s \`forwardCompound2\` field."""
   forwardCompound2: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`forwardId\` field.\\"\\"\\"
+  """Filter by the object’s \`forwardId\` field."""
   forwardId: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`hstore\` field.\\"\\"\\"
+  """Filter by the object’s \`hstore\` field."""
   hstore: KeyValueHashFilter
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`inet\` field.\\"\\"\\"
+  """Filter by the object’s \`inet\` field."""
   inet: InternetAddressFilter
 
-  \\"\\"\\"Filter by the object’s \`int2\` field.\\"\\"\\"
+  """Filter by the object’s \`int2\` field."""
   int2: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`int4\` field.\\"\\"\\"
+  """Filter by the object’s \`int4\` field."""
   int4: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`int8\` field.\\"\\"\\"
+  """Filter by the object’s \`int8\` field."""
   int8: BigIntFilter
 
-  \\"\\"\\"Filter by the object’s \`interval\` field.\\"\\"\\"
+  """Filter by the object’s \`interval\` field."""
   interval: IntervalFilter
 
-  \\"\\"\\"Filter by the object’s \`jsonb\` field.\\"\\"\\"
+  """Filter by the object’s \`jsonb\` field."""
   jsonb: JSONFilter
 
-  \\"\\"\\"Filter by the object’s \`money\` field.\\"\\"\\"
+  """Filter by the object’s \`money\` field."""
   money: FloatFilter
 
-  \\"\\"\\"Filter by the object’s \`name\` field.\\"\\"\\"
+  """Filter by the object’s \`name\` field."""
   name: StringFilter
 
-  \\"\\"\\"Filter by the object’s \`numeric\` field.\\"\\"\\"
+  """Filter by the object’s \`numeric\` field."""
   numeric: BigFloatFilter
 
-  \\"\\"\\"Filter by the object’s \`parentId\` field.\\"\\"\\"
+  """Filter by the object’s \`parentId\` field."""
   parentId: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`text\` field.\\"\\"\\"
+  """Filter by the object’s \`text\` field."""
   text: StringFilter
 
-  \\"\\"\\"Filter by the object’s \`time\` field.\\"\\"\\"
+  """Filter by the object’s \`time\` field."""
   time: TimeFilter
 
-  \\"\\"\\"Filter by the object’s \`timestamp\` field.\\"\\"\\"
+  """Filter by the object’s \`timestamp\` field."""
   timestamp: DatetimeFilter
 
-  \\"\\"\\"Filter by the object’s \`timestamptz\` field.\\"\\"\\"
+  """Filter by the object’s \`timestamptz\` field."""
   timestamptz: DatetimeFilter
 
-  \\"\\"\\"Filter by the object’s \`timetz\` field.\\"\\"\\"
+  """Filter by the object’s \`timetz\` field."""
   timetz: TimeFilter
 
-  \\"\\"\\"Filter by the object’s \`uuid\` field.\\"\\"\\"
+  """Filter by the object’s \`uuid\` field."""
   uuid: UUIDFilter
 
-  \\"\\"\\"Filter by the object’s \`varbit\` field.\\"\\"\\"
+  """Filter by the object’s \`varbit\` field."""
   varbit: BitStringFilter
 
-  \\"\\"\\"Filter by the object’s \`varchar\` field.\\"\\"\\"
+  """Filter by the object’s \`varchar\` field."""
   varchar: StringFilter
 }
 
-\\"\\"\\"A connection to a list of \`Filterable\` values.\\"\\"\\"
+"""A connection to a list of \`Filterable\` values."""
 type FilterablesConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`Filterable\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [FilterablesEdge!]!
 
-  \\"\\"\\"A list of \`Filterable\` objects.\\"\\"\\"
+  """A list of \`Filterable\` objects."""
   nodes: [Filterable]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`Filterable\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`Filterable\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`Filterable\` edge in the connection.\\"\\"\\"
+"""A \`Filterable\` edge in the connection."""
 type FilterablesEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`Filterable\` at the end of the edge.\\"\\"\\"
+  """The \`Filterable\` at the end of the edge."""
   node: Filterable
 }
 
-\\"\\"\\"Methods to use when ordering \`Filterable\`.\\"\\"\\"
+"""Methods to use when ordering \`Filterable\`."""
 enum FilterablesOrderBy {
   BACKWARD_COMPOUND_1_ASC
   BACKWARD_COMPOUND_1_DESC
@@ -2812,179 +2812,179 @@ enum FilterablesOrderBy {
   XML_DESC
 }
 
-\\"\\"\\"
+"""
 A filter to be used against Float fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input FloatFilter {
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: Float
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: Float
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: Float
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: Float
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [Float!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: Float
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: Float
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: Float
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: Float
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [Float!]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against Float List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input FloatListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: Float
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: Float
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: Float
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: Float
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: Float
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: Float
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [Float]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [Float]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [Float]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [Float]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [Float]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [Float]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [Float]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [Float]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [Float]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [Float]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [Float]
 }
 
 type Forward implements Node {
-  \\"\\"\\"Reads a single \`Filterable\` that is related to this \`Forward\`.\\"\\"\\"
+  """Reads a single \`Filterable\` that is related to this \`Forward\`."""
   filterableByForwardId: Filterable
   id: Int!
   name: String!
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
 type ForwardCompound implements Node {
-  \\"\\"\\"Reads a single \`Filterable\` that is related to this \`ForwardCompound\`.\\"\\"\\"
+  """Reads a single \`Filterable\` that is related to this \`ForwardCompound\`."""
   filterableByForwardCompound1AndForwardCompound2: Filterable
   forwardCompound1: Int!
   forwardCompound2: Int!
   name: String
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`ForwardCompound\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input ForwardCompoundFilter {
-  \\"\\"\\"Filter by the object’s \`forwardCompound1\` field.\\"\\"\\"
+  """Filter by the object’s \`forwardCompound1\` field."""
   forwardCompound1: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`forwardCompound2\` field.\\"\\"\\"
+  """Filter by the object’s \`forwardCompound2\` field."""
   forwardCompound2: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`name\` field.\\"\\"\\"
+  """Filter by the object’s \`name\` field."""
   name: StringFilter
 }
 
-\\"\\"\\"A connection to a list of \`ForwardCompound\` values.\\"\\"\\"
+"""A connection to a list of \`ForwardCompound\` values."""
 type ForwardCompoundsConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`ForwardCompound\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [ForwardCompoundsEdge!]!
 
-  \\"\\"\\"A list of \`ForwardCompound\` objects.\\"\\"\\"
+  """A list of \`ForwardCompound\` objects."""
   nodes: [ForwardCompound]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"
+  """
   The count of *all* \`ForwardCompound\` you could get from the connection.
-  \\"\\"\\"
+  """
   totalCount: Int!
 }
 
-\\"\\"\\"A \`ForwardCompound\` edge in the connection.\\"\\"\\"
+"""A \`ForwardCompound\` edge in the connection."""
 type ForwardCompoundsEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`ForwardCompound\` at the end of the edge.\\"\\"\\"
+  """The \`ForwardCompound\` at the end of the edge."""
   node: ForwardCompound
 }
 
-\\"\\"\\"Methods to use when ordering \`ForwardCompound\`.\\"\\"\\"
+"""Methods to use when ordering \`ForwardCompound\`."""
 enum ForwardCompoundsOrderBy {
   FORWARD_COMPOUND_1_ASC
   FORWARD_COMPOUND_1_DESC
@@ -2997,44 +2997,44 @@ enum ForwardCompoundsOrderBy {
   PRIMARY_KEY_DESC
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`Forward\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input ForwardFilter {
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`name\` field.\\"\\"\\"
+  """Filter by the object’s \`name\` field."""
   name: StringFilter
 }
 
-\\"\\"\\"A connection to a list of \`Forward\` values.\\"\\"\\"
+"""A connection to a list of \`Forward\` values."""
 type ForwardsConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`Forward\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [ForwardsEdge!]!
 
-  \\"\\"\\"A list of \`Forward\` objects.\\"\\"\\"
+  """A list of \`Forward\` objects."""
   nodes: [Forward]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`Forward\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`Forward\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`Forward\` edge in the connection.\\"\\"\\"
+"""A \`Forward\` edge in the connection."""
 type ForwardsEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`Forward\` at the end of the edge.\\"\\"\\"
+  """The \`Forward\` at the end of the edge."""
   node: Forward
 }
 
-\\"\\"\\"Methods to use when ordering \`Forward\`.\\"\\"\\"
+"""Methods to use when ordering \`Forward\`."""
 enum ForwardsOrderBy {
   ID_ASC
   ID_DESC
@@ -3048,40 +3048,40 @@ enum ForwardsOrderBy {
 type FullyOmitted implements Node {
   id: Int!
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
   text: String
 }
 
-\\"\\"\\"A connection to a list of \`FullyOmitted\` values.\\"\\"\\"
+"""A connection to a list of \`FullyOmitted\` values."""
 type FullyOmittedsConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`FullyOmitted\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [FullyOmittedsEdge!]!
 
-  \\"\\"\\"A list of \`FullyOmitted\` objects.\\"\\"\\"
+  """A list of \`FullyOmitted\` objects."""
   nodes: [FullyOmitted]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`FullyOmitted\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`FullyOmitted\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`FullyOmitted\` edge in the connection.\\"\\"\\"
+"""A \`FullyOmitted\` edge in the connection."""
 type FullyOmittedsEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`FullyOmitted\` at the end of the edge.\\"\\"\\"
+  """The \`FullyOmitted\` at the end of the edge."""
   node: FullyOmitted
 }
 
-\\"\\"\\"Methods to use when ordering \`FullyOmitted\`.\\"\\"\\"
+"""Methods to use when ordering \`FullyOmitted\`."""
 enum FullyOmittedsOrderBy {
   ID_ASC
   ID_DESC
@@ -3092,728 +3092,728 @@ enum FullyOmittedsOrderBy {
   TEXT_DESC
 }
 
-\\"\\"\\"A connection to a list of \`FuncReturnsTableMultiColRecord\` values.\\"\\"\\"
+"""A connection to a list of \`FuncReturnsTableMultiColRecord\` values."""
 type FuncReturnsTableMultiColConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`FuncReturnsTableMultiColRecord\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [FuncReturnsTableMultiColEdge!]!
 
-  \\"\\"\\"A list of \`FuncReturnsTableMultiColRecord\` objects.\\"\\"\\"
+  """A list of \`FuncReturnsTableMultiColRecord\` objects."""
   nodes: [FuncReturnsTableMultiColRecord]!
 
-  \\"\\"\\"
+  """
   The count of *all* \`FuncReturnsTableMultiColRecord\` you could get from the connection.
-  \\"\\"\\"
+  """
   totalCount: Int!
 }
 
-\\"\\"\\"A \`FuncReturnsTableMultiColRecord\` edge in the connection.\\"\\"\\"
+"""A \`FuncReturnsTableMultiColRecord\` edge in the connection."""
 type FuncReturnsTableMultiColEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`FuncReturnsTableMultiColRecord\` at the end of the edge.\\"\\"\\"
+  """The \`FuncReturnsTableMultiColRecord\` at the end of the edge."""
   node: FuncReturnsTableMultiColRecord
 }
 
-\\"\\"\\"The return type of our \`funcReturnsTableMultiCol\` query.\\"\\"\\"
+"""The return type of our \`funcReturnsTableMultiCol\` query."""
 type FuncReturnsTableMultiColRecord {
   col1: Int
   col2: String
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`FuncReturnsTableMultiColRecord\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input FuncReturnsTableMultiColRecordFilter {
-  \\"\\"\\"Filter by the object’s \`col1\` field.\\"\\"\\"
+  """Filter by the object’s \`col1\` field."""
   col1: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`col2\` field.\\"\\"\\"
+  """Filter by the object’s \`col2\` field."""
   col2: StringFilter
 }
 
-\\"\\"\\"A connection to a list of \`Int\` values.\\"\\"\\"
+"""A connection to a list of \`Int\` values."""
 type FuncReturnsTableOneColConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`Int\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [FuncReturnsTableOneColEdge!]!
 
-  \\"\\"\\"A list of \`Int\` objects.\\"\\"\\"
+  """A list of \`Int\` objects."""
   nodes: [Int]!
 
-  \\"\\"\\"The count of *all* \`Int\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`Int\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`Int\` edge in the connection.\\"\\"\\"
+"""A \`Int\` edge in the connection."""
 type FuncReturnsTableOneColEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`Int\` at the end of the edge.\\"\\"\\"
+  """The \`Int\` at the end of the edge."""
   node: Int
 }
 
-\\"\\"\\"
+"""
 A connection to a list of \`FuncTaggedFilterableReturnsTableMultiColRecord\` values.
-\\"\\"\\"
+"""
 type FuncTaggedFilterableReturnsTableMultiColConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`FuncTaggedFilterableReturnsTableMultiColRecord\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [FuncTaggedFilterableReturnsTableMultiColEdge!]!
 
-  \\"\\"\\"A list of \`FuncTaggedFilterableReturnsTableMultiColRecord\` objects.\\"\\"\\"
+  """A list of \`FuncTaggedFilterableReturnsTableMultiColRecord\` objects."""
   nodes: [FuncTaggedFilterableReturnsTableMultiColRecord]!
 
-  \\"\\"\\"
+  """
   The count of *all* \`FuncTaggedFilterableReturnsTableMultiColRecord\` you could get from the connection.
-  \\"\\"\\"
+  """
   totalCount: Int!
 }
 
-\\"\\"\\"
+"""
 A \`FuncTaggedFilterableReturnsTableMultiColRecord\` edge in the connection.
-\\"\\"\\"
+"""
 type FuncTaggedFilterableReturnsTableMultiColEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"
+  """
   The \`FuncTaggedFilterableReturnsTableMultiColRecord\` at the end of the edge.
-  \\"\\"\\"
+  """
   node: FuncTaggedFilterableReturnsTableMultiColRecord
 }
 
-\\"\\"\\"
+"""
 The return type of our \`funcTaggedFilterableReturnsTableMultiCol\` query.
-\\"\\"\\"
+"""
 type FuncTaggedFilterableReturnsTableMultiColRecord {
   col1: Int
   col2: String
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`FuncTaggedFilterableReturnsTableMultiColRecord\`
 object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input FuncTaggedFilterableReturnsTableMultiColRecordFilter {
-  \\"\\"\\"Filter by the object’s \`col1\` field.\\"\\"\\"
+  """Filter by the object’s \`col1\` field."""
   col1: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`col2\` field.\\"\\"\\"
+  """Filter by the object’s \`col2\` field."""
   col2: StringFilter
 }
 
 scalar Int4Domain
 
-\\"\\"\\"
+"""
 A filter to be used against Int4Domain fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input Int4DomainFilter {
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: Int4Domain
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: Int4Domain
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: Int4Domain
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: Int4Domain
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [Int4Domain!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: Int4Domain
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: Int4Domain
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: Int4Domain
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: Int4Domain
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [Int4Domain!]
 }
 
-\\"\\"\\"An IPv4 or IPv6 host address, and optionally its subnet.\\"\\"\\"
+"""An IPv4 or IPv6 host address, and optionally its subnet."""
 scalar InternetAddress
 
-\\"\\"\\"
+"""
 A filter to be used against InternetAddress fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input InternetAddressFilter {
-  \\"\\"\\"Contained by the specified internet address.\\"\\"\\"
+  """Contained by the specified internet address."""
   containedBy: InternetAddress
 
-  \\"\\"\\"Contained by or equal to the specified internet address.\\"\\"\\"
+  """Contained by or equal to the specified internet address."""
   containedByOrEqualTo: InternetAddress
 
-  \\"\\"\\"Contains the specified internet address.\\"\\"\\"
+  """Contains the specified internet address."""
   contains: InternetAddress
 
-  \\"\\"\\"Contains or contained by the specified internet address.\\"\\"\\"
+  """Contains or contained by the specified internet address."""
   containsOrContainedBy: InternetAddress
 
-  \\"\\"\\"Contains or equal to the specified internet address.\\"\\"\\"
+  """Contains or equal to the specified internet address."""
   containsOrEqualTo: InternetAddress
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: InternetAddress
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: InternetAddress
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: InternetAddress
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: InternetAddress
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [InternetAddress!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: InternetAddress
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: InternetAddress
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: InternetAddress
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: InternetAddress
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [InternetAddress!]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against InternetAddress List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input InternetAddressListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: InternetAddress
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: InternetAddress
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: InternetAddress
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: InternetAddress
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: InternetAddress
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: InternetAddress
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [InternetAddress]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [InternetAddress]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [InternetAddress]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [InternetAddress]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [InternetAddress]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [InternetAddress]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [InternetAddress]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [InternetAddress]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [InternetAddress]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [InternetAddress]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [InternetAddress]
 }
 
-\\"\\"\\"
+"""
 An interval of time that has passed where the smallest distinct unit is a second.
-\\"\\"\\"
+"""
 type Interval {
-  \\"\\"\\"A quantity of days.\\"\\"\\"
+  """A quantity of days."""
   days: Int
 
-  \\"\\"\\"A quantity of hours.\\"\\"\\"
+  """A quantity of hours."""
   hours: Int
 
-  \\"\\"\\"A quantity of minutes.\\"\\"\\"
+  """A quantity of minutes."""
   minutes: Int
 
-  \\"\\"\\"A quantity of months.\\"\\"\\"
+  """A quantity of months."""
   months: Int
 
-  \\"\\"\\"
+  """
   A quantity of seconds. This is the only non-integer field, as all the other
   fields will dump their overflow into a smaller unit of time. Intervals don’t
   have a smaller unit than seconds.
-  \\"\\"\\"
+  """
   seconds: Float
 
-  \\"\\"\\"A quantity of years.\\"\\"\\"
+  """A quantity of years."""
   years: Int
 }
 
-\\"\\"\\"
+"""
 A filter to be used against Interval fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input IntervalFilter {
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: IntervalInput
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: IntervalInput
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: IntervalInput
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: IntervalInput
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [IntervalInput!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: IntervalInput
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: IntervalInput
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: IntervalInput
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: IntervalInput
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [IntervalInput!]
 }
 
-\\"\\"\\"
+"""
 An interval of time that has passed where the smallest distinct unit is a second.
-\\"\\"\\"
+"""
 input IntervalInput {
-  \\"\\"\\"A quantity of days.\\"\\"\\"
+  """A quantity of days."""
   days: Int
 
-  \\"\\"\\"A quantity of hours.\\"\\"\\"
+  """A quantity of hours."""
   hours: Int
 
-  \\"\\"\\"A quantity of minutes.\\"\\"\\"
+  """A quantity of minutes."""
   minutes: Int
 
-  \\"\\"\\"A quantity of months.\\"\\"\\"
+  """A quantity of months."""
   months: Int
 
-  \\"\\"\\"
+  """
   A quantity of seconds. This is the only non-integer field, as all the other
   fields will dump their overflow into a smaller unit of time. Intervals don’t
   have a smaller unit than seconds.
-  \\"\\"\\"
+  """
   seconds: Float
 
-  \\"\\"\\"A quantity of years.\\"\\"\\"
+  """A quantity of years."""
   years: Int
 }
 
-\\"\\"\\"
+"""
 A filter to be used against Interval List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input IntervalListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: IntervalInput
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: IntervalInput
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: IntervalInput
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: IntervalInput
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: IntervalInput
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: IntervalInput
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [IntervalInput]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [IntervalInput]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [IntervalInput]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [IntervalInput]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [IntervalInput]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [IntervalInput]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [IntervalInput]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [IntervalInput]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [IntervalInput]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [IntervalInput]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [IntervalInput]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against Int fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input IntFilter {
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: Int
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: Int
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: Int
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: Int
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [Int!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: Int
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: Int
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: Int
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: Int
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [Int!]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against Int List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input IntListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: Int
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: Int
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: Int
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: Int
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: Int
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: Int
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [Int]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [Int]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [Int]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [Int]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [Int]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [Int]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [Int]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [Int]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [Int]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [Int]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [Int]
 }
 
-\\"\\"\\"A range of \`Int\`.\\"\\"\\"
+"""A range of \`Int\`."""
 type IntRange {
-  \\"\\"\\"The ending bound of our range.\\"\\"\\"
+  """The ending bound of our range."""
   end: IntRangeBound
 
-  \\"\\"\\"The starting bound of our range.\\"\\"\\"
+  """The starting bound of our range."""
   start: IntRangeBound
 }
 
-\\"\\"\\"
+"""
 The value at one end of a range. A range can either include this value, or not.
-\\"\\"\\"
+"""
 type IntRangeBound {
-  \\"\\"\\"Whether or not the value of this bound is included in the range.\\"\\"\\"
+  """Whether or not the value of this bound is included in the range."""
   inclusive: Boolean!
 
-  \\"\\"\\"The value at one end of our range.\\"\\"\\"
+  """The value at one end of our range."""
   value: Int!
 }
 
-\\"\\"\\"
+"""
 The value at one end of a range. A range can either include this value, or not.
-\\"\\"\\"
+"""
 input IntRangeBoundInput {
-  \\"\\"\\"Whether or not the value of this bound is included in the range.\\"\\"\\"
+  """Whether or not the value of this bound is included in the range."""
   inclusive: Boolean!
 
-  \\"\\"\\"The value at one end of our range.\\"\\"\\"
+  """The value at one end of our range."""
   value: Int!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against IntRange fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input IntRangeFilter {
-  \\"\\"\\"Adjacent to the specified range.\\"\\"\\"
+  """Adjacent to the specified range."""
   adjacentTo: IntRangeInput
 
-  \\"\\"\\"Contained by the specified range.\\"\\"\\"
+  """Contained by the specified range."""
   containedBy: IntRangeInput
 
-  \\"\\"\\"Contains the specified range.\\"\\"\\"
+  """Contains the specified range."""
   contains: IntRangeInput
 
-  \\"\\"\\"Contains the specified value.\\"\\"\\"
+  """Contains the specified value."""
   containsElement: Int
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: IntRangeInput
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: IntRangeInput
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: IntRangeInput
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: IntRangeInput
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [IntRangeInput!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: IntRangeInput
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: IntRangeInput
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: IntRangeInput
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: IntRangeInput
 
-  \\"\\"\\"Does not extend left of the specified range.\\"\\"\\"
+  """Does not extend left of the specified range."""
   notExtendsLeftOf: IntRangeInput
 
-  \\"\\"\\"Does not extend right of the specified range.\\"\\"\\"
+  """Does not extend right of the specified range."""
   notExtendsRightOf: IntRangeInput
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [IntRangeInput!]
 
-  \\"\\"\\"Overlaps the specified range.\\"\\"\\"
+  """Overlaps the specified range."""
   overlaps: IntRangeInput
 
-  \\"\\"\\"Strictly left of the specified range.\\"\\"\\"
+  """Strictly left of the specified range."""
   strictlyLeftOf: IntRangeInput
 
-  \\"\\"\\"Strictly right of the specified range.\\"\\"\\"
+  """Strictly right of the specified range."""
   strictlyRightOf: IntRangeInput
 }
 
-\\"\\"\\"A range of \`Int\`.\\"\\"\\"
+"""A range of \`Int\`."""
 input IntRangeInput {
-  \\"\\"\\"The ending bound of our range.\\"\\"\\"
+  """The ending bound of our range."""
   end: IntRangeBoundInput
 
-  \\"\\"\\"The starting bound of our range.\\"\\"\\"
+  """The starting bound of our range."""
   start: IntRangeBoundInput
 }
 
-\\"\\"\\"
+"""
 A filter to be used against IntRange List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input IntRangeListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: IntRangeInput
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: IntRangeInput
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: IntRangeInput
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: IntRangeInput
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: IntRangeInput
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: IntRangeInput
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [IntRangeInput]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [IntRangeInput]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [IntRangeInput]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [IntRangeInput]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [IntRangeInput]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [IntRangeInput]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [IntRangeInput]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [IntRangeInput]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [IntRangeInput]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [IntRangeInput]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [IntRangeInput]
 }
 
-\\"\\"\\"
+"""
 A JavaScript object encoded in the JSON format as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf).
-\\"\\"\\"
+"""
 scalar JSON
 
 type JsonbTest implements Node {
@@ -3821,53 +3821,53 @@ type JsonbTest implements Node {
   jsonbWithArray: JSON
   jsonbWithObject: JSON
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`JsonbTest\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input JsonbTestFilter {
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`jsonbWithArray\` field.\\"\\"\\"
+  """Filter by the object’s \`jsonbWithArray\` field."""
   jsonbWithArray: JSONFilter
 
-  \\"\\"\\"Filter by the object’s \`jsonbWithObject\` field.\\"\\"\\"
+  """Filter by the object’s \`jsonbWithObject\` field."""
   jsonbWithObject: JSONFilter
 }
 
-\\"\\"\\"A connection to a list of \`JsonbTest\` values.\\"\\"\\"
+"""A connection to a list of \`JsonbTest\` values."""
 type JsonbTestsConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`JsonbTest\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [JsonbTestsEdge!]!
 
-  \\"\\"\\"A list of \`JsonbTest\` objects.\\"\\"\\"
+  """A list of \`JsonbTest\` objects."""
   nodes: [JsonbTest]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`JsonbTest\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`JsonbTest\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`JsonbTest\` edge in the connection.\\"\\"\\"
+"""A \`JsonbTest\` edge in the connection."""
 type JsonbTestsEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`JsonbTest\` at the end of the edge.\\"\\"\\"
+  """The \`JsonbTest\` at the end of the edge."""
   node: JsonbTest
 }
 
-\\"\\"\\"Methods to use when ordering \`JsonbTest\`.\\"\\"\\"
+"""Methods to use when ordering \`JsonbTest\`."""
 enum JsonbTestsOrderBy {
   ID_ASC
   ID_DESC
@@ -3880,179 +3880,179 @@ enum JsonbTestsOrderBy {
   PRIMARY_KEY_DESC
 }
 
-\\"\\"\\"
+"""
 A filter to be used against JSON fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input JSONFilter {
-  \\"\\"\\"Contained by the specified JSON.\\"\\"\\"
+  """Contained by the specified JSON."""
   containedBy: JSON
 
-  \\"\\"\\"Contains the specified JSON.\\"\\"\\"
+  """Contains the specified JSON."""
   contains: JSON
 
-  \\"\\"\\"Contains all of the specified keys.\\"\\"\\"
+  """Contains all of the specified keys."""
   containsAllKeys: [String!]
 
-  \\"\\"\\"Contains any of the specified keys.\\"\\"\\"
+  """Contains any of the specified keys."""
   containsAnyKeys: [String!]
 
-  \\"\\"\\"Contains the specified key.\\"\\"\\"
+  """Contains the specified key."""
   containsKey: String
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: JSON
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: JSON
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: JSON
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: JSON
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [JSON!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: JSON
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: JSON
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: JSON
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: JSON
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [JSON!]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against JSON List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input JSONListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: JSON
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: JSON
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: JSON
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: JSON
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: JSON
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: JSON
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [JSON]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [JSON]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [JSON]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [JSON]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [JSON]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [JSON]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [JSON]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [JSON]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [JSON]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [JSON]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [JSON]
 }
 
 type Junction implements Node {
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 
-  \\"\\"\\"Reads a single \`SideA\` that is related to this \`Junction\`.\\"\\"\\"
+  """Reads a single \`SideA\` that is related to this \`Junction\`."""
   sideABySideAId: SideA
   sideAId: Int!
 
-  \\"\\"\\"Reads a single \`SideB\` that is related to this \`Junction\`.\\"\\"\\"
+  """Reads a single \`SideB\` that is related to this \`Junction\`."""
   sideBBySideBId: SideB
   sideBId: Int!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`Junction\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input JunctionFilter {
-  \\"\\"\\"Filter by the object’s \`sideAId\` field.\\"\\"\\"
+  """Filter by the object’s \`sideAId\` field."""
   sideAId: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`sideBId\` field.\\"\\"\\"
+  """Filter by the object’s \`sideBId\` field."""
   sideBId: IntFilter
 }
 
-\\"\\"\\"A connection to a list of \`Junction\` values.\\"\\"\\"
+"""A connection to a list of \`Junction\` values."""
 type JunctionsConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`Junction\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [JunctionsEdge!]!
 
-  \\"\\"\\"A list of \`Junction\` objects.\\"\\"\\"
+  """A list of \`Junction\` objects."""
   nodes: [Junction]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`Junction\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`Junction\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`Junction\` edge in the connection.\\"\\"\\"
+"""A \`Junction\` edge in the connection."""
 type JunctionsEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`Junction\` at the end of the edge.\\"\\"\\"
+  """The \`Junction\` at the end of the edge."""
   node: Junction
 }
 
-\\"\\"\\"Methods to use when ordering \`Junction\`.\\"\\"\\"
+"""Methods to use when ordering \`Junction\`."""
 enum JunctionsOrderBy {
   NATURAL
   PRIMARY_KEY_ASC
@@ -4063,116 +4063,116 @@ enum JunctionsOrderBy {
   SIDE_B_ID_DESC
 }
 
-\\"\\"\\"
+"""
 A set of key/value pairs, keys are strings, values may be a string or null. Exposed as a JSON object.
-\\"\\"\\"
+"""
 scalar KeyValueHash
 
-\\"\\"\\"
+"""
 A filter to be used against KeyValueHash fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input KeyValueHashFilter {
-  \\"\\"\\"Contained by the specified KeyValueHash.\\"\\"\\"
+  """Contained by the specified KeyValueHash."""
   containedBy: KeyValueHash
 
-  \\"\\"\\"Contains the specified KeyValueHash.\\"\\"\\"
+  """Contains the specified KeyValueHash."""
   contains: KeyValueHash
 
-  \\"\\"\\"Contains all of the specified keys.\\"\\"\\"
+  """Contains all of the specified keys."""
   containsAllKeys: [String!]
 
-  \\"\\"\\"Contains any of the specified keys.\\"\\"\\"
+  """Contains any of the specified keys."""
   containsAnyKeys: [String!]
 
-  \\"\\"\\"Contains the specified key.\\"\\"\\"
+  """Contains the specified key."""
   containsKey: String
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: KeyValueHash
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: KeyValueHash
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [KeyValueHash!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: KeyValueHash
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: KeyValueHash
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [KeyValueHash!]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against KeyValueHash List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input KeyValueHashListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: KeyValueHash
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: KeyValueHash
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: KeyValueHash
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: KeyValueHash
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: KeyValueHash
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: KeyValueHash
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [KeyValueHash]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [KeyValueHash]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [KeyValueHash]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [KeyValueHash]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [KeyValueHash]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [KeyValueHash]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [KeyValueHash]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [KeyValueHash]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [KeyValueHash]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [KeyValueHash]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [KeyValueHash]
 }
 
@@ -4182,210 +4182,210 @@ enum Mood {
   SAD
 }
 
-\\"\\"\\"
+"""
 A filter to be used against Mood fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input MoodFilter {
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: Mood
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: Mood
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: Mood
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: Mood
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [Mood!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: Mood
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: Mood
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: Mood
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: Mood
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [Mood!]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against Mood List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input MoodListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: Mood
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: Mood
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: Mood
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: Mood
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: Mood
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: Mood
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [Mood]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [Mood]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [Mood]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [Mood]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [Mood]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [Mood]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [Mood]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [Mood]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [Mood]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [Mood]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [Mood]
 }
 
-\\"\\"\\"An object with a globally unique \`ID\`.\\"\\"\\"
+"""An object with a globally unique \`ID\`."""
 interface Node {
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
-\\"\\"\\"Information about pagination in a connection.\\"\\"\\"
+"""Information about pagination in a connection."""
 type PageInfo {
-  \\"\\"\\"When paginating forwards, the cursor to continue.\\"\\"\\"
+  """When paginating forwards, the cursor to continue."""
   endCursor: Cursor
 
-  \\"\\"\\"When paginating forwards, are there more items?\\"\\"\\"
+  """When paginating forwards, are there more items?"""
   hasNextPage: Boolean!
 
-  \\"\\"\\"When paginating backwards, are there more items?\\"\\"\\"
+  """When paginating backwards, are there more items?"""
   hasPreviousPage: Boolean!
 
-  \\"\\"\\"When paginating backwards, the cursor to continue.\\"\\"\\"
+  """When paginating backwards, the cursor to continue."""
   startCursor: Cursor
 }
 
 type Parent implements Node {
-  \\"\\"\\"Reads and enables pagination through a set of \`Filterable\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Filterable\`."""
   filterablesByParentId(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: FilterableFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`Filterable\`.\\"\\"\\"
+    """The method to use when ordering \`Filterable\`."""
     orderBy: [FilterablesOrderBy!] = [PRIMARY_KEY_ASC]
   ): FilterablesConnection!
   id: Int!
   name: String!
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`Parent\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input ParentFilter {
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`name\` field.\\"\\"\\"
+  """Filter by the object’s \`name\` field."""
   name: StringFilter
 }
 
-\\"\\"\\"A connection to a list of \`Parent\` values.\\"\\"\\"
+"""A connection to a list of \`Parent\` values."""
 type ParentsConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`Parent\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [ParentsEdge!]!
 
-  \\"\\"\\"A list of \`Parent\` objects.\\"\\"\\"
+  """A list of \`Parent\` objects."""
   nodes: [Parent]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`Parent\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`Parent\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`Parent\` edge in the connection.\\"\\"\\"
+"""A \`Parent\` edge in the connection."""
 type ParentsEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`Parent\` at the end of the edge.\\"\\"\\"
+  """The \`Parent\` at the end of the edge."""
   node: Parent
 }
 
-\\"\\"\\"Methods to use when ordering \`Parent\`.\\"\\"\\"
+"""Methods to use when ordering \`Parent\`."""
 enum ParentsOrderBy {
   ID_ASC
   ID_DESC
@@ -4400,695 +4400,695 @@ type Protected implements Node {
   id: Int!
   name: String
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
   otherId: Int
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`Protected\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input ProtectedFilter {
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`name\` field.\\"\\"\\"
+  """Filter by the object’s \`name\` field."""
   name: StringFilter
 
-  \\"\\"\\"Filter by the object’s \`otherId\` field.\\"\\"\\"
+  """Filter by the object’s \`otherId\` field."""
   otherId: IntFilter
 }
 
-\\"\\"\\"A connection to a list of \`Protected\` values.\\"\\"\\"
+"""A connection to a list of \`Protected\` values."""
 type ProtectedsConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`Protected\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [ProtectedsEdge!]!
 
-  \\"\\"\\"A list of \`Protected\` objects.\\"\\"\\"
+  """A list of \`Protected\` objects."""
   nodes: [Protected]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`Protected\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`Protected\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`Protected\` edge in the connection.\\"\\"\\"
+"""A \`Protected\` edge in the connection."""
 type ProtectedsEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`Protected\` at the end of the edge.\\"\\"\\"
+  """The \`Protected\` at the end of the edge."""
   node: Protected
 }
 
-\\"\\"\\"The root query type which gives access points into the data universe.\\"\\"\\"
+"""The root query type which gives access points into the data universe."""
 type Query implements Node {
-  \\"\\"\\"Reads and enables pagination through a set of \`ArrayType\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`ArrayType\`."""
   allArrayTypes(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: ArrayTypeFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`ArrayType\`.\\"\\"\\"
+    """The method to use when ordering \`ArrayType\`."""
     orderBy: [ArrayTypesOrderBy!] = [PRIMARY_KEY_ASC]
   ): ArrayTypesConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`BackwardCompound\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`BackwardCompound\`."""
   allBackwardCompounds(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: BackwardCompoundFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`BackwardCompound\`.\\"\\"\\"
+    """The method to use when ordering \`BackwardCompound\`."""
     orderBy: [BackwardCompoundsOrderBy!] = [PRIMARY_KEY_ASC]
   ): BackwardCompoundsConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Backward\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Backward\`."""
   allBackwards(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: BackwardFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`Backward\`.\\"\\"\\"
+    """The method to use when ordering \`Backward\`."""
     orderBy: [BackwardsOrderBy!] = [PRIMARY_KEY_ASC]
   ): BackwardsConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`ChildNoRelatedFilter\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`ChildNoRelatedFilter\`."""
   allChildNoRelatedFilters(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: ChildNoRelatedFilterFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`ChildNoRelatedFilter\`.\\"\\"\\"
+    """The method to use when ordering \`ChildNoRelatedFilter\`."""
     orderBy: [ChildNoRelatedFiltersOrderBy!] = [PRIMARY_KEY_ASC]
   ): ChildNoRelatedFiltersConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Child\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Child\`."""
   allChildren(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: ChildFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`Child\`.\\"\\"\\"
+    """The method to use when ordering \`Child\`."""
     orderBy: [ChildrenOrderBy!] = [PRIMARY_KEY_ASC]
   ): ChildrenConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`DomainType\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`DomainType\`."""
   allDomainTypes(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: DomainTypeFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`DomainType\`.\\"\\"\\"
+    """The method to use when ordering \`DomainType\`."""
     orderBy: [DomainTypesOrderBy!] = [PRIMARY_KEY_ASC]
   ): DomainTypesConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`EnumArrayType\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`EnumArrayType\`."""
   allEnumArrayTypes(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: EnumArrayTypeFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`EnumArrayType\`.\\"\\"\\"
+    """The method to use when ordering \`EnumArrayType\`."""
     orderBy: [EnumArrayTypesOrderBy!] = [PRIMARY_KEY_ASC]
   ): EnumArrayTypesConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`EnumType\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`EnumType\`."""
   allEnumTypes(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: EnumTypeFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`EnumType\`.\\"\\"\\"
+    """The method to use when ordering \`EnumType\`."""
     orderBy: [EnumTypesOrderBy!] = [PRIMARY_KEY_ASC]
   ): EnumTypesConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Filterable\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Filterable\`."""
   allFilterables(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: FilterableFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`Filterable\`.\\"\\"\\"
+    """The method to use when ordering \`Filterable\`."""
     orderBy: [FilterablesOrderBy!] = [PRIMARY_KEY_ASC]
   ): FilterablesConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`ForwardCompound\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`ForwardCompound\`."""
   allForwardCompounds(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: ForwardCompoundFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`ForwardCompound\`.\\"\\"\\"
+    """The method to use when ordering \`ForwardCompound\`."""
     orderBy: [ForwardCompoundsOrderBy!] = [PRIMARY_KEY_ASC]
   ): ForwardCompoundsConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Forward\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Forward\`."""
   allForwards(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: ForwardFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`Forward\`.\\"\\"\\"
+    """The method to use when ordering \`Forward\`."""
     orderBy: [ForwardsOrderBy!] = [PRIMARY_KEY_ASC]
   ): ForwardsConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`FullyOmitted\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`FullyOmitted\`."""
   allFullyOmitteds(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`FullyOmitted\`.\\"\\"\\"
+    """The method to use when ordering \`FullyOmitted\`."""
     orderBy: [FullyOmittedsOrderBy!] = [PRIMARY_KEY_ASC]
   ): FullyOmittedsConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`JsonbTest\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`JsonbTest\`."""
   allJsonbTests(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: JsonbTestFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`JsonbTest\`.\\"\\"\\"
+    """The method to use when ordering \`JsonbTest\`."""
     orderBy: [JsonbTestsOrderBy!] = [PRIMARY_KEY_ASC]
   ): JsonbTestsConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Junction\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Junction\`."""
   allJunctions(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: JunctionFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`Junction\`.\\"\\"\\"
+    """The method to use when ordering \`Junction\`."""
     orderBy: [JunctionsOrderBy!] = [PRIMARY_KEY_ASC]
   ): JunctionsConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Parent\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Parent\`."""
   allParents(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: ParentFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`Parent\`.\\"\\"\\"
+    """The method to use when ordering \`Parent\`."""
     orderBy: [ParentsOrderBy!] = [PRIMARY_KEY_ASC]
   ): ParentsConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`RangeArrayType\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`RangeArrayType\`."""
   allRangeArrayTypes(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: RangeArrayTypeFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`RangeArrayType\`.\\"\\"\\"
+    """The method to use when ordering \`RangeArrayType\`."""
     orderBy: [RangeArrayTypesOrderBy!] = [PRIMARY_KEY_ASC]
   ): RangeArrayTypesConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`RangeType\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`RangeType\`."""
   allRangeTypes(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: RangeTypeFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`RangeType\`.\\"\\"\\"
+    """The method to use when ordering \`RangeType\`."""
     orderBy: [RangeTypesOrderBy!] = [PRIMARY_KEY_ASC]
   ): RangeTypesConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`SideA\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`SideA\`."""
   allSideAs(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: SideAFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`SideA\`.\\"\\"\\"
+    """The method to use when ordering \`SideA\`."""
     orderBy: [SideAsOrderBy!] = [PRIMARY_KEY_ASC]
   ): SideAsConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`SideB\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`SideB\`."""
   allSideBs(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: SideBFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`SideB\`.\\"\\"\\"
+    """The method to use when ordering \`SideB\`."""
     orderBy: [SideBsOrderBy!] = [PRIMARY_KEY_ASC]
   ): SideBsConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Unfilterable\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Unfilterable\`."""
   allUnfilterables(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`Unfilterable\`.\\"\\"\\"
+    """The method to use when ordering \`Unfilterable\`."""
     orderBy: [UnfilterablesOrderBy!] = [PRIMARY_KEY_ASC]
   ): UnfilterablesConnection
 
-  \\"\\"\\"Reads a single \`ArrayType\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`ArrayType\` using its globally unique \`ID\`."""
   arrayType(
-    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`ArrayType\`.\\"\\"\\"
+    """The globally unique \`ID\` to be used in selecting a single \`ArrayType\`."""
     nodeId: ID!
   ): ArrayType
   arrayTypeById(id: Int!): ArrayType
 
-  \\"\\"\\"Reads a single \`Backward\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`Backward\` using its globally unique \`ID\`."""
   backward(
-    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`Backward\`.\\"\\"\\"
+    """The globally unique \`ID\` to be used in selecting a single \`Backward\`."""
     nodeId: ID!
   ): Backward
   backwardByFilterableId(filterableId: Int!): Backward
   backwardById(id: Int!): Backward
 
-  \\"\\"\\"Reads a single \`BackwardCompound\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`BackwardCompound\` using its globally unique \`ID\`."""
   backwardCompound(
-    \\"\\"\\"
+    """
     The globally unique \`ID\` to be used in selecting a single \`BackwardCompound\`.
-    \\"\\"\\"
+    """
     nodeId: ID!
   ): BackwardCompound
   backwardCompoundByBackwardCompound1AndBackwardCompound2(backwardCompound1: Int!, backwardCompound2: Int!): BackwardCompound
 
-  \\"\\"\\"Reads a single \`Child\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`Child\` using its globally unique \`ID\`."""
   child(
-    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`Child\`.\\"\\"\\"
+    """The globally unique \`ID\` to be used in selecting a single \`Child\`."""
     nodeId: ID!
   ): Child
   childById(id: Int!): Child
 
-  \\"\\"\\"Reads a single \`ChildNoRelatedFilter\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`ChildNoRelatedFilter\` using its globally unique \`ID\`."""
   childNoRelatedFilter(
-    \\"\\"\\"
+    """
     The globally unique \`ID\` to be used in selecting a single \`ChildNoRelatedFilter\`.
-    \\"\\"\\"
+    """
     nodeId: ID!
   ): ChildNoRelatedFilter
   childNoRelatedFilterById(id: Int!): ChildNoRelatedFilter
 
-  \\"\\"\\"Reads a single \`DomainType\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`DomainType\` using its globally unique \`ID\`."""
   domainType(
-    \\"\\"\\"
+    """
     The globally unique \`ID\` to be used in selecting a single \`DomainType\`.
-    \\"\\"\\"
+    """
     nodeId: ID!
   ): DomainType
   domainTypeById(id: Int!): DomainType
 
-  \\"\\"\\"Reads a single \`EnumArrayType\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`EnumArrayType\` using its globally unique \`ID\`."""
   enumArrayType(
-    \\"\\"\\"
+    """
     The globally unique \`ID\` to be used in selecting a single \`EnumArrayType\`.
-    \\"\\"\\"
+    """
     nodeId: ID!
   ): EnumArrayType
   enumArrayTypeById(id: Int!): EnumArrayType
 
-  \\"\\"\\"Reads a single \`EnumType\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`EnumType\` using its globally unique \`ID\`."""
   enumType(
-    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`EnumType\`.\\"\\"\\"
+    """The globally unique \`ID\` to be used in selecting a single \`EnumType\`."""
     nodeId: ID!
   ): EnumType
   enumTypeById(id: Int!): EnumType
 
-  \\"\\"\\"Reads a single \`Filterable\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`Filterable\` using its globally unique \`ID\`."""
   filterable(
-    \\"\\"\\"
+    """
     The globally unique \`ID\` to be used in selecting a single \`Filterable\`.
-    \\"\\"\\"
+    """
     nodeId: ID!
   ): Filterable
   filterableByBackwardCompound1AndBackwardCompound2(backwardCompound1: Int!, backwardCompound2: Int!): Filterable
@@ -5096,247 +5096,247 @@ type Query implements Node {
   filterableByForwardId(forwardId: Int!): Filterable
   filterableById(id: Int!): Filterable
 
-  \\"\\"\\"Reads a single \`FilterableClosure\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`FilterableClosure\` using its globally unique \`ID\`."""
   filterableClosure(
-    \\"\\"\\"
+    """
     The globally unique \`ID\` to be used in selecting a single \`FilterableClosure\`.
-    \\"\\"\\"
+    """
     nodeId: ID!
   ): FilterableClosure
   filterableClosureById(id: Int!): FilterableClosure
 
-  \\"\\"\\"Reads a single \`Forward\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`Forward\` using its globally unique \`ID\`."""
   forward(
-    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`Forward\`.\\"\\"\\"
+    """The globally unique \`ID\` to be used in selecting a single \`Forward\`."""
     nodeId: ID!
   ): Forward
   forwardById(id: Int!): Forward
 
-  \\"\\"\\"Reads a single \`ForwardCompound\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`ForwardCompound\` using its globally unique \`ID\`."""
   forwardCompound(
-    \\"\\"\\"
+    """
     The globally unique \`ID\` to be used in selecting a single \`ForwardCompound\`.
-    \\"\\"\\"
+    """
     nodeId: ID!
   ): ForwardCompound
   forwardCompoundByForwardCompound1AndForwardCompound2(forwardCompound1: Int!, forwardCompound2: Int!): ForwardCompound
 
-  \\"\\"\\"Reads a single \`FullyOmitted\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`FullyOmitted\` using its globally unique \`ID\`."""
   fullyOmitted(
-    \\"\\"\\"
+    """
     The globally unique \`ID\` to be used in selecting a single \`FullyOmitted\`.
-    \\"\\"\\"
+    """
     nodeId: ID!
   ): FullyOmitted
   fullyOmittedById(id: Int!): FullyOmitted
   funcReturnsTableMultiCol(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: FuncReturnsTableMultiColRecordFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
     i: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
   ): FuncReturnsTableMultiColConnection!
   funcReturnsTableOneCol(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: IntFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
     i: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
   ): FuncReturnsTableOneColConnection!
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Filterable\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Filterable\`."""
   funcTaggedFilterableReturnsSetofFilterable(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: FilterableFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
   ): FilterablesConnection!
   funcTaggedFilterableReturnsTableMultiCol(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: FuncTaggedFilterableReturnsTableMultiColRecordFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
   ): FuncTaggedFilterableReturnsTableMultiColConnection!
 
-  \\"\\"\\"Reads a single \`JsonbTest\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`JsonbTest\` using its globally unique \`ID\`."""
   jsonbTest(
-    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`JsonbTest\`.\\"\\"\\"
+    """The globally unique \`ID\` to be used in selecting a single \`JsonbTest\`."""
     nodeId: ID!
   ): JsonbTest
   jsonbTestById(id: Int!): JsonbTest
 
-  \\"\\"\\"Reads a single \`Junction\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`Junction\` using its globally unique \`ID\`."""
   junction(
-    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`Junction\`.\\"\\"\\"
+    """The globally unique \`ID\` to be used in selecting a single \`Junction\`."""
     nodeId: ID!
   ): Junction
   junctionBySideAIdAndSideBId(sideAId: Int!, sideBId: Int!): Junction
 
-  \\"\\"\\"Fetches an object given its globally unique \`ID\`.\\"\\"\\"
+  """Fetches an object given its globally unique \`ID\`."""
   node(
-    \\"\\"\\"The globally unique \`ID\`.\\"\\"\\"
+    """The globally unique \`ID\`."""
     nodeId: ID!
   ): Node
 
-  \\"\\"\\"
+  """
   The root query type must be a \`Node\` to work well with Relay 1 mutations. This just resolves to \`query\`.
-  \\"\\"\\"
+  """
   nodeId: ID!
 
-  \\"\\"\\"Reads a single \`Parent\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`Parent\` using its globally unique \`ID\`."""
   parent(
-    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`Parent\`.\\"\\"\\"
+    """The globally unique \`ID\` to be used in selecting a single \`Parent\`."""
     nodeId: ID!
   ): Parent
   parentById(id: Int!): Parent
 
-  \\"\\"\\"Reads a single \`Protected\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`Protected\` using its globally unique \`ID\`."""
   protected(
-    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`Protected\`.\\"\\"\\"
+    """The globally unique \`ID\` to be used in selecting a single \`Protected\`."""
     nodeId: ID!
   ): Protected
   protectedById(id: Int!): Protected
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Protected\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Protected\`."""
   protectedsByOtherId(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: ProtectedFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
     otherId: Int
   ): ProtectedsConnection!
 
-  \\"\\"\\"
+  """
   Exposes the root query type nested one level down. This is helpful for Relay 1
   which can only query top level fields if they are in a particular form.
-  \\"\\"\\"
+  """
   query: Query!
 
-  \\"\\"\\"Reads a single \`RangeArrayType\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`RangeArrayType\` using its globally unique \`ID\`."""
   rangeArrayType(
-    \\"\\"\\"
+    """
     The globally unique \`ID\` to be used in selecting a single \`RangeArrayType\`.
-    \\"\\"\\"
+    """
     nodeId: ID!
   ): RangeArrayType
   rangeArrayTypeById(id: Int!): RangeArrayType
 
-  \\"\\"\\"Reads a single \`RangeType\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`RangeType\` using its globally unique \`ID\`."""
   rangeType(
-    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`RangeType\`.\\"\\"\\"
+    """The globally unique \`ID\` to be used in selecting a single \`RangeType\`."""
     nodeId: ID!
   ): RangeType
   rangeTypeById(id: Int!): RangeType
 
-  \\"\\"\\"Reads a single \`SideA\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`SideA\` using its globally unique \`ID\`."""
   sideA(
-    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`SideA\`.\\"\\"\\"
+    """The globally unique \`ID\` to be used in selecting a single \`SideA\`."""
     nodeId: ID!
   ): SideA
   sideAByAId(aId: Int!): SideA
 
-  \\"\\"\\"Reads a single \`SideB\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`SideB\` using its globally unique \`ID\`."""
   sideB(
-    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`SideB\`.\\"\\"\\"
+    """The globally unique \`ID\` to be used in selecting a single \`SideB\`."""
     nodeId: ID!
   ): SideB
   sideBByBId(bId: Int!): SideB
 
-  \\"\\"\\"Reads a single \`Unfilterable\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`Unfilterable\` using its globally unique \`ID\`."""
   unfilterable(
-    \\"\\"\\"
+    """
     The globally unique \`ID\` to be used in selecting a single \`Unfilterable\`.
-    \\"\\"\\"
+    """
     nodeId: ID!
   ): Unfilterable
   unfilterableById(id: Int!): Unfilterable
@@ -5348,68 +5348,68 @@ type RangeArrayType implements Node {
   int4RangeArray: [IntRange]
   int8RangeArray: [BigIntRange]
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
   numericRangeArray: [BigFloatRange]
   timestampRangeArray: [DatetimeRange]
   timestamptzRangeArray: [DatetimeRange]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`RangeArrayType\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input RangeArrayTypeFilter {
-  \\"\\"\\"Filter by the object’s \`dateRangeArray\` field.\\"\\"\\"
+  """Filter by the object’s \`dateRangeArray\` field."""
   dateRangeArray: DateRangeListFilter
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`int4RangeArray\` field.\\"\\"\\"
+  """Filter by the object’s \`int4RangeArray\` field."""
   int4RangeArray: IntRangeListFilter
 
-  \\"\\"\\"Filter by the object’s \`int8RangeArray\` field.\\"\\"\\"
+  """Filter by the object’s \`int8RangeArray\` field."""
   int8RangeArray: BigIntRangeListFilter
 
-  \\"\\"\\"Filter by the object’s \`numericRangeArray\` field.\\"\\"\\"
+  """Filter by the object’s \`numericRangeArray\` field."""
   numericRangeArray: BigFloatRangeListFilter
 
-  \\"\\"\\"Filter by the object’s \`timestampRangeArray\` field.\\"\\"\\"
+  """Filter by the object’s \`timestampRangeArray\` field."""
   timestampRangeArray: DatetimeRangeListFilter
 
-  \\"\\"\\"Filter by the object’s \`timestamptzRangeArray\` field.\\"\\"\\"
+  """Filter by the object’s \`timestamptzRangeArray\` field."""
   timestamptzRangeArray: DatetimeRangeListFilter
 }
 
-\\"\\"\\"A connection to a list of \`RangeArrayType\` values.\\"\\"\\"
+"""A connection to a list of \`RangeArrayType\` values."""
 type RangeArrayTypesConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`RangeArrayType\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [RangeArrayTypesEdge!]!
 
-  \\"\\"\\"A list of \`RangeArrayType\` objects.\\"\\"\\"
+  """A list of \`RangeArrayType\` objects."""
   nodes: [RangeArrayType]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`RangeArrayType\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`RangeArrayType\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`RangeArrayType\` edge in the connection.\\"\\"\\"
+"""A \`RangeArrayType\` edge in the connection."""
 type RangeArrayTypesEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`RangeArrayType\` at the end of the edge.\\"\\"\\"
+  """The \`RangeArrayType\` at the end of the edge."""
   node: RangeArrayType
 }
 
-\\"\\"\\"Methods to use when ordering \`RangeArrayType\`.\\"\\"\\"
+"""Methods to use when ordering \`RangeArrayType\`."""
 enum RangeArrayTypesOrderBy {
   DATE_RANGE_ARRAY_ASC
   DATE_RANGE_ARRAY_DESC
@@ -5436,68 +5436,68 @@ type RangeType implements Node {
   int4Range: IntRange
   int8Range: BigIntRange
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
   numericRange: BigFloatRange
   timestampRange: DatetimeRange
   timestamptzRange: DatetimeRange
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`RangeType\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input RangeTypeFilter {
-  \\"\\"\\"Filter by the object’s \`dateRange\` field.\\"\\"\\"
+  """Filter by the object’s \`dateRange\` field."""
   dateRange: DateRangeFilter
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`int4Range\` field.\\"\\"\\"
+  """Filter by the object’s \`int4Range\` field."""
   int4Range: IntRangeFilter
 
-  \\"\\"\\"Filter by the object’s \`int8Range\` field.\\"\\"\\"
+  """Filter by the object’s \`int8Range\` field."""
   int8Range: BigIntRangeFilter
 
-  \\"\\"\\"Filter by the object’s \`numericRange\` field.\\"\\"\\"
+  """Filter by the object’s \`numericRange\` field."""
   numericRange: BigFloatRangeFilter
 
-  \\"\\"\\"Filter by the object’s \`timestampRange\` field.\\"\\"\\"
+  """Filter by the object’s \`timestampRange\` field."""
   timestampRange: DatetimeRangeFilter
 
-  \\"\\"\\"Filter by the object’s \`timestamptzRange\` field.\\"\\"\\"
+  """Filter by the object’s \`timestamptzRange\` field."""
   timestamptzRange: DatetimeRangeFilter
 }
 
-\\"\\"\\"A connection to a list of \`RangeType\` values.\\"\\"\\"
+"""A connection to a list of \`RangeType\` values."""
 type RangeTypesConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`RangeType\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [RangeTypesEdge!]!
 
-  \\"\\"\\"A list of \`RangeType\` objects.\\"\\"\\"
+  """A list of \`RangeType\` objects."""
   nodes: [RangeType]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`RangeType\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`RangeType\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`RangeType\` edge in the connection.\\"\\"\\"
+"""A \`RangeType\` edge in the connection."""
 type RangeTypesEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`RangeType\` at the end of the edge.\\"\\"\\"
+  """The \`RangeType\` at the end of the edge."""
   node: RangeType
 }
 
-\\"\\"\\"Methods to use when ordering \`RangeType\`.\\"\\"\\"
+"""Methods to use when ordering \`RangeType\`."""
 enum RangeTypesOrderBy {
   DATE_RANGE_ASC
   DATE_RANGE_DESC
@@ -5521,80 +5521,80 @@ enum RangeTypesOrderBy {
 type SideA implements Node {
   aId: Int!
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Junction\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Junction\`."""
   junctionsBySideAId(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: JunctionFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`Junction\`.\\"\\"\\"
+    """The method to use when ordering \`Junction\`."""
     orderBy: [JunctionsOrderBy!] = [PRIMARY_KEY_ASC]
   ): JunctionsConnection!
   name: String!
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`SideA\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input SideAFilter {
-  \\"\\"\\"Filter by the object’s \`aId\` field.\\"\\"\\"
+  """Filter by the object’s \`aId\` field."""
   aId: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`name\` field.\\"\\"\\"
+  """Filter by the object’s \`name\` field."""
   name: StringFilter
 }
 
-\\"\\"\\"A connection to a list of \`SideA\` values.\\"\\"\\"
+"""A connection to a list of \`SideA\` values."""
 type SideAsConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`SideA\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [SideAsEdge!]!
 
-  \\"\\"\\"A list of \`SideA\` objects.\\"\\"\\"
+  """A list of \`SideA\` objects."""
   nodes: [SideA]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`SideA\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`SideA\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`SideA\` edge in the connection.\\"\\"\\"
+"""A \`SideA\` edge in the connection."""
 type SideAsEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`SideA\` at the end of the edge.\\"\\"\\"
+  """The \`SideA\` at the end of the edge."""
   node: SideA
 }
 
-\\"\\"\\"Methods to use when ordering \`SideA\`.\\"\\"\\"
+"""Methods to use when ordering \`SideA\`."""
 enum SideAsOrderBy {
   A_ID_ASC
   A_ID_DESC
@@ -5608,80 +5608,80 @@ enum SideAsOrderBy {
 type SideB implements Node {
   bId: Int!
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Junction\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Junction\`."""
   junctionsBySideBId(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: JunctionFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`Junction\`.\\"\\"\\"
+    """The method to use when ordering \`Junction\`."""
     orderBy: [JunctionsOrderBy!] = [PRIMARY_KEY_ASC]
   ): JunctionsConnection!
   name: String!
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`SideB\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input SideBFilter {
-  \\"\\"\\"Filter by the object’s \`bId\` field.\\"\\"\\"
+  """Filter by the object’s \`bId\` field."""
   bId: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`name\` field.\\"\\"\\"
+  """Filter by the object’s \`name\` field."""
   name: StringFilter
 }
 
-\\"\\"\\"A connection to a list of \`SideB\` values.\\"\\"\\"
+"""A connection to a list of \`SideB\` values."""
 type SideBsConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`SideB\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [SideBsEdge!]!
 
-  \\"\\"\\"A list of \`SideB\` objects.\\"\\"\\"
+  """A list of \`SideB\` objects."""
   nodes: [SideB]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`SideB\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`SideB\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`SideB\` edge in the connection.\\"\\"\\"
+"""A \`SideB\` edge in the connection."""
 type SideBsEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`SideB\` at the end of the edge.\\"\\"\\"
+  """The \`SideB\` at the end of the edge."""
   node: SideB
 }
 
-\\"\\"\\"Methods to use when ordering \`SideB\`.\\"\\"\\"
+"""Methods to use when ordering \`SideB\`."""
 enum SideBsOrderBy {
   B_ID_ASC
   B_ID_DESC
@@ -5692,382 +5692,382 @@ enum SideBsOrderBy {
   PRIMARY_KEY_DESC
 }
 
-\\"\\"\\"
+"""
 A filter to be used against String fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input StringFilter {
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: String
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value (case-insensitive).
-  \\"\\"\\"
+  """
   distinctFromInsensitive: String
 
-  \\"\\"\\"Ends with the specified string (case-sensitive).\\"\\"\\"
+  """Ends with the specified string (case-sensitive)."""
   endsWith: String
 
-  \\"\\"\\"Ends with the specified string (case-insensitive).\\"\\"\\"
+  """Ends with the specified string (case-insensitive)."""
   endsWithInsensitive: String
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: String
 
-  \\"\\"\\"Equal to the specified value (case-insensitive).\\"\\"\\"
+  """Equal to the specified value (case-insensitive)."""
   equalToInsensitive: String
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: String
 
-  \\"\\"\\"Greater than the specified value (case-insensitive).\\"\\"\\"
+  """Greater than the specified value (case-insensitive)."""
   greaterThanInsensitive: String
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: String
 
-  \\"\\"\\"Greater than or equal to the specified value (case-insensitive).\\"\\"\\"
+  """Greater than or equal to the specified value (case-insensitive)."""
   greaterThanOrEqualToInsensitive: String
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [String!]
 
-  \\"\\"\\"Included in the specified list (case-insensitive).\\"\\"\\"
-  inInsensitive: [String!]
-
-  \\"\\"\\"Contains the specified string (case-sensitive).\\"\\"\\"
+  """Contains the specified string (case-sensitive)."""
   includes: String
 
-  \\"\\"\\"Contains the specified string (case-insensitive).\\"\\"\\"
+  """Contains the specified string (case-insensitive)."""
   includesInsensitive: String
 
-  \\"\\"\\"
+  """Included in the specified list (case-insensitive)."""
+  inInsensitive: [String!]
+
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: String
 
-  \\"\\"\\"Less than the specified value (case-insensitive).\\"\\"\\"
+  """Less than the specified value (case-insensitive)."""
   lessThanInsensitive: String
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: String
 
-  \\"\\"\\"Less than or equal to the specified value (case-insensitive).\\"\\"\\"
+  """Less than or equal to the specified value (case-insensitive)."""
   lessThanOrEqualToInsensitive: String
 
-  \\"\\"\\"
+  """
   Matches the specified pattern (case-sensitive). An underscore (_) matches any
   single character; a percent sign (%) matches any sequence of zero or more characters.
-  \\"\\"\\"
+  """
   like: String
 
-  \\"\\"\\"
+  """
   Matches the specified pattern (case-insensitive). An underscore (_) matches
   any single character; a percent sign (%) matches any sequence of zero or more characters.
-  \\"\\"\\"
+  """
   likeInsensitive: String
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: String
 
-  \\"\\"\\"
+  """
   Equal to the specified value, treating null like an ordinary value (case-insensitive).
-  \\"\\"\\"
+  """
   notDistinctFromInsensitive: String
 
-  \\"\\"\\"Does not end with the specified string (case-sensitive).\\"\\"\\"
+  """Does not end with the specified string (case-sensitive)."""
   notEndsWith: String
 
-  \\"\\"\\"Does not end with the specified string (case-insensitive).\\"\\"\\"
+  """Does not end with the specified string (case-insensitive)."""
   notEndsWithInsensitive: String
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: String
 
-  \\"\\"\\"Not equal to the specified value (case-insensitive).\\"\\"\\"
+  """Not equal to the specified value (case-insensitive)."""
   notEqualToInsensitive: String
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [String!]
 
-  \\"\\"\\"Not included in the specified list (case-insensitive).\\"\\"\\"
-  notInInsensitive: [String!]
-
-  \\"\\"\\"Does not contain the specified string (case-sensitive).\\"\\"\\"
+  """Does not contain the specified string (case-sensitive)."""
   notIncludes: String
 
-  \\"\\"\\"Does not contain the specified string (case-insensitive).\\"\\"\\"
+  """Does not contain the specified string (case-insensitive)."""
   notIncludesInsensitive: String
 
-  \\"\\"\\"
+  """Not included in the specified list (case-insensitive)."""
+  notInInsensitive: [String!]
+
+  """
   Does not match the specified pattern (case-sensitive). An underscore (_)
   matches any single character; a percent sign (%) matches any sequence of zero
   or more characters.
-  \\"\\"\\"
+  """
   notLike: String
 
-  \\"\\"\\"
+  """
   Does not match the specified pattern (case-insensitive). An underscore (_)
   matches any single character; a percent sign (%) matches any sequence of zero
   or more characters.
-  \\"\\"\\"
+  """
   notLikeInsensitive: String
 
-  \\"\\"\\"Does not start with the specified string (case-sensitive).\\"\\"\\"
+  """Does not start with the specified string (case-sensitive)."""
   notStartsWith: String
 
-  \\"\\"\\"Does not start with the specified string (case-insensitive).\\"\\"\\"
+  """Does not start with the specified string (case-insensitive)."""
   notStartsWithInsensitive: String
 
-  \\"\\"\\"Starts with the specified string (case-sensitive).\\"\\"\\"
+  """Starts with the specified string (case-sensitive)."""
   startsWith: String
 
-  \\"\\"\\"Starts with the specified string (case-insensitive).\\"\\"\\"
+  """Starts with the specified string (case-insensitive)."""
   startsWithInsensitive: String
 }
 
-\\"\\"\\"
+"""
 A filter to be used against String List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input StringListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: String
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: String
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: String
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: String
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: String
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: String
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [String]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [String]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [String]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [String]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [String]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [String]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [String]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [String]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [String]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [String]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [String]
 }
 
-\\"\\"\\"
+"""
 The exact time of day, does not include the date. May or may not have a timezone offset.
-\\"\\"\\"
+"""
 scalar Time
 
-\\"\\"\\"
+"""
 A filter to be used against Time fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input TimeFilter {
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: Time
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: Time
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: Time
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: Time
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [Time!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: Time
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: Time
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: Time
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: Time
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [Time!]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against Time List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input TimeListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: Time
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: Time
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: Time
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: Time
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: Time
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: Time
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [Time]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [Time]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [Time]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [Time]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [Time]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [Time]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [Time]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [Time]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [Time]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [Time]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [Time]
 }
 
 type Unfilterable implements Node {
-  \\"\\"\\"Reads and enables pagination through a set of \`ChildNoRelatedFilter\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`ChildNoRelatedFilter\`."""
   childNoRelatedFiltersByUnfilterableId(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: ChildNoRelatedFilterFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`ChildNoRelatedFilter\`.\\"\\"\\"
+    """The method to use when ordering \`ChildNoRelatedFilter\`."""
     orderBy: [ChildNoRelatedFiltersOrderBy!] = [PRIMARY_KEY_ASC]
   ): ChildNoRelatedFiltersConnection!
   id: Int!
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
   text: String
 }
 
-\\"\\"\\"A connection to a list of \`Unfilterable\` values.\\"\\"\\"
+"""A connection to a list of \`Unfilterable\` values."""
 type UnfilterablesConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`Unfilterable\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [UnfilterablesEdge!]!
 
-  \\"\\"\\"A list of \`Unfilterable\` objects.\\"\\"\\"
+  """A list of \`Unfilterable\` objects."""
   nodes: [Unfilterable]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`Unfilterable\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`Unfilterable\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`Unfilterable\` edge in the connection.\\"\\"\\"
+"""A \`Unfilterable\` edge in the connection."""
 type UnfilterablesEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`Unfilterable\` at the end of the edge.\\"\\"\\"
+  """The \`Unfilterable\` at the end of the edge."""
   node: Unfilterable
 }
 
-\\"\\"\\"Methods to use when ordering \`Unfilterable\`.\\"\\"\\"
+"""Methods to use when ordering \`Unfilterable\`."""
 enum UnfilterablesOrderBy {
   ID_ASC
   ID_DESC
@@ -6078,114 +6078,114 @@ enum UnfilterablesOrderBy {
   TEXT_DESC
 }
 
-\\"\\"\\"
+"""
 A universally unique identifier as defined by [RFC 4122](https://tools.ietf.org/html/rfc4122).
-\\"\\"\\"
+"""
 scalar UUID
 
-\\"\\"\\"
+"""
 A filter to be used against UUID fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input UUIDFilter {
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: UUID
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: UUID
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: UUID
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: UUID
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [UUID!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: UUID
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: UUID
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: UUID
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: UUID
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [UUID!]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against UUID List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input UUIDListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: UUID
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: UUID
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: UUID
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: UUID
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: UUID
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: UUID
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [UUID]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [UUID]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [UUID]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [UUID]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [UUID]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [UUID]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [UUID]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [UUID]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [UUID]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [UUID]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [UUID]
 }
-"
+
 `;

--- a/__tests__/integration/schema/__snapshots__/operatorNames.test.ts.snap
+++ b/__tests__/integration/schema/__snapshots__/operatorNames.test.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`prints a schema with the filter plugin and the connectionFilterOperatorNames option 1`] = `
-"type ArrayType implements Node {
+type ArrayType implements Node {
   bit4Array: [BitString]
   boolArray: [Boolean]
   bpchar4Array: [String]
@@ -25,9 +25,9 @@ exports[`prints a schema with the filter plugin and the connectionFilterOperator
   moneyArray: [Float]
   nameArray: [String]
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
   numericArray: [BigFloat]
   textArray: [String]
@@ -41,128 +41,128 @@ exports[`prints a schema with the filter plugin and the connectionFilterOperator
   xmlArray: [String]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`ArrayType\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input ArrayTypeFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [ArrayTypeFilter!]
 
-  \\"\\"\\"Filter by the object’s \`bit4Array\` field.\\"\\"\\"
+  """Filter by the object’s \`bit4Array\` field."""
   bit4Array: BitStringListFilter
 
-  \\"\\"\\"Filter by the object’s \`boolArray\` field.\\"\\"\\"
+  """Filter by the object’s \`boolArray\` field."""
   boolArray: BooleanListFilter
 
-  \\"\\"\\"Filter by the object’s \`bpchar4Array\` field.\\"\\"\\"
+  """Filter by the object’s \`bpchar4Array\` field."""
   bpchar4Array: StringListFilter
 
-  \\"\\"\\"Filter by the object’s \`char4Array\` field.\\"\\"\\"
+  """Filter by the object’s \`char4Array\` field."""
   char4Array: StringListFilter
 
-  \\"\\"\\"Filter by the object’s \`citextArray\` field.\\"\\"\\"
+  """Filter by the object’s \`citextArray\` field."""
   citextArray: StringListFilter
 
-  \\"\\"\\"Filter by the object’s \`dateArray\` field.\\"\\"\\"
+  """Filter by the object’s \`dateArray\` field."""
   dateArray: DateListFilter
 
-  \\"\\"\\"Filter by the object’s \`float4Array\` field.\\"\\"\\"
+  """Filter by the object’s \`float4Array\` field."""
   float4Array: FloatListFilter
 
-  \\"\\"\\"Filter by the object’s \`float8Array\` field.\\"\\"\\"
+  """Filter by the object’s \`float8Array\` field."""
   float8Array: FloatListFilter
 
-  \\"\\"\\"Filter by the object’s \`hstoreArray\` field.\\"\\"\\"
+  """Filter by the object’s \`hstoreArray\` field."""
   hstoreArray: KeyValueHashListFilter
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`inetArray\` field.\\"\\"\\"
+  """Filter by the object’s \`inetArray\` field."""
   inetArray: InternetAddressListFilter
 
-  \\"\\"\\"Filter by the object’s \`int2Array\` field.\\"\\"\\"
+  """Filter by the object’s \`int2Array\` field."""
   int2Array: IntListFilter
 
-  \\"\\"\\"Filter by the object’s \`int4Array\` field.\\"\\"\\"
+  """Filter by the object’s \`int4Array\` field."""
   int4Array: IntListFilter
 
-  \\"\\"\\"Filter by the object’s \`int8Array\` field.\\"\\"\\"
+  """Filter by the object’s \`int8Array\` field."""
   int8Array: BigIntListFilter
 
-  \\"\\"\\"Filter by the object’s \`intervalArray\` field.\\"\\"\\"
+  """Filter by the object’s \`intervalArray\` field."""
   intervalArray: IntervalListFilter
 
-  \\"\\"\\"Filter by the object’s \`jsonbArray\` field.\\"\\"\\"
+  """Filter by the object’s \`jsonbArray\` field."""
   jsonbArray: JSONListFilter
 
-  \\"\\"\\"Filter by the object’s \`moneyArray\` field.\\"\\"\\"
+  """Filter by the object’s \`moneyArray\` field."""
   moneyArray: FloatListFilter
 
-  \\"\\"\\"Filter by the object’s \`nameArray\` field.\\"\\"\\"
+  """Filter by the object’s \`nameArray\` field."""
   nameArray: StringListFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: ArrayTypeFilter
 
-  \\"\\"\\"Filter by the object’s \`numericArray\` field.\\"\\"\\"
+  """Filter by the object’s \`numericArray\` field."""
   numericArray: BigFloatListFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [ArrayTypeFilter!]
 
-  \\"\\"\\"Filter by the object’s \`textArray\` field.\\"\\"\\"
+  """Filter by the object’s \`textArray\` field."""
   textArray: StringListFilter
 
-  \\"\\"\\"Filter by the object’s \`timeArray\` field.\\"\\"\\"
+  """Filter by the object’s \`timeArray\` field."""
   timeArray: TimeListFilter
 
-  \\"\\"\\"Filter by the object’s \`timestampArray\` field.\\"\\"\\"
+  """Filter by the object’s \`timestampArray\` field."""
   timestampArray: DatetimeListFilter
 
-  \\"\\"\\"Filter by the object’s \`timestamptzArray\` field.\\"\\"\\"
+  """Filter by the object’s \`timestamptzArray\` field."""
   timestamptzArray: DatetimeListFilter
 
-  \\"\\"\\"Filter by the object’s \`timetzArray\` field.\\"\\"\\"
+  """Filter by the object’s \`timetzArray\` field."""
   timetzArray: TimeListFilter
 
-  \\"\\"\\"Filter by the object’s \`uuidArray\` field.\\"\\"\\"
+  """Filter by the object’s \`uuidArray\` field."""
   uuidArray: UUIDListFilter
 
-  \\"\\"\\"Filter by the object’s \`varbitArray\` field.\\"\\"\\"
+  """Filter by the object’s \`varbitArray\` field."""
   varbitArray: BitStringListFilter
 
-  \\"\\"\\"Filter by the object’s \`varcharArray\` field.\\"\\"\\"
+  """Filter by the object’s \`varcharArray\` field."""
   varcharArray: StringListFilter
 }
 
-\\"\\"\\"A connection to a list of \`ArrayType\` values.\\"\\"\\"
+"""A connection to a list of \`ArrayType\` values."""
 type ArrayTypesConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`ArrayType\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [ArrayTypesEdge!]!
 
-  \\"\\"\\"A list of \`ArrayType\` objects.\\"\\"\\"
+  """A list of \`ArrayType\` objects."""
   nodes: [ArrayType]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`ArrayType\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`ArrayType\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`ArrayType\` edge in the connection.\\"\\"\\"
+"""A \`ArrayType\` edge in the connection."""
 type ArrayTypesEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`ArrayType\` at the end of the edge.\\"\\"\\"
+  """The \`ArrayType\` at the end of the edge."""
   node: ArrayType
 }
 
-\\"\\"\\"Methods to use when ordering \`ArrayType\`.\\"\\"\\"
+"""Methods to use when ordering \`ArrayType\`."""
 enum ArrayTypesOrderBy {
   BIT4_ARRAY_ASC
   BIT4_ARRAY_DESC
@@ -234,15 +234,15 @@ enum ArrayTypesOrderBy {
 }
 
 type Backward implements Node {
-  \\"\\"\\"Reads a single \`Filterable\` that is related to this \`Backward\`.\\"\\"\\"
+  """Reads a single \`Filterable\` that is related to this \`Backward\`."""
   filterableByFilterableId: Filterable
   filterableId: Int
   id: Int!
   name: String!
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
@@ -250,70 +250,70 @@ type BackwardCompound implements Node {
   backwardCompound1: Int!
   backwardCompound2: Int!
 
-  \\"\\"\\"
+  """
   Reads a single \`Filterable\` that is related to this \`BackwardCompound\`.
-  \\"\\"\\"
+  """
   filterableByBackwardCompound1AndBackwardCompound2: Filterable
   name: String
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`BackwardCompound\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input BackwardCompoundFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [BackwardCompoundFilter!]
 
-  \\"\\"\\"Filter by the object’s \`backwardCompound1\` field.\\"\\"\\"
+  """Filter by the object’s \`backwardCompound1\` field."""
   backwardCompound1: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`backwardCompound2\` field.\\"\\"\\"
+  """Filter by the object’s \`backwardCompound2\` field."""
   backwardCompound2: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`name\` field.\\"\\"\\"
+  """Filter by the object’s \`name\` field."""
   name: StringFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: BackwardCompoundFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [BackwardCompoundFilter!]
 }
 
-\\"\\"\\"A connection to a list of \`BackwardCompound\` values.\\"\\"\\"
+"""A connection to a list of \`BackwardCompound\` values."""
 type BackwardCompoundsConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`BackwardCompound\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [BackwardCompoundsEdge!]!
 
-  \\"\\"\\"A list of \`BackwardCompound\` objects.\\"\\"\\"
+  """A list of \`BackwardCompound\` objects."""
   nodes: [BackwardCompound]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"
+  """
   The count of *all* \`BackwardCompound\` you could get from the connection.
-  \\"\\"\\"
+  """
   totalCount: Int!
 }
 
-\\"\\"\\"A \`BackwardCompound\` edge in the connection.\\"\\"\\"
+"""A \`BackwardCompound\` edge in the connection."""
 type BackwardCompoundsEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`BackwardCompound\` at the end of the edge.\\"\\"\\"
+  """The \`BackwardCompound\` at the end of the edge."""
   node: BackwardCompound
 }
 
-\\"\\"\\"Methods to use when ordering \`BackwardCompound\`.\\"\\"\\"
+"""Methods to use when ordering \`BackwardCompound\`."""
 enum BackwardCompoundsOrderBy {
   BACKWARD_COMPOUND_1_ASC
   BACKWARD_COMPOUND_1_DESC
@@ -326,56 +326,56 @@ enum BackwardCompoundsOrderBy {
   PRIMARY_KEY_DESC
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`Backward\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input BackwardFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [BackwardFilter!]
 
-  \\"\\"\\"Filter by the object’s \`filterableId\` field.\\"\\"\\"
+  """Filter by the object’s \`filterableId\` field."""
   filterableId: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`name\` field.\\"\\"\\"
+  """Filter by the object’s \`name\` field."""
   name: StringFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: BackwardFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [BackwardFilter!]
 }
 
-\\"\\"\\"A connection to a list of \`Backward\` values.\\"\\"\\"
+"""A connection to a list of \`Backward\` values."""
 type BackwardsConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`Backward\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [BackwardsEdge!]!
 
-  \\"\\"\\"A list of \`Backward\` objects.\\"\\"\\"
+  """A list of \`Backward\` objects."""
   nodes: [Backward]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`Backward\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`Backward\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`Backward\` edge in the connection.\\"\\"\\"
+"""A \`Backward\` edge in the connection."""
 type BackwardsEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`Backward\` at the end of the edge.\\"\\"\\"
+  """The \`Backward\` at the end of the edge."""
   node: Backward
 }
 
-\\"\\"\\"Methods to use when ordering \`Backward\`.\\"\\"\\"
+"""Methods to use when ordering \`Backward\`."""
 enum BackwardsOrderBy {
   FILTERABLE_ID_ASC
   FILTERABLE_ID_DESC
@@ -388,1037 +388,1037 @@ enum BackwardsOrderBy {
   PRIMARY_KEY_DESC
 }
 
-\\"\\"\\"
+"""
 A floating point number that requires more precision than IEEE 754 binary 64
-\\"\\"\\"
+"""
 scalar BigFloat
 
-\\"\\"\\"
+"""
 A filter to be used against BigFloat fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input BigFloatFilter {
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: BigFloat
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   eq: BigFloat
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: BigFloat
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: BigFloat
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [BigFloat!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: BigFloat
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: BigFloat
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   ne: BigFloat
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: BigFloat
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [BigFloat!]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against BigFloat List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input BigFloatListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: BigFloat
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: BigFloat
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: BigFloat
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: BigFloat
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: BigFloat
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: BigFloat
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [BigFloat]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [BigFloat]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [BigFloat]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   eq: [BigFloat]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [BigFloat]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [BigFloat]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [BigFloat]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [BigFloat]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   ne: [BigFloat]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [BigFloat]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [BigFloat]
 }
 
-\\"\\"\\"A range of \`BigFloat\`.\\"\\"\\"
+"""A range of \`BigFloat\`."""
 type BigFloatRange {
-  \\"\\"\\"The ending bound of our range.\\"\\"\\"
+  """The ending bound of our range."""
   end: BigFloatRangeBound
 
-  \\"\\"\\"The starting bound of our range.\\"\\"\\"
+  """The starting bound of our range."""
   start: BigFloatRangeBound
 }
 
-\\"\\"\\"
+"""
 The value at one end of a range. A range can either include this value, or not.
-\\"\\"\\"
+"""
 type BigFloatRangeBound {
-  \\"\\"\\"Whether or not the value of this bound is included in the range.\\"\\"\\"
+  """Whether or not the value of this bound is included in the range."""
   inclusive: Boolean!
 
-  \\"\\"\\"The value at one end of our range.\\"\\"\\"
+  """The value at one end of our range."""
   value: BigFloat!
 }
 
-\\"\\"\\"
+"""
 The value at one end of a range. A range can either include this value, or not.
-\\"\\"\\"
+"""
 input BigFloatRangeBoundInput {
-  \\"\\"\\"Whether or not the value of this bound is included in the range.\\"\\"\\"
+  """Whether or not the value of this bound is included in the range."""
   inclusive: Boolean!
 
-  \\"\\"\\"The value at one end of our range.\\"\\"\\"
+  """The value at one end of our range."""
   value: BigFloat!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against BigFloatRange fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input BigFloatRangeFilter {
-  \\"\\"\\"Adjacent to the specified range.\\"\\"\\"
+  """Adjacent to the specified range."""
   adjacentTo: BigFloatRangeInput
 
-  \\"\\"\\"Contained by the specified range.\\"\\"\\"
+  """Contained by the specified range."""
   containedBy: BigFloatRangeInput
 
-  \\"\\"\\"Contains the specified range.\\"\\"\\"
+  """Contains the specified range."""
   contains: BigFloatRangeInput
 
-  \\"\\"\\"Contains the specified value.\\"\\"\\"
+  """Contains the specified value."""
   containsElement: BigFloat
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: BigFloatRangeInput
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   eq: BigFloatRangeInput
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: BigFloatRangeInput
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: BigFloatRangeInput
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [BigFloatRangeInput!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: BigFloatRangeInput
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: BigFloatRangeInput
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   ne: BigFloatRangeInput
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: BigFloatRangeInput
 
-  \\"\\"\\"Does not extend left of the specified range.\\"\\"\\"
+  """Does not extend left of the specified range."""
   notExtendsLeftOf: BigFloatRangeInput
 
-  \\"\\"\\"Does not extend right of the specified range.\\"\\"\\"
+  """Does not extend right of the specified range."""
   notExtendsRightOf: BigFloatRangeInput
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [BigFloatRangeInput!]
 
-  \\"\\"\\"Overlaps the specified range.\\"\\"\\"
+  """Overlaps the specified range."""
   overlaps: BigFloatRangeInput
 
-  \\"\\"\\"Strictly left of the specified range.\\"\\"\\"
+  """Strictly left of the specified range."""
   strictlyLeftOf: BigFloatRangeInput
 
-  \\"\\"\\"Strictly right of the specified range.\\"\\"\\"
+  """Strictly right of the specified range."""
   strictlyRightOf: BigFloatRangeInput
 }
 
-\\"\\"\\"A range of \`BigFloat\`.\\"\\"\\"
+"""A range of \`BigFloat\`."""
 input BigFloatRangeInput {
-  \\"\\"\\"The ending bound of our range.\\"\\"\\"
+  """The ending bound of our range."""
   end: BigFloatRangeBoundInput
 
-  \\"\\"\\"The starting bound of our range.\\"\\"\\"
+  """The starting bound of our range."""
   start: BigFloatRangeBoundInput
 }
 
-\\"\\"\\"
+"""
 A filter to be used against BigFloatRange List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input BigFloatRangeListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: BigFloatRangeInput
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: BigFloatRangeInput
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: BigFloatRangeInput
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: BigFloatRangeInput
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: BigFloatRangeInput
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: BigFloatRangeInput
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [BigFloatRangeInput]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [BigFloatRangeInput]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [BigFloatRangeInput]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   eq: [BigFloatRangeInput]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [BigFloatRangeInput]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [BigFloatRangeInput]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [BigFloatRangeInput]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [BigFloatRangeInput]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   ne: [BigFloatRangeInput]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [BigFloatRangeInput]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [BigFloatRangeInput]
 }
 
-\\"\\"\\"
+"""
 A signed eight-byte integer. The upper big integer values are greater than the
 max value for a JavaScript number. Therefore all big integers will be output as
 strings and not numbers.
-\\"\\"\\"
+"""
 scalar BigInt
 
-\\"\\"\\"
+"""
 A filter to be used against BigInt fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input BigIntFilter {
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: BigInt
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   eq: BigInt
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: BigInt
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: BigInt
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [BigInt!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: BigInt
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: BigInt
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   ne: BigInt
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: BigInt
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [BigInt!]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against BigInt List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input BigIntListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: BigInt
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: BigInt
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: BigInt
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: BigInt
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: BigInt
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: BigInt
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [BigInt]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [BigInt]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [BigInt]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   eq: [BigInt]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [BigInt]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [BigInt]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [BigInt]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [BigInt]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   ne: [BigInt]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [BigInt]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [BigInt]
 }
 
-\\"\\"\\"A range of \`BigInt\`.\\"\\"\\"
+"""A range of \`BigInt\`."""
 type BigIntRange {
-  \\"\\"\\"The ending bound of our range.\\"\\"\\"
+  """The ending bound of our range."""
   end: BigIntRangeBound
 
-  \\"\\"\\"The starting bound of our range.\\"\\"\\"
+  """The starting bound of our range."""
   start: BigIntRangeBound
 }
 
-\\"\\"\\"
+"""
 The value at one end of a range. A range can either include this value, or not.
-\\"\\"\\"
+"""
 type BigIntRangeBound {
-  \\"\\"\\"Whether or not the value of this bound is included in the range.\\"\\"\\"
+  """Whether or not the value of this bound is included in the range."""
   inclusive: Boolean!
 
-  \\"\\"\\"The value at one end of our range.\\"\\"\\"
+  """The value at one end of our range."""
   value: BigInt!
 }
 
-\\"\\"\\"
+"""
 The value at one end of a range. A range can either include this value, or not.
-\\"\\"\\"
+"""
 input BigIntRangeBoundInput {
-  \\"\\"\\"Whether or not the value of this bound is included in the range.\\"\\"\\"
+  """Whether or not the value of this bound is included in the range."""
   inclusive: Boolean!
 
-  \\"\\"\\"The value at one end of our range.\\"\\"\\"
+  """The value at one end of our range."""
   value: BigInt!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against BigIntRange fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input BigIntRangeFilter {
-  \\"\\"\\"Adjacent to the specified range.\\"\\"\\"
+  """Adjacent to the specified range."""
   adjacentTo: BigIntRangeInput
 
-  \\"\\"\\"Contained by the specified range.\\"\\"\\"
+  """Contained by the specified range."""
   containedBy: BigIntRangeInput
 
-  \\"\\"\\"Contains the specified range.\\"\\"\\"
+  """Contains the specified range."""
   contains: BigIntRangeInput
 
-  \\"\\"\\"Contains the specified value.\\"\\"\\"
+  """Contains the specified value."""
   containsElement: BigInt
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: BigIntRangeInput
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   eq: BigIntRangeInput
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: BigIntRangeInput
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: BigIntRangeInput
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [BigIntRangeInput!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: BigIntRangeInput
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: BigIntRangeInput
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   ne: BigIntRangeInput
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: BigIntRangeInput
 
-  \\"\\"\\"Does not extend left of the specified range.\\"\\"\\"
+  """Does not extend left of the specified range."""
   notExtendsLeftOf: BigIntRangeInput
 
-  \\"\\"\\"Does not extend right of the specified range.\\"\\"\\"
+  """Does not extend right of the specified range."""
   notExtendsRightOf: BigIntRangeInput
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [BigIntRangeInput!]
 
-  \\"\\"\\"Overlaps the specified range.\\"\\"\\"
+  """Overlaps the specified range."""
   overlaps: BigIntRangeInput
 
-  \\"\\"\\"Strictly left of the specified range.\\"\\"\\"
+  """Strictly left of the specified range."""
   strictlyLeftOf: BigIntRangeInput
 
-  \\"\\"\\"Strictly right of the specified range.\\"\\"\\"
+  """Strictly right of the specified range."""
   strictlyRightOf: BigIntRangeInput
 }
 
-\\"\\"\\"A range of \`BigInt\`.\\"\\"\\"
+"""A range of \`BigInt\`."""
 input BigIntRangeInput {
-  \\"\\"\\"The ending bound of our range.\\"\\"\\"
+  """The ending bound of our range."""
   end: BigIntRangeBoundInput
 
-  \\"\\"\\"The starting bound of our range.\\"\\"\\"
+  """The starting bound of our range."""
   start: BigIntRangeBoundInput
 }
 
-\\"\\"\\"
+"""
 A filter to be used against BigIntRange List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input BigIntRangeListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: BigIntRangeInput
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: BigIntRangeInput
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: BigIntRangeInput
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: BigIntRangeInput
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: BigIntRangeInput
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: BigIntRangeInput
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [BigIntRangeInput]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [BigIntRangeInput]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [BigIntRangeInput]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   eq: [BigIntRangeInput]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [BigIntRangeInput]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [BigIntRangeInput]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [BigIntRangeInput]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [BigIntRangeInput]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   ne: [BigIntRangeInput]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [BigIntRangeInput]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [BigIntRangeInput]
 }
 
-\\"\\"\\"A string representing a series of binary bits\\"\\"\\"
+"""A string representing a series of binary bits"""
 scalar BitString
 
-\\"\\"\\"
+"""
 A filter to be used against BitString fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input BitStringFilter {
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: BitString
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   eq: BitString
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: BitString
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: BitString
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [BitString!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: BitString
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: BitString
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   ne: BitString
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: BitString
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [BitString!]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against BitString List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input BitStringListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: BitString
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: BitString
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: BitString
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: BitString
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: BitString
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: BitString
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [BitString]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [BitString]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [BitString]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   eq: [BitString]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [BitString]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [BitString]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [BitString]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [BitString]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   ne: [BitString]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [BitString]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [BitString]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against Boolean fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input BooleanFilter {
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: Boolean
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   eq: Boolean
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: Boolean
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: Boolean
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [Boolean!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: Boolean
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: Boolean
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   ne: Boolean
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: Boolean
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [Boolean!]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against Boolean List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input BooleanListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: Boolean
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: Boolean
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: Boolean
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: Boolean
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: Boolean
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: Boolean
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [Boolean]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [Boolean]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [Boolean]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   eq: [Boolean]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [Boolean]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [Boolean]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [Boolean]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [Boolean]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   ne: [Boolean]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [Boolean]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [Boolean]
 }
 
 scalar Char4Domain
 
-\\"\\"\\"
+"""
 A filter to be used against Char4Domain fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input Char4DomainFilter {
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: Char4Domain
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value (case-insensitive).
-  \\"\\"\\"
+  """
   distinctFromInsensitive: Char4Domain
 
-  \\"\\"\\"Ends with the specified string (case-sensitive).\\"\\"\\"
+  """Ends with the specified string (case-sensitive)."""
   endsWith: Char4Domain
 
-  \\"\\"\\"Ends with the specified string (case-insensitive).\\"\\"\\"
+  """Ends with the specified string (case-insensitive)."""
   endsWithInsensitive: Char4Domain
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   eq: Char4Domain
 
-  \\"\\"\\"Equal to the specified value (case-insensitive).\\"\\"\\"
+  """Equal to the specified value (case-insensitive)."""
   equalToInsensitive: Char4Domain
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: Char4Domain
 
-  \\"\\"\\"Greater than the specified value (case-insensitive).\\"\\"\\"
+  """Greater than the specified value (case-insensitive)."""
   greaterThanInsensitive: Char4Domain
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: Char4Domain
 
-  \\"\\"\\"Greater than or equal to the specified value (case-insensitive).\\"\\"\\"
+  """Greater than or equal to the specified value (case-insensitive)."""
   greaterThanOrEqualToInsensitive: Char4Domain
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [Char4Domain!]
 
-  \\"\\"\\"Included in the specified list (case-insensitive).\\"\\"\\"
-  inInsensitive: [Char4Domain!]
-
-  \\"\\"\\"Contains the specified string (case-sensitive).\\"\\"\\"
+  """Contains the specified string (case-sensitive)."""
   includes: Char4Domain
 
-  \\"\\"\\"Contains the specified string (case-insensitive).\\"\\"\\"
+  """Contains the specified string (case-insensitive)."""
   includesInsensitive: Char4Domain
 
-  \\"\\"\\"
+  """Included in the specified list (case-insensitive)."""
+  inInsensitive: [Char4Domain!]
+
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: Char4Domain
 
-  \\"\\"\\"Less than the specified value (case-insensitive).\\"\\"\\"
+  """Less than the specified value (case-insensitive)."""
   lessThanInsensitive: Char4Domain
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: Char4Domain
 
-  \\"\\"\\"Less than or equal to the specified value (case-insensitive).\\"\\"\\"
+  """Less than or equal to the specified value (case-insensitive)."""
   lessThanOrEqualToInsensitive: Char4Domain
 
-  \\"\\"\\"
+  """
   Matches the specified pattern (case-sensitive). An underscore (_) matches any
   single character; a percent sign (%) matches any sequence of zero or more characters.
-  \\"\\"\\"
+  """
   like: Char4Domain
 
-  \\"\\"\\"
+  """
   Matches the specified pattern (case-insensitive). An underscore (_) matches
   any single character; a percent sign (%) matches any sequence of zero or more characters.
-  \\"\\"\\"
+  """
   likeInsensitive: Char4Domain
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   ne: Char4Domain
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: Char4Domain
 
-  \\"\\"\\"
+  """
   Equal to the specified value, treating null like an ordinary value (case-insensitive).
-  \\"\\"\\"
+  """
   notDistinctFromInsensitive: Char4Domain
 
-  \\"\\"\\"Does not end with the specified string (case-sensitive).\\"\\"\\"
+  """Does not end with the specified string (case-sensitive)."""
   notEndsWith: Char4Domain
 
-  \\"\\"\\"Does not end with the specified string (case-insensitive).\\"\\"\\"
+  """Does not end with the specified string (case-insensitive)."""
   notEndsWithInsensitive: Char4Domain
 
-  \\"\\"\\"Not equal to the specified value (case-insensitive).\\"\\"\\"
+  """Not equal to the specified value (case-insensitive)."""
   notEqualToInsensitive: Char4Domain
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [Char4Domain!]
 
-  \\"\\"\\"Not included in the specified list (case-insensitive).\\"\\"\\"
-  notInInsensitive: [Char4Domain!]
-
-  \\"\\"\\"Does not contain the specified string (case-sensitive).\\"\\"\\"
+  """Does not contain the specified string (case-sensitive)."""
   notIncludes: Char4Domain
 
-  \\"\\"\\"Does not contain the specified string (case-insensitive).\\"\\"\\"
+  """Does not contain the specified string (case-insensitive)."""
   notIncludesInsensitive: Char4Domain
 
-  \\"\\"\\"
+  """Not included in the specified list (case-insensitive)."""
+  notInInsensitive: [Char4Domain!]
+
+  """
   Does not match the specified pattern (case-sensitive). An underscore (_)
   matches any single character; a percent sign (%) matches any sequence of zero
   or more characters.
-  \\"\\"\\"
+  """
   notLike: Char4Domain
 
-  \\"\\"\\"
+  """
   Does not match the specified pattern (case-insensitive). An underscore (_)
   matches any single character; a percent sign (%) matches any sequence of zero
   or more characters.
-  \\"\\"\\"
+  """
   notLikeInsensitive: Char4Domain
 
-  \\"\\"\\"Does not start with the specified string (case-sensitive).\\"\\"\\"
+  """Does not start with the specified string (case-sensitive)."""
   notStartsWith: Char4Domain
 
-  \\"\\"\\"Does not start with the specified string (case-insensitive).\\"\\"\\"
+  """Does not start with the specified string (case-insensitive)."""
   notStartsWithInsensitive: Char4Domain
 
-  \\"\\"\\"Starts with the specified string (case-sensitive).\\"\\"\\"
+  """Starts with the specified string (case-sensitive)."""
   startsWith: Char4Domain
 
-  \\"\\"\\"Starts with the specified string (case-insensitive).\\"\\"\\"
+  """Starts with the specified string (case-insensitive)."""
   startsWithInsensitive: Char4Domain
 }
 
 type Child implements Node {
-  \\"\\"\\"Reads a single \`Filterable\` that is related to this \`Child\`.\\"\\"\\"
+  """Reads a single \`Filterable\` that is related to this \`Child\`."""
   filterableByFilterableId: Filterable
   filterableId: Int
   id: Int!
   name: String!
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`Child\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input ChildFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [ChildFilter!]
 
-  \\"\\"\\"Filter by the object’s \`filterableId\` field.\\"\\"\\"
+  """Filter by the object’s \`filterableId\` field."""
   filterableId: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`name\` field.\\"\\"\\"
+  """Filter by the object’s \`name\` field."""
   name: StringFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: ChildFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [ChildFilter!]
 }
 
 type ChildNoRelatedFilter implements Node {
-  \\"\\"\\"
+  """
   Reads a single \`Filterable\` that is related to this \`ChildNoRelatedFilter\`.
-  \\"\\"\\"
+  """
   filterableByFilterableId: Filterable
   filterableId: Int
   id: Int!
   name: String!
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 
-  \\"\\"\\"
+  """
   Reads a single \`Unfilterable\` that is related to this \`ChildNoRelatedFilter\`.
-  \\"\\"\\"
+  """
   unfilterableByUnfilterableId: Unfilterable
   unfilterableId: Int
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`ChildNoRelatedFilter\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input ChildNoRelatedFilterFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [ChildNoRelatedFilterFilter!]
 
-  \\"\\"\\"Filter by the object’s \`filterableId\` field.\\"\\"\\"
+  """Filter by the object’s \`filterableId\` field."""
   filterableId: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`name\` field.\\"\\"\\"
+  """Filter by the object’s \`name\` field."""
   name: StringFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: ChildNoRelatedFilterFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [ChildNoRelatedFilterFilter!]
 
-  \\"\\"\\"Filter by the object’s \`unfilterableId\` field.\\"\\"\\"
+  """Filter by the object’s \`unfilterableId\` field."""
   unfilterableId: IntFilter
 }
 
-\\"\\"\\"A connection to a list of \`ChildNoRelatedFilter\` values.\\"\\"\\"
+"""A connection to a list of \`ChildNoRelatedFilter\` values."""
 type ChildNoRelatedFiltersConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`ChildNoRelatedFilter\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [ChildNoRelatedFiltersEdge!]!
 
-  \\"\\"\\"A list of \`ChildNoRelatedFilter\` objects.\\"\\"\\"
+  """A list of \`ChildNoRelatedFilter\` objects."""
   nodes: [ChildNoRelatedFilter]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"
+  """
   The count of *all* \`ChildNoRelatedFilter\` you could get from the connection.
-  \\"\\"\\"
+  """
   totalCount: Int!
 }
 
-\\"\\"\\"A \`ChildNoRelatedFilter\` edge in the connection.\\"\\"\\"
+"""A \`ChildNoRelatedFilter\` edge in the connection."""
 type ChildNoRelatedFiltersEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`ChildNoRelatedFilter\` at the end of the edge.\\"\\"\\"
+  """The \`ChildNoRelatedFilter\` at the end of the edge."""
   node: ChildNoRelatedFilter
 }
 
-\\"\\"\\"Methods to use when ordering \`ChildNoRelatedFilter\`.\\"\\"\\"
+"""Methods to use when ordering \`ChildNoRelatedFilter\`."""
 enum ChildNoRelatedFiltersOrderBy {
   FILTERABLE_ID_ASC
   FILTERABLE_ID_DESC
@@ -1433,33 +1433,33 @@ enum ChildNoRelatedFiltersOrderBy {
   UNFILTERABLE_ID_DESC
 }
 
-\\"\\"\\"A connection to a list of \`Child\` values.\\"\\"\\"
+"""A connection to a list of \`Child\` values."""
 type ChildrenConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`Child\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [ChildrenEdge!]!
 
-  \\"\\"\\"A list of \`Child\` objects.\\"\\"\\"
+  """A list of \`Child\` objects."""
   nodes: [Child]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`Child\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`Child\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`Child\` edge in the connection.\\"\\"\\"
+"""A \`Child\` edge in the connection."""
 type ChildrenEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`Child\` at the end of the edge.\\"\\"\\"
+  """The \`Child\` at the end of the edge."""
   node: Child
 }
 
-\\"\\"\\"Methods to use when ordering \`Child\`.\\"\\"\\"
+"""Methods to use when ordering \`Child\`."""
 enum ChildrenOrderBy {
   FILTERABLE_ID_ASC
   FILTERABLE_ID_DESC
@@ -1477,633 +1477,633 @@ type Composite {
   b: String
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`Composite\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input CompositeFilter {
-  \\"\\"\\"Filter by the object’s \`a\` field.\\"\\"\\"
+  """Filter by the object’s \`a\` field."""
   a: IntFilter
 
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [CompositeFilter!]
 
-  \\"\\"\\"Filter by the object’s \`b\` field.\\"\\"\\"
+  """Filter by the object’s \`b\` field."""
   b: StringFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: CompositeFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [CompositeFilter!]
 }
 
-\\"\\"\\"A location in a connection that can be used for resuming pagination.\\"\\"\\"
+"""A location in a connection that can be used for resuming pagination."""
 scalar Cursor
 
-\\"\\"\\"The day, does not include a time.\\"\\"\\"
+"""The day, does not include a time."""
 scalar Date
 
 scalar DateDomain
 
-\\"\\"\\"
+"""
 A filter to be used against DateDomain fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input DateDomainFilter {
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: DateDomain
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   eq: DateDomain
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: DateDomain
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: DateDomain
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [DateDomain!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: DateDomain
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: DateDomain
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   ne: DateDomain
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: DateDomain
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [DateDomain!]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against Date fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input DateFilter {
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: Date
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   eq: Date
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: Date
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: Date
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [Date!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: Date
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: Date
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   ne: Date
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: Date
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [Date!]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against Date List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input DateListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: Date
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: Date
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: Date
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: Date
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: Date
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: Date
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [Date]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [Date]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [Date]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   eq: [Date]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [Date]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [Date]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [Date]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [Date]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   ne: [Date]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [Date]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [Date]
 }
 
-\\"\\"\\"A range of \`Date\`.\\"\\"\\"
+"""A range of \`Date\`."""
 type DateRange {
-  \\"\\"\\"The ending bound of our range.\\"\\"\\"
+  """The ending bound of our range."""
   end: DateRangeBound
 
-  \\"\\"\\"The starting bound of our range.\\"\\"\\"
+  """The starting bound of our range."""
   start: DateRangeBound
 }
 
-\\"\\"\\"
+"""
 The value at one end of a range. A range can either include this value, or not.
-\\"\\"\\"
+"""
 type DateRangeBound {
-  \\"\\"\\"Whether or not the value of this bound is included in the range.\\"\\"\\"
+  """Whether or not the value of this bound is included in the range."""
   inclusive: Boolean!
 
-  \\"\\"\\"The value at one end of our range.\\"\\"\\"
+  """The value at one end of our range."""
   value: Date!
 }
 
-\\"\\"\\"
+"""
 The value at one end of a range. A range can either include this value, or not.
-\\"\\"\\"
+"""
 input DateRangeBoundInput {
-  \\"\\"\\"Whether or not the value of this bound is included in the range.\\"\\"\\"
+  """Whether or not the value of this bound is included in the range."""
   inclusive: Boolean!
 
-  \\"\\"\\"The value at one end of our range.\\"\\"\\"
+  """The value at one end of our range."""
   value: Date!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against DateRange fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input DateRangeFilter {
-  \\"\\"\\"Adjacent to the specified range.\\"\\"\\"
+  """Adjacent to the specified range."""
   adjacentTo: DateRangeInput
 
-  \\"\\"\\"Contained by the specified range.\\"\\"\\"
+  """Contained by the specified range."""
   containedBy: DateRangeInput
 
-  \\"\\"\\"Contains the specified range.\\"\\"\\"
+  """Contains the specified range."""
   contains: DateRangeInput
 
-  \\"\\"\\"Contains the specified value.\\"\\"\\"
+  """Contains the specified value."""
   containsElement: Date
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: DateRangeInput
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   eq: DateRangeInput
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: DateRangeInput
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: DateRangeInput
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [DateRangeInput!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: DateRangeInput
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: DateRangeInput
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   ne: DateRangeInput
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: DateRangeInput
 
-  \\"\\"\\"Does not extend left of the specified range.\\"\\"\\"
+  """Does not extend left of the specified range."""
   notExtendsLeftOf: DateRangeInput
 
-  \\"\\"\\"Does not extend right of the specified range.\\"\\"\\"
+  """Does not extend right of the specified range."""
   notExtendsRightOf: DateRangeInput
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [DateRangeInput!]
 
-  \\"\\"\\"Overlaps the specified range.\\"\\"\\"
+  """Overlaps the specified range."""
   overlaps: DateRangeInput
 
-  \\"\\"\\"Strictly left of the specified range.\\"\\"\\"
+  """Strictly left of the specified range."""
   strictlyLeftOf: DateRangeInput
 
-  \\"\\"\\"Strictly right of the specified range.\\"\\"\\"
+  """Strictly right of the specified range."""
   strictlyRightOf: DateRangeInput
 }
 
-\\"\\"\\"A range of \`Date\`.\\"\\"\\"
+"""A range of \`Date\`."""
 input DateRangeInput {
-  \\"\\"\\"The ending bound of our range.\\"\\"\\"
+  """The ending bound of our range."""
   end: DateRangeBoundInput
 
-  \\"\\"\\"The starting bound of our range.\\"\\"\\"
+  """The starting bound of our range."""
   start: DateRangeBoundInput
 }
 
-\\"\\"\\"
+"""
 A filter to be used against DateRange List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input DateRangeListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: DateRangeInput
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: DateRangeInput
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: DateRangeInput
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: DateRangeInput
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: DateRangeInput
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: DateRangeInput
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [DateRangeInput]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [DateRangeInput]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [DateRangeInput]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   eq: [DateRangeInput]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [DateRangeInput]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [DateRangeInput]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [DateRangeInput]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [DateRangeInput]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   ne: [DateRangeInput]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [DateRangeInput]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [DateRangeInput]
 }
 
-\\"\\"\\"
+"""
 A point in time as described by the [ISO
 8601](https://en.wikipedia.org/wiki/ISO_8601) standard. May or may not include a timezone.
-\\"\\"\\"
+"""
 scalar Datetime
 
-\\"\\"\\"
+"""
 A filter to be used against Datetime fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input DatetimeFilter {
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: Datetime
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   eq: Datetime
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: Datetime
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: Datetime
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [Datetime!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: Datetime
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: Datetime
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   ne: Datetime
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: Datetime
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [Datetime!]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against Datetime List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input DatetimeListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: Datetime
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: Datetime
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: Datetime
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: Datetime
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: Datetime
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: Datetime
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [Datetime]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [Datetime]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [Datetime]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   eq: [Datetime]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [Datetime]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [Datetime]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [Datetime]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [Datetime]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   ne: [Datetime]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [Datetime]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [Datetime]
 }
 
-\\"\\"\\"A range of \`Datetime\`.\\"\\"\\"
+"""A range of \`Datetime\`."""
 type DatetimeRange {
-  \\"\\"\\"The ending bound of our range.\\"\\"\\"
+  """The ending bound of our range."""
   end: DatetimeRangeBound
 
-  \\"\\"\\"The starting bound of our range.\\"\\"\\"
+  """The starting bound of our range."""
   start: DatetimeRangeBound
 }
 
-\\"\\"\\"
+"""
 The value at one end of a range. A range can either include this value, or not.
-\\"\\"\\"
+"""
 type DatetimeRangeBound {
-  \\"\\"\\"Whether or not the value of this bound is included in the range.\\"\\"\\"
+  """Whether or not the value of this bound is included in the range."""
   inclusive: Boolean!
 
-  \\"\\"\\"The value at one end of our range.\\"\\"\\"
+  """The value at one end of our range."""
   value: Datetime!
 }
 
-\\"\\"\\"
+"""
 The value at one end of a range. A range can either include this value, or not.
-\\"\\"\\"
+"""
 input DatetimeRangeBoundInput {
-  \\"\\"\\"Whether or not the value of this bound is included in the range.\\"\\"\\"
+  """Whether or not the value of this bound is included in the range."""
   inclusive: Boolean!
 
-  \\"\\"\\"The value at one end of our range.\\"\\"\\"
+  """The value at one end of our range."""
   value: Datetime!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against DatetimeRange fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input DatetimeRangeFilter {
-  \\"\\"\\"Adjacent to the specified range.\\"\\"\\"
+  """Adjacent to the specified range."""
   adjacentTo: DatetimeRangeInput
 
-  \\"\\"\\"Contained by the specified range.\\"\\"\\"
+  """Contained by the specified range."""
   containedBy: DatetimeRangeInput
 
-  \\"\\"\\"Contains the specified range.\\"\\"\\"
+  """Contains the specified range."""
   contains: DatetimeRangeInput
 
-  \\"\\"\\"Contains the specified value.\\"\\"\\"
+  """Contains the specified value."""
   containsElement: Datetime
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: DatetimeRangeInput
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   eq: DatetimeRangeInput
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: DatetimeRangeInput
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: DatetimeRangeInput
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [DatetimeRangeInput!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: DatetimeRangeInput
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: DatetimeRangeInput
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   ne: DatetimeRangeInput
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: DatetimeRangeInput
 
-  \\"\\"\\"Does not extend left of the specified range.\\"\\"\\"
+  """Does not extend left of the specified range."""
   notExtendsLeftOf: DatetimeRangeInput
 
-  \\"\\"\\"Does not extend right of the specified range.\\"\\"\\"
+  """Does not extend right of the specified range."""
   notExtendsRightOf: DatetimeRangeInput
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [DatetimeRangeInput!]
 
-  \\"\\"\\"Overlaps the specified range.\\"\\"\\"
+  """Overlaps the specified range."""
   overlaps: DatetimeRangeInput
 
-  \\"\\"\\"Strictly left of the specified range.\\"\\"\\"
+  """Strictly left of the specified range."""
   strictlyLeftOf: DatetimeRangeInput
 
-  \\"\\"\\"Strictly right of the specified range.\\"\\"\\"
+  """Strictly right of the specified range."""
   strictlyRightOf: DatetimeRangeInput
 }
 
-\\"\\"\\"A range of \`Datetime\`.\\"\\"\\"
+"""A range of \`Datetime\`."""
 input DatetimeRangeInput {
-  \\"\\"\\"The ending bound of our range.\\"\\"\\"
+  """The ending bound of our range."""
   end: DatetimeRangeBoundInput
 
-  \\"\\"\\"The starting bound of our range.\\"\\"\\"
+  """The starting bound of our range."""
   start: DatetimeRangeBoundInput
 }
 
-\\"\\"\\"
+"""
 A filter to be used against DatetimeRange List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input DatetimeRangeListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: DatetimeRangeInput
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: DatetimeRangeInput
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: DatetimeRangeInput
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: DatetimeRangeInput
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: DatetimeRangeInput
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: DatetimeRangeInput
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [DatetimeRangeInput]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [DatetimeRangeInput]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [DatetimeRangeInput]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   eq: [DatetimeRangeInput]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [DatetimeRangeInput]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [DatetimeRangeInput]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [DatetimeRangeInput]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [DatetimeRangeInput]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   ne: [DatetimeRangeInput]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [DatetimeRangeInput]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [DatetimeRangeInput]
 }
 
@@ -2113,65 +2113,65 @@ type DomainType implements Node {
   id: Int!
   int4Domain: Int4Domain
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`DomainType\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input DomainTypeFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [DomainTypeFilter!]
 
-  \\"\\"\\"Filter by the object’s \`char4Domain\` field.\\"\\"\\"
+  """Filter by the object’s \`char4Domain\` field."""
   char4Domain: Char4DomainFilter
 
-  \\"\\"\\"Filter by the object’s \`dateDomain\` field.\\"\\"\\"
+  """Filter by the object’s \`dateDomain\` field."""
   dateDomain: DateDomainFilter
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`int4Domain\` field.\\"\\"\\"
+  """Filter by the object’s \`int4Domain\` field."""
   int4Domain: Int4DomainFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: DomainTypeFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [DomainTypeFilter!]
 }
 
-\\"\\"\\"A connection to a list of \`DomainType\` values.\\"\\"\\"
+"""A connection to a list of \`DomainType\` values."""
 type DomainTypesConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`DomainType\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [DomainTypesEdge!]!
 
-  \\"\\"\\"A list of \`DomainType\` objects.\\"\\"\\"
+  """A list of \`DomainType\` objects."""
   nodes: [DomainType]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`DomainType\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`DomainType\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`DomainType\` edge in the connection.\\"\\"\\"
+"""A \`DomainType\` edge in the connection."""
 type DomainTypesEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`DomainType\` at the end of the edge.\\"\\"\\"
+  """The \`DomainType\` at the end of the edge."""
   node: DomainType
 }
 
-\\"\\"\\"Methods to use when ordering \`DomainType\`.\\"\\"\\"
+"""Methods to use when ordering \`DomainType\`."""
 enum DomainTypesOrderBy {
   CHAR4_DOMAIN_ASC
   CHAR4_DOMAIN_DESC
@@ -2190,59 +2190,59 @@ type EnumArrayType implements Node {
   enumArray: [Mood]
   id: Int!
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`EnumArrayType\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input EnumArrayTypeFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [EnumArrayTypeFilter!]
 
-  \\"\\"\\"Filter by the object’s \`enumArray\` field.\\"\\"\\"
+  """Filter by the object’s \`enumArray\` field."""
   enumArray: MoodListFilter
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: EnumArrayTypeFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [EnumArrayTypeFilter!]
 }
 
-\\"\\"\\"A connection to a list of \`EnumArrayType\` values.\\"\\"\\"
+"""A connection to a list of \`EnumArrayType\` values."""
 type EnumArrayTypesConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`EnumArrayType\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [EnumArrayTypesEdge!]!
 
-  \\"\\"\\"A list of \`EnumArrayType\` objects.\\"\\"\\"
+  """A list of \`EnumArrayType\` objects."""
   nodes: [EnumArrayType]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`EnumArrayType\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`EnumArrayType\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`EnumArrayType\` edge in the connection.\\"\\"\\"
+"""A \`EnumArrayType\` edge in the connection."""
 type EnumArrayTypesEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`EnumArrayType\` at the end of the edge.\\"\\"\\"
+  """The \`EnumArrayType\` at the end of the edge."""
   node: EnumArrayType
 }
 
-\\"\\"\\"Methods to use when ordering \`EnumArrayType\`.\\"\\"\\"
+"""Methods to use when ordering \`EnumArrayType\`."""
 enum EnumArrayTypesOrderBy {
   ENUM_ARRAY_ASC
   ENUM_ARRAY_DESC
@@ -2257,59 +2257,59 @@ type EnumType implements Node {
   enum: Mood
   id: Int!
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`EnumType\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input EnumTypeFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [EnumTypeFilter!]
 
-  \\"\\"\\"Filter by the object’s \`enum\` field.\\"\\"\\"
+  """Filter by the object’s \`enum\` field."""
   enum: MoodFilter
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: EnumTypeFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [EnumTypeFilter!]
 }
 
-\\"\\"\\"A connection to a list of \`EnumType\` values.\\"\\"\\"
+"""A connection to a list of \`EnumType\` values."""
 type EnumTypesConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`EnumType\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [EnumTypesEdge!]!
 
-  \\"\\"\\"A list of \`EnumType\` objects.\\"\\"\\"
+  """A list of \`EnumType\` objects."""
   nodes: [EnumType]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`EnumType\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`EnumType\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`EnumType\` edge in the connection.\\"\\"\\"
+"""A \`EnumType\` edge in the connection."""
 type EnumTypesEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`EnumType\` at the end of the edge.\\"\\"\\"
+  """The \`EnumType\` at the end of the edge."""
   node: EnumType
 }
 
-\\"\\"\\"Methods to use when ordering \`EnumType\`.\\"\\"\\"
+"""Methods to use when ordering \`EnumType\`."""
 enum EnumTypesOrderBy {
   ENUM_ASC
   ENUM_DESC
@@ -2321,14 +2321,14 @@ enum EnumTypesOrderBy {
 }
 
 type Filterable implements Node {
-  \\"\\"\\"Reads a single \`Backward\` that is related to this \`Filterable\`.\\"\\"\\"
+  """Reads a single \`Backward\` that is related to this \`Filterable\`."""
   backwardByFilterableId: Backward
   backwardCompound1: Int
   backwardCompound2: Int
 
-  \\"\\"\\"
+  """
   Reads a single \`BackwardCompound\` that is related to this \`Filterable\`.
-  \\"\\"\\"
+  """
   backwardCompoundByBackwardCompound1AndBackwardCompound2: BackwardCompound
   bit4: BitString
   bool: Boolean
@@ -2336,61 +2336,61 @@ type Filterable implements Node {
   bytea: String
   char4: String
 
-  \\"\\"\\"Reads and enables pagination through a set of \`ChildNoRelatedFilter\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`ChildNoRelatedFilter\`."""
   childNoRelatedFiltersByFilterableId(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: ChildNoRelatedFilterFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`ChildNoRelatedFilter\`.\\"\\"\\"
+    """The method to use when ordering \`ChildNoRelatedFilter\`."""
     orderBy: [ChildNoRelatedFiltersOrderBy!] = [PRIMARY_KEY_ASC]
   ): ChildNoRelatedFiltersConnection!
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Child\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Child\`."""
   childrenByFilterableId(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: ChildFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`Child\`.\\"\\"\\"
+    """The method to use when ordering \`Child\`."""
     orderBy: [ChildrenOrderBy!] = [PRIMARY_KEY_ASC]
   ): ChildrenConnection!
   cidr: String
@@ -2401,126 +2401,126 @@ type Filterable implements Node {
   computedChild: Child
   computedIntArray: [Int]
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Child\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Child\`."""
   computedSetofChild(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: ChildFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
   ): ChildrenConnection!
   computedSetofInt(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: IntFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
   ): FilterableComputedSetofIntConnection!
   computedTaggedFilterable: Int
   computedWithRequiredArg(i: Int!): Int
   date: Date
 
-  \\"\\"\\"Reads and enables pagination through a set of \`FilterableClosure\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`FilterableClosure\`."""
   filterableClosuresByAncestorId(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: FilterableClosureFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`FilterableClosure\`.\\"\\"\\"
+    """The method to use when ordering \`FilterableClosure\`."""
     orderBy: [FilterableClosuresOrderBy!] = [PRIMARY_KEY_ASC]
   ): FilterableClosuresConnection!
 
-  \\"\\"\\"Reads and enables pagination through a set of \`FilterableClosure\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`FilterableClosure\`."""
   filterableClosuresByDescendantId(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: FilterableClosureFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`FilterableClosure\`.\\"\\"\\"
+    """The method to use when ordering \`FilterableClosure\`."""
     orderBy: [FilterableClosuresOrderBy!] = [PRIMARY_KEY_ASC]
   ): FilterableClosuresConnection!
   float4: Float
   float8: Float
 
-  \\"\\"\\"Reads a single \`Forward\` that is related to this \`Filterable\`.\\"\\"\\"
+  """Reads a single \`Forward\` that is related to this \`Filterable\`."""
   forwardByForwardId: Forward
   forwardColumn: Forward
   forwardCompound1: Int
   forwardCompound2: Int
 
-  \\"\\"\\"Reads a single \`ForwardCompound\` that is related to this \`Filterable\`.\\"\\"\\"
+  """Reads a single \`ForwardCompound\` that is related to this \`Filterable\`."""
   forwardCompoundByForwardCompound1AndForwardCompound2: ForwardCompound
   forwardId: Int
   hstore: KeyValueHash
@@ -2536,13 +2536,13 @@ type Filterable implements Node {
   money: Float
   name: String
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
   numeric: BigFloat
 
-  \\"\\"\\"Reads a single \`Parent\` that is related to this \`Filterable\`.\\"\\"\\"
+  """Reads a single \`Parent\` that is related to this \`Filterable\`."""
   parentByParentId: Parent
   parentId: Int
   text: String
@@ -2562,78 +2562,78 @@ type FilterableClosure implements Node {
   depth: Int!
   descendantId: Int!
 
-  \\"\\"\\"
+  """
   Reads a single \`Filterable\` that is related to this \`FilterableClosure\`.
-  \\"\\"\\"
+  """
   filterableByAncestorId: Filterable
 
-  \\"\\"\\"
+  """
   Reads a single \`Filterable\` that is related to this \`FilterableClosure\`.
-  \\"\\"\\"
+  """
   filterableByDescendantId: Filterable
   id: Int!
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`FilterableClosure\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input FilterableClosureFilter {
-  \\"\\"\\"Filter by the object’s \`ancestorId\` field.\\"\\"\\"
+  """Filter by the object’s \`ancestorId\` field."""
   ancestorId: IntFilter
 
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [FilterableClosureFilter!]
 
-  \\"\\"\\"Filter by the object’s \`depth\` field.\\"\\"\\"
+  """Filter by the object’s \`depth\` field."""
   depth: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`descendantId\` field.\\"\\"\\"
+  """Filter by the object’s \`descendantId\` field."""
   descendantId: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: FilterableClosureFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [FilterableClosureFilter!]
 }
 
-\\"\\"\\"A connection to a list of \`FilterableClosure\` values.\\"\\"\\"
+"""A connection to a list of \`FilterableClosure\` values."""
 type FilterableClosuresConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`FilterableClosure\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [FilterableClosuresEdge!]!
 
-  \\"\\"\\"A list of \`FilterableClosure\` objects.\\"\\"\\"
+  """A list of \`FilterableClosure\` objects."""
   nodes: [FilterableClosure]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"
+  """
   The count of *all* \`FilterableClosure\` you could get from the connection.
-  \\"\\"\\"
+  """
   totalCount: Int!
 }
 
-\\"\\"\\"A \`FilterableClosure\` edge in the connection.\\"\\"\\"
+"""A \`FilterableClosure\` edge in the connection."""
 type FilterableClosuresEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`FilterableClosure\` at the end of the edge.\\"\\"\\"
+  """The \`FilterableClosure\` at the end of the edge."""
   node: FilterableClosure
 }
 
-\\"\\"\\"Methods to use when ordering \`FilterableClosure\`.\\"\\"\\"
+"""Methods to use when ordering \`FilterableClosure\`."""
 enum FilterableClosuresOrderBy {
   ANCESTOR_ID_ASC
   ANCESTOR_ID_DESC
@@ -2648,181 +2648,181 @@ enum FilterableClosuresOrderBy {
   PRIMARY_KEY_DESC
 }
 
-\\"\\"\\"A connection to a list of \`Int\` values.\\"\\"\\"
+"""A connection to a list of \`Int\` values."""
 type FilterableComputedSetofIntConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`Int\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [FilterableComputedSetofIntEdge!]!
 
-  \\"\\"\\"A list of \`Int\` objects.\\"\\"\\"
+  """A list of \`Int\` objects."""
   nodes: [Int]!
 
-  \\"\\"\\"The count of *all* \`Int\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`Int\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`Int\` edge in the connection.\\"\\"\\"
+"""A \`Int\` edge in the connection."""
 type FilterableComputedSetofIntEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`Int\` at the end of the edge.\\"\\"\\"
+  """The \`Int\` at the end of the edge."""
   node: Int
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`Filterable\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input FilterableFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [FilterableFilter!]
 
-  \\"\\"\\"Filter by the object’s \`backwardCompound1\` field.\\"\\"\\"
+  """Filter by the object’s \`backwardCompound1\` field."""
   backwardCompound1: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`backwardCompound2\` field.\\"\\"\\"
+  """Filter by the object’s \`backwardCompound2\` field."""
   backwardCompound2: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`bit4\` field.\\"\\"\\"
+  """Filter by the object’s \`bit4\` field."""
   bit4: BitStringFilter
 
-  \\"\\"\\"Filter by the object’s \`bool\` field.\\"\\"\\"
+  """Filter by the object’s \`bool\` field."""
   bool: BooleanFilter
 
-  \\"\\"\\"Filter by the object’s \`bpchar4\` field.\\"\\"\\"
+  """Filter by the object’s \`bpchar4\` field."""
   bpchar4: StringFilter
 
-  \\"\\"\\"Filter by the object’s \`char4\` field.\\"\\"\\"
+  """Filter by the object’s \`char4\` field."""
   char4: StringFilter
 
-  \\"\\"\\"Filter by the object’s \`citext\` field.\\"\\"\\"
+  """Filter by the object’s \`citext\` field."""
   citext: StringFilter
 
-  \\"\\"\\"Filter by the object’s \`compositeColumn\` field.\\"\\"\\"
+  """Filter by the object’s \`compositeColumn\` field."""
   compositeColumn: CompositeFilter
 
-  \\"\\"\\"Filter by the object’s \`computed\` field.\\"\\"\\"
+  """Filter by the object’s \`computed\` field."""
   computed: StringFilter
 
-  \\"\\"\\"Filter by the object’s \`computedIntArray\` field.\\"\\"\\"
+  """Filter by the object’s \`computedIntArray\` field."""
   computedIntArray: IntListFilter
 
-  \\"\\"\\"Filter by the object’s \`computedTaggedFilterable\` field.\\"\\"\\"
+  """Filter by the object’s \`computedTaggedFilterable\` field."""
   computedTaggedFilterable: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`date\` field.\\"\\"\\"
+  """Filter by the object’s \`date\` field."""
   date: DateFilter
 
-  \\"\\"\\"Filter by the object’s \`float4\` field.\\"\\"\\"
+  """Filter by the object’s \`float4\` field."""
   float4: FloatFilter
 
-  \\"\\"\\"Filter by the object’s \`float8\` field.\\"\\"\\"
+  """Filter by the object’s \`float8\` field."""
   float8: FloatFilter
 
-  \\"\\"\\"Filter by the object’s \`forwardCompound1\` field.\\"\\"\\"
+  """Filter by the object’s \`forwardCompound1\` field."""
   forwardCompound1: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`forwardCompound2\` field.\\"\\"\\"
+  """Filter by the object’s \`forwardCompound2\` field."""
   forwardCompound2: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`forwardId\` field.\\"\\"\\"
+  """Filter by the object’s \`forwardId\` field."""
   forwardId: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`hstore\` field.\\"\\"\\"
+  """Filter by the object’s \`hstore\` field."""
   hstore: KeyValueHashFilter
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`inet\` field.\\"\\"\\"
+  """Filter by the object’s \`inet\` field."""
   inet: InternetAddressFilter
 
-  \\"\\"\\"Filter by the object’s \`int2\` field.\\"\\"\\"
+  """Filter by the object’s \`int2\` field."""
   int2: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`int4\` field.\\"\\"\\"
+  """Filter by the object’s \`int4\` field."""
   int4: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`int8\` field.\\"\\"\\"
+  """Filter by the object’s \`int8\` field."""
   int8: BigIntFilter
 
-  \\"\\"\\"Filter by the object’s \`interval\` field.\\"\\"\\"
+  """Filter by the object’s \`interval\` field."""
   interval: IntervalFilter
 
-  \\"\\"\\"Filter by the object’s \`jsonb\` field.\\"\\"\\"
+  """Filter by the object’s \`jsonb\` field."""
   jsonb: JSONFilter
 
-  \\"\\"\\"Filter by the object’s \`money\` field.\\"\\"\\"
+  """Filter by the object’s \`money\` field."""
   money: FloatFilter
 
-  \\"\\"\\"Filter by the object’s \`name\` field.\\"\\"\\"
+  """Filter by the object’s \`name\` field."""
   name: StringFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: FilterableFilter
 
-  \\"\\"\\"Filter by the object’s \`numeric\` field.\\"\\"\\"
+  """Filter by the object’s \`numeric\` field."""
   numeric: BigFloatFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [FilterableFilter!]
 
-  \\"\\"\\"Filter by the object’s \`parentId\` field.\\"\\"\\"
+  """Filter by the object’s \`parentId\` field."""
   parentId: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`text\` field.\\"\\"\\"
+  """Filter by the object’s \`text\` field."""
   text: StringFilter
 
-  \\"\\"\\"Filter by the object’s \`time\` field.\\"\\"\\"
+  """Filter by the object’s \`time\` field."""
   time: TimeFilter
 
-  \\"\\"\\"Filter by the object’s \`timestamp\` field.\\"\\"\\"
+  """Filter by the object’s \`timestamp\` field."""
   timestamp: DatetimeFilter
 
-  \\"\\"\\"Filter by the object’s \`timestamptz\` field.\\"\\"\\"
+  """Filter by the object’s \`timestamptz\` field."""
   timestamptz: DatetimeFilter
 
-  \\"\\"\\"Filter by the object’s \`timetz\` field.\\"\\"\\"
+  """Filter by the object’s \`timetz\` field."""
   timetz: TimeFilter
 
-  \\"\\"\\"Filter by the object’s \`uuid\` field.\\"\\"\\"
+  """Filter by the object’s \`uuid\` field."""
   uuid: UUIDFilter
 
-  \\"\\"\\"Filter by the object’s \`varbit\` field.\\"\\"\\"
+  """Filter by the object’s \`varbit\` field."""
   varbit: BitStringFilter
 
-  \\"\\"\\"Filter by the object’s \`varchar\` field.\\"\\"\\"
+  """Filter by the object’s \`varchar\` field."""
   varchar: StringFilter
 }
 
-\\"\\"\\"A connection to a list of \`Filterable\` values.\\"\\"\\"
+"""A connection to a list of \`Filterable\` values."""
 type FilterablesConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`Filterable\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [FilterablesEdge!]!
 
-  \\"\\"\\"A list of \`Filterable\` objects.\\"\\"\\"
+  """A list of \`Filterable\` objects."""
   nodes: [Filterable]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`Filterable\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`Filterable\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`Filterable\` edge in the connection.\\"\\"\\"
+"""A \`Filterable\` edge in the connection."""
 type FilterablesEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`Filterable\` at the end of the edge.\\"\\"\\"
+  """The \`Filterable\` at the end of the edge."""
   node: Filterable
 }
 
-\\"\\"\\"Methods to use when ordering \`Filterable\`.\\"\\"\\"
+"""Methods to use when ordering \`Filterable\`."""
 enum FilterablesOrderBy {
   BACKWARD_COMPOUND_1_ASC
   BACKWARD_COMPOUND_1_DESC
@@ -2911,188 +2911,188 @@ enum FilterablesOrderBy {
   XML_DESC
 }
 
-\\"\\"\\"
+"""
 A filter to be used against Float fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input FloatFilter {
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: Float
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   eq: Float
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: Float
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: Float
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [Float!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: Float
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: Float
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   ne: Float
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: Float
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [Float!]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against Float List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input FloatListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: Float
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: Float
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: Float
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: Float
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: Float
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: Float
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [Float]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [Float]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [Float]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   eq: [Float]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [Float]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [Float]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [Float]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [Float]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   ne: [Float]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [Float]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [Float]
 }
 
 type Forward implements Node {
-  \\"\\"\\"Reads a single \`Filterable\` that is related to this \`Forward\`.\\"\\"\\"
+  """Reads a single \`Filterable\` that is related to this \`Forward\`."""
   filterableByForwardId: Filterable
   id: Int!
   name: String!
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
 type ForwardCompound implements Node {
-  \\"\\"\\"Reads a single \`Filterable\` that is related to this \`ForwardCompound\`.\\"\\"\\"
+  """Reads a single \`Filterable\` that is related to this \`ForwardCompound\`."""
   filterableByForwardCompound1AndForwardCompound2: Filterable
   forwardCompound1: Int!
   forwardCompound2: Int!
   name: String
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`ForwardCompound\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input ForwardCompoundFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [ForwardCompoundFilter!]
 
-  \\"\\"\\"Filter by the object’s \`forwardCompound1\` field.\\"\\"\\"
+  """Filter by the object’s \`forwardCompound1\` field."""
   forwardCompound1: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`forwardCompound2\` field.\\"\\"\\"
+  """Filter by the object’s \`forwardCompound2\` field."""
   forwardCompound2: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`name\` field.\\"\\"\\"
+  """Filter by the object’s \`name\` field."""
   name: StringFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: ForwardCompoundFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [ForwardCompoundFilter!]
 }
 
-\\"\\"\\"A connection to a list of \`ForwardCompound\` values.\\"\\"\\"
+"""A connection to a list of \`ForwardCompound\` values."""
 type ForwardCompoundsConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`ForwardCompound\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [ForwardCompoundsEdge!]!
 
-  \\"\\"\\"A list of \`ForwardCompound\` objects.\\"\\"\\"
+  """A list of \`ForwardCompound\` objects."""
   nodes: [ForwardCompound]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"
+  """
   The count of *all* \`ForwardCompound\` you could get from the connection.
-  \\"\\"\\"
+  """
   totalCount: Int!
 }
 
-\\"\\"\\"A \`ForwardCompound\` edge in the connection.\\"\\"\\"
+"""A \`ForwardCompound\` edge in the connection."""
 type ForwardCompoundsEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`ForwardCompound\` at the end of the edge.\\"\\"\\"
+  """The \`ForwardCompound\` at the end of the edge."""
   node: ForwardCompound
 }
 
-\\"\\"\\"Methods to use when ordering \`ForwardCompound\`.\\"\\"\\"
+"""Methods to use when ordering \`ForwardCompound\`."""
 enum ForwardCompoundsOrderBy {
   FORWARD_COMPOUND_1_ASC
   FORWARD_COMPOUND_1_DESC
@@ -3105,53 +3105,53 @@ enum ForwardCompoundsOrderBy {
   PRIMARY_KEY_DESC
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`Forward\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input ForwardFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [ForwardFilter!]
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`name\` field.\\"\\"\\"
+  """Filter by the object’s \`name\` field."""
   name: StringFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: ForwardFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [ForwardFilter!]
 }
 
-\\"\\"\\"A connection to a list of \`Forward\` values.\\"\\"\\"
+"""A connection to a list of \`Forward\` values."""
 type ForwardsConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`Forward\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [ForwardsEdge!]!
 
-  \\"\\"\\"A list of \`Forward\` objects.\\"\\"\\"
+  """A list of \`Forward\` objects."""
   nodes: [Forward]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`Forward\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`Forward\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`Forward\` edge in the connection.\\"\\"\\"
+"""A \`Forward\` edge in the connection."""
 type ForwardsEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`Forward\` at the end of the edge.\\"\\"\\"
+  """The \`Forward\` at the end of the edge."""
   node: Forward
 }
 
-\\"\\"\\"Methods to use when ordering \`Forward\`.\\"\\"\\"
+"""Methods to use when ordering \`Forward\`."""
 enum ForwardsOrderBy {
   ID_ASC
   ID_DESC
@@ -3165,40 +3165,40 @@ enum ForwardsOrderBy {
 type FullyOmitted implements Node {
   id: Int!
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
   text: String
 }
 
-\\"\\"\\"A connection to a list of \`FullyOmitted\` values.\\"\\"\\"
+"""A connection to a list of \`FullyOmitted\` values."""
 type FullyOmittedsConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`FullyOmitted\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [FullyOmittedsEdge!]!
 
-  \\"\\"\\"A list of \`FullyOmitted\` objects.\\"\\"\\"
+  """A list of \`FullyOmitted\` objects."""
   nodes: [FullyOmitted]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`FullyOmitted\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`FullyOmitted\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`FullyOmitted\` edge in the connection.\\"\\"\\"
+"""A \`FullyOmitted\` edge in the connection."""
 type FullyOmittedsEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`FullyOmitted\` at the end of the edge.\\"\\"\\"
+  """The \`FullyOmitted\` at the end of the edge."""
   node: FullyOmitted
 }
 
-\\"\\"\\"Methods to use when ordering \`FullyOmitted\`.\\"\\"\\"
+"""Methods to use when ordering \`FullyOmitted\`."""
 enum FullyOmittedsOrderBy {
   ID_ASC
   ID_DESC
@@ -3209,746 +3209,746 @@ enum FullyOmittedsOrderBy {
   TEXT_DESC
 }
 
-\\"\\"\\"A connection to a list of \`FuncReturnsTableMultiColRecord\` values.\\"\\"\\"
+"""A connection to a list of \`FuncReturnsTableMultiColRecord\` values."""
 type FuncReturnsTableMultiColConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`FuncReturnsTableMultiColRecord\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [FuncReturnsTableMultiColEdge!]!
 
-  \\"\\"\\"A list of \`FuncReturnsTableMultiColRecord\` objects.\\"\\"\\"
+  """A list of \`FuncReturnsTableMultiColRecord\` objects."""
   nodes: [FuncReturnsTableMultiColRecord]!
 
-  \\"\\"\\"
+  """
   The count of *all* \`FuncReturnsTableMultiColRecord\` you could get from the connection.
-  \\"\\"\\"
+  """
   totalCount: Int!
 }
 
-\\"\\"\\"A \`FuncReturnsTableMultiColRecord\` edge in the connection.\\"\\"\\"
+"""A \`FuncReturnsTableMultiColRecord\` edge in the connection."""
 type FuncReturnsTableMultiColEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`FuncReturnsTableMultiColRecord\` at the end of the edge.\\"\\"\\"
+  """The \`FuncReturnsTableMultiColRecord\` at the end of the edge."""
   node: FuncReturnsTableMultiColRecord
 }
 
-\\"\\"\\"The return type of our \`funcReturnsTableMultiCol\` query.\\"\\"\\"
+"""The return type of our \`funcReturnsTableMultiCol\` query."""
 type FuncReturnsTableMultiColRecord {
   col1: Int
   col2: String
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`FuncReturnsTableMultiColRecord\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input FuncReturnsTableMultiColRecordFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [FuncReturnsTableMultiColRecordFilter!]
 
-  \\"\\"\\"Filter by the object’s \`col1\` field.\\"\\"\\"
+  """Filter by the object’s \`col1\` field."""
   col1: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`col2\` field.\\"\\"\\"
+  """Filter by the object’s \`col2\` field."""
   col2: StringFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: FuncReturnsTableMultiColRecordFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [FuncReturnsTableMultiColRecordFilter!]
 }
 
-\\"\\"\\"A connection to a list of \`Int\` values.\\"\\"\\"
+"""A connection to a list of \`Int\` values."""
 type FuncReturnsTableOneColConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`Int\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [FuncReturnsTableOneColEdge!]!
 
-  \\"\\"\\"A list of \`Int\` objects.\\"\\"\\"
+  """A list of \`Int\` objects."""
   nodes: [Int]!
 
-  \\"\\"\\"The count of *all* \`Int\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`Int\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`Int\` edge in the connection.\\"\\"\\"
+"""A \`Int\` edge in the connection."""
 type FuncReturnsTableOneColEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`Int\` at the end of the edge.\\"\\"\\"
+  """The \`Int\` at the end of the edge."""
   node: Int
 }
 
-\\"\\"\\"
+"""
 A connection to a list of \`FuncTaggedFilterableReturnsTableMultiColRecord\` values.
-\\"\\"\\"
+"""
 type FuncTaggedFilterableReturnsTableMultiColConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`FuncTaggedFilterableReturnsTableMultiColRecord\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [FuncTaggedFilterableReturnsTableMultiColEdge!]!
 
-  \\"\\"\\"A list of \`FuncTaggedFilterableReturnsTableMultiColRecord\` objects.\\"\\"\\"
+  """A list of \`FuncTaggedFilterableReturnsTableMultiColRecord\` objects."""
   nodes: [FuncTaggedFilterableReturnsTableMultiColRecord]!
 
-  \\"\\"\\"
+  """
   The count of *all* \`FuncTaggedFilterableReturnsTableMultiColRecord\` you could get from the connection.
-  \\"\\"\\"
+  """
   totalCount: Int!
 }
 
-\\"\\"\\"
+"""
 A \`FuncTaggedFilterableReturnsTableMultiColRecord\` edge in the connection.
-\\"\\"\\"
+"""
 type FuncTaggedFilterableReturnsTableMultiColEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"
+  """
   The \`FuncTaggedFilterableReturnsTableMultiColRecord\` at the end of the edge.
-  \\"\\"\\"
+  """
   node: FuncTaggedFilterableReturnsTableMultiColRecord
 }
 
-\\"\\"\\"
+"""
 The return type of our \`funcTaggedFilterableReturnsTableMultiCol\` query.
-\\"\\"\\"
+"""
 type FuncTaggedFilterableReturnsTableMultiColRecord {
   col1: Int
   col2: String
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`FuncTaggedFilterableReturnsTableMultiColRecord\`
 object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input FuncTaggedFilterableReturnsTableMultiColRecordFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [FuncTaggedFilterableReturnsTableMultiColRecordFilter!]
 
-  \\"\\"\\"Filter by the object’s \`col1\` field.\\"\\"\\"
+  """Filter by the object’s \`col1\` field."""
   col1: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`col2\` field.\\"\\"\\"
+  """Filter by the object’s \`col2\` field."""
   col2: StringFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: FuncTaggedFilterableReturnsTableMultiColRecordFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [FuncTaggedFilterableReturnsTableMultiColRecordFilter!]
 }
 
 scalar Int4Domain
 
-\\"\\"\\"
+"""
 A filter to be used against Int4Domain fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input Int4DomainFilter {
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: Int4Domain
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   eq: Int4Domain
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: Int4Domain
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: Int4Domain
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [Int4Domain!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: Int4Domain
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: Int4Domain
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   ne: Int4Domain
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: Int4Domain
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [Int4Domain!]
 }
 
-\\"\\"\\"An IPv4 or IPv6 host address, and optionally its subnet.\\"\\"\\"
+"""An IPv4 or IPv6 host address, and optionally its subnet."""
 scalar InternetAddress
 
-\\"\\"\\"
+"""
 A filter to be used against InternetAddress fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input InternetAddressFilter {
-  \\"\\"\\"Contained by the specified internet address.\\"\\"\\"
+  """Contained by the specified internet address."""
   containedBy: InternetAddress
 
-  \\"\\"\\"Contained by or equal to the specified internet address.\\"\\"\\"
+  """Contained by or equal to the specified internet address."""
   containedByOrEqualTo: InternetAddress
 
-  \\"\\"\\"Contains the specified internet address.\\"\\"\\"
+  """Contains the specified internet address."""
   contains: InternetAddress
 
-  \\"\\"\\"Contains or contained by the specified internet address.\\"\\"\\"
+  """Contains or contained by the specified internet address."""
   containsOrContainedBy: InternetAddress
 
-  \\"\\"\\"Contains or equal to the specified internet address.\\"\\"\\"
+  """Contains or equal to the specified internet address."""
   containsOrEqualTo: InternetAddress
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: InternetAddress
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   eq: InternetAddress
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: InternetAddress
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: InternetAddress
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [InternetAddress!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: InternetAddress
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: InternetAddress
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   ne: InternetAddress
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: InternetAddress
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [InternetAddress!]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against InternetAddress List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input InternetAddressListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: InternetAddress
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: InternetAddress
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: InternetAddress
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: InternetAddress
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: InternetAddress
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: InternetAddress
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [InternetAddress]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [InternetAddress]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [InternetAddress]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   eq: [InternetAddress]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [InternetAddress]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [InternetAddress]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [InternetAddress]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [InternetAddress]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   ne: [InternetAddress]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [InternetAddress]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [InternetAddress]
 }
 
-\\"\\"\\"
+"""
 An interval of time that has passed where the smallest distinct unit is a second.
-\\"\\"\\"
+"""
 type Interval {
-  \\"\\"\\"A quantity of days.\\"\\"\\"
+  """A quantity of days."""
   days: Int
 
-  \\"\\"\\"A quantity of hours.\\"\\"\\"
+  """A quantity of hours."""
   hours: Int
 
-  \\"\\"\\"A quantity of minutes.\\"\\"\\"
+  """A quantity of minutes."""
   minutes: Int
 
-  \\"\\"\\"A quantity of months.\\"\\"\\"
+  """A quantity of months."""
   months: Int
 
-  \\"\\"\\"
+  """
   A quantity of seconds. This is the only non-integer field, as all the other
   fields will dump their overflow into a smaller unit of time. Intervals don’t
   have a smaller unit than seconds.
-  \\"\\"\\"
+  """
   seconds: Float
 
-  \\"\\"\\"A quantity of years.\\"\\"\\"
+  """A quantity of years."""
   years: Int
 }
 
-\\"\\"\\"
+"""
 A filter to be used against Interval fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input IntervalFilter {
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: IntervalInput
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   eq: IntervalInput
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: IntervalInput
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: IntervalInput
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [IntervalInput!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: IntervalInput
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: IntervalInput
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   ne: IntervalInput
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: IntervalInput
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [IntervalInput!]
 }
 
-\\"\\"\\"
+"""
 An interval of time that has passed where the smallest distinct unit is a second.
-\\"\\"\\"
+"""
 input IntervalInput {
-  \\"\\"\\"A quantity of days.\\"\\"\\"
+  """A quantity of days."""
   days: Int
 
-  \\"\\"\\"A quantity of hours.\\"\\"\\"
+  """A quantity of hours."""
   hours: Int
 
-  \\"\\"\\"A quantity of minutes.\\"\\"\\"
+  """A quantity of minutes."""
   minutes: Int
 
-  \\"\\"\\"A quantity of months.\\"\\"\\"
+  """A quantity of months."""
   months: Int
 
-  \\"\\"\\"
+  """
   A quantity of seconds. This is the only non-integer field, as all the other
   fields will dump their overflow into a smaller unit of time. Intervals don’t
   have a smaller unit than seconds.
-  \\"\\"\\"
+  """
   seconds: Float
 
-  \\"\\"\\"A quantity of years.\\"\\"\\"
+  """A quantity of years."""
   years: Int
 }
 
-\\"\\"\\"
+"""
 A filter to be used against Interval List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input IntervalListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: IntervalInput
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: IntervalInput
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: IntervalInput
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: IntervalInput
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: IntervalInput
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: IntervalInput
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [IntervalInput]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [IntervalInput]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [IntervalInput]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   eq: [IntervalInput]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [IntervalInput]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [IntervalInput]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [IntervalInput]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [IntervalInput]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   ne: [IntervalInput]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [IntervalInput]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [IntervalInput]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against Int fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input IntFilter {
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: Int
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   eq: Int
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: Int
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: Int
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [Int!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: Int
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: Int
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   ne: Int
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: Int
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [Int!]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against Int List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input IntListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: Int
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: Int
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: Int
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: Int
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: Int
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: Int
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [Int]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [Int]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [Int]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   eq: [Int]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [Int]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [Int]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [Int]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [Int]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   ne: [Int]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [Int]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [Int]
 }
 
-\\"\\"\\"A range of \`Int\`.\\"\\"\\"
+"""A range of \`Int\`."""
 type IntRange {
-  \\"\\"\\"The ending bound of our range.\\"\\"\\"
+  """The ending bound of our range."""
   end: IntRangeBound
 
-  \\"\\"\\"The starting bound of our range.\\"\\"\\"
+  """The starting bound of our range."""
   start: IntRangeBound
 }
 
-\\"\\"\\"
+"""
 The value at one end of a range. A range can either include this value, or not.
-\\"\\"\\"
+"""
 type IntRangeBound {
-  \\"\\"\\"Whether or not the value of this bound is included in the range.\\"\\"\\"
+  """Whether or not the value of this bound is included in the range."""
   inclusive: Boolean!
 
-  \\"\\"\\"The value at one end of our range.\\"\\"\\"
+  """The value at one end of our range."""
   value: Int!
 }
 
-\\"\\"\\"
+"""
 The value at one end of a range. A range can either include this value, or not.
-\\"\\"\\"
+"""
 input IntRangeBoundInput {
-  \\"\\"\\"Whether or not the value of this bound is included in the range.\\"\\"\\"
+  """Whether or not the value of this bound is included in the range."""
   inclusive: Boolean!
 
-  \\"\\"\\"The value at one end of our range.\\"\\"\\"
+  """The value at one end of our range."""
   value: Int!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against IntRange fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input IntRangeFilter {
-  \\"\\"\\"Adjacent to the specified range.\\"\\"\\"
+  """Adjacent to the specified range."""
   adjacentTo: IntRangeInput
 
-  \\"\\"\\"Contained by the specified range.\\"\\"\\"
+  """Contained by the specified range."""
   containedBy: IntRangeInput
 
-  \\"\\"\\"Contains the specified range.\\"\\"\\"
+  """Contains the specified range."""
   contains: IntRangeInput
 
-  \\"\\"\\"Contains the specified value.\\"\\"\\"
+  """Contains the specified value."""
   containsElement: Int
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: IntRangeInput
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   eq: IntRangeInput
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: IntRangeInput
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: IntRangeInput
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [IntRangeInput!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: IntRangeInput
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: IntRangeInput
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   ne: IntRangeInput
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: IntRangeInput
 
-  \\"\\"\\"Does not extend left of the specified range.\\"\\"\\"
+  """Does not extend left of the specified range."""
   notExtendsLeftOf: IntRangeInput
 
-  \\"\\"\\"Does not extend right of the specified range.\\"\\"\\"
+  """Does not extend right of the specified range."""
   notExtendsRightOf: IntRangeInput
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [IntRangeInput!]
 
-  \\"\\"\\"Overlaps the specified range.\\"\\"\\"
+  """Overlaps the specified range."""
   overlaps: IntRangeInput
 
-  \\"\\"\\"Strictly left of the specified range.\\"\\"\\"
+  """Strictly left of the specified range."""
   strictlyLeftOf: IntRangeInput
 
-  \\"\\"\\"Strictly right of the specified range.\\"\\"\\"
+  """Strictly right of the specified range."""
   strictlyRightOf: IntRangeInput
 }
 
-\\"\\"\\"A range of \`Int\`.\\"\\"\\"
+"""A range of \`Int\`."""
 input IntRangeInput {
-  \\"\\"\\"The ending bound of our range.\\"\\"\\"
+  """The ending bound of our range."""
   end: IntRangeBoundInput
 
-  \\"\\"\\"The starting bound of our range.\\"\\"\\"
+  """The starting bound of our range."""
   start: IntRangeBoundInput
 }
 
-\\"\\"\\"
+"""
 A filter to be used against IntRange List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input IntRangeListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: IntRangeInput
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: IntRangeInput
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: IntRangeInput
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: IntRangeInput
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: IntRangeInput
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: IntRangeInput
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [IntRangeInput]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [IntRangeInput]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [IntRangeInput]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   eq: [IntRangeInput]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [IntRangeInput]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [IntRangeInput]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [IntRangeInput]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [IntRangeInput]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   ne: [IntRangeInput]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [IntRangeInput]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [IntRangeInput]
 }
 
-\\"\\"\\"
+"""
 A JavaScript object encoded in the JSON format as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf).
-\\"\\"\\"
+"""
 scalar JSON
 
 type JsonbTest implements Node {
@@ -3956,62 +3956,62 @@ type JsonbTest implements Node {
   jsonbWithArray: JSON
   jsonbWithObject: JSON
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`JsonbTest\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input JsonbTestFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [JsonbTestFilter!]
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`jsonbWithArray\` field.\\"\\"\\"
+  """Filter by the object’s \`jsonbWithArray\` field."""
   jsonbWithArray: JSONFilter
 
-  \\"\\"\\"Filter by the object’s \`jsonbWithObject\` field.\\"\\"\\"
+  """Filter by the object’s \`jsonbWithObject\` field."""
   jsonbWithObject: JSONFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: JsonbTestFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [JsonbTestFilter!]
 }
 
-\\"\\"\\"A connection to a list of \`JsonbTest\` values.\\"\\"\\"
+"""A connection to a list of \`JsonbTest\` values."""
 type JsonbTestsConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`JsonbTest\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [JsonbTestsEdge!]!
 
-  \\"\\"\\"A list of \`JsonbTest\` objects.\\"\\"\\"
+  """A list of \`JsonbTest\` objects."""
   nodes: [JsonbTest]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`JsonbTest\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`JsonbTest\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`JsonbTest\` edge in the connection.\\"\\"\\"
+"""A \`JsonbTest\` edge in the connection."""
 type JsonbTestsEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`JsonbTest\` at the end of the edge.\\"\\"\\"
+  """The \`JsonbTest\` at the end of the edge."""
   node: JsonbTest
 }
 
-\\"\\"\\"Methods to use when ordering \`JsonbTest\`.\\"\\"\\"
+"""Methods to use when ordering \`JsonbTest\`."""
 enum JsonbTestsOrderBy {
   ID_ASC
   ID_DESC
@@ -4024,188 +4024,188 @@ enum JsonbTestsOrderBy {
   PRIMARY_KEY_DESC
 }
 
-\\"\\"\\"
+"""
 A filter to be used against JSON fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input JSONFilter {
-  \\"\\"\\"Contained by the specified JSON.\\"\\"\\"
+  """Contained by the specified JSON."""
   containedBy: JSON
 
-  \\"\\"\\"Contains the specified JSON.\\"\\"\\"
+  """Contains the specified JSON."""
   contains: JSON
 
-  \\"\\"\\"Contains all of the specified keys.\\"\\"\\"
+  """Contains all of the specified keys."""
   containsAllKeys: [String!]
 
-  \\"\\"\\"Contains any of the specified keys.\\"\\"\\"
+  """Contains any of the specified keys."""
   containsAnyKeys: [String!]
 
-  \\"\\"\\"Contains the specified key.\\"\\"\\"
+  """Contains the specified key."""
   containsKey: String
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: JSON
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   eq: JSON
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: JSON
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: JSON
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [JSON!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: JSON
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: JSON
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   ne: JSON
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: JSON
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [JSON!]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against JSON List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input JSONListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: JSON
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: JSON
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: JSON
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: JSON
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: JSON
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: JSON
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [JSON]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [JSON]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [JSON]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   eq: [JSON]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [JSON]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [JSON]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [JSON]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [JSON]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   ne: [JSON]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [JSON]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [JSON]
 }
 
 type Junction implements Node {
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 
-  \\"\\"\\"Reads a single \`SideA\` that is related to this \`Junction\`.\\"\\"\\"
+  """Reads a single \`SideA\` that is related to this \`Junction\`."""
   sideABySideAId: SideA
   sideAId: Int!
 
-  \\"\\"\\"Reads a single \`SideB\` that is related to this \`Junction\`.\\"\\"\\"
+  """Reads a single \`SideB\` that is related to this \`Junction\`."""
   sideBBySideBId: SideB
   sideBId: Int!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`Junction\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input JunctionFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [JunctionFilter!]
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: JunctionFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [JunctionFilter!]
 
-  \\"\\"\\"Filter by the object’s \`sideAId\` field.\\"\\"\\"
+  """Filter by the object’s \`sideAId\` field."""
   sideAId: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`sideBId\` field.\\"\\"\\"
+  """Filter by the object’s \`sideBId\` field."""
   sideBId: IntFilter
 }
 
-\\"\\"\\"A connection to a list of \`Junction\` values.\\"\\"\\"
+"""A connection to a list of \`Junction\` values."""
 type JunctionsConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`Junction\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [JunctionsEdge!]!
 
-  \\"\\"\\"A list of \`Junction\` objects.\\"\\"\\"
+  """A list of \`Junction\` objects."""
   nodes: [Junction]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`Junction\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`Junction\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`Junction\` edge in the connection.\\"\\"\\"
+"""A \`Junction\` edge in the connection."""
 type JunctionsEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`Junction\` at the end of the edge.\\"\\"\\"
+  """The \`Junction\` at the end of the edge."""
   node: Junction
 }
 
-\\"\\"\\"Methods to use when ordering \`Junction\`.\\"\\"\\"
+"""Methods to use when ordering \`Junction\`."""
 enum JunctionsOrderBy {
   NATURAL
   PRIMARY_KEY_ASC
@@ -4216,116 +4216,116 @@ enum JunctionsOrderBy {
   SIDE_B_ID_DESC
 }
 
-\\"\\"\\"
+"""
 A set of key/value pairs, keys are strings, values may be a string or null. Exposed as a JSON object.
-\\"\\"\\"
+"""
 scalar KeyValueHash
 
-\\"\\"\\"
+"""
 A filter to be used against KeyValueHash fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input KeyValueHashFilter {
-  \\"\\"\\"Contained by the specified KeyValueHash.\\"\\"\\"
+  """Contained by the specified KeyValueHash."""
   containedBy: KeyValueHash
 
-  \\"\\"\\"Contains the specified KeyValueHash.\\"\\"\\"
+  """Contains the specified KeyValueHash."""
   contains: KeyValueHash
 
-  \\"\\"\\"Contains all of the specified keys.\\"\\"\\"
+  """Contains all of the specified keys."""
   containsAllKeys: [String!]
 
-  \\"\\"\\"Contains any of the specified keys.\\"\\"\\"
+  """Contains any of the specified keys."""
   containsAnyKeys: [String!]
 
-  \\"\\"\\"Contains the specified key.\\"\\"\\"
+  """Contains the specified key."""
   containsKey: String
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: KeyValueHash
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   eq: KeyValueHash
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [KeyValueHash!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   ne: KeyValueHash
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: KeyValueHash
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [KeyValueHash!]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against KeyValueHash List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input KeyValueHashListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: KeyValueHash
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: KeyValueHash
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: KeyValueHash
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: KeyValueHash
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: KeyValueHash
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: KeyValueHash
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [KeyValueHash]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [KeyValueHash]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [KeyValueHash]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   eq: [KeyValueHash]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [KeyValueHash]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [KeyValueHash]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [KeyValueHash]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [KeyValueHash]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   ne: [KeyValueHash]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [KeyValueHash]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [KeyValueHash]
 }
 
@@ -4335,219 +4335,219 @@ enum Mood {
   SAD
 }
 
-\\"\\"\\"
+"""
 A filter to be used against Mood fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input MoodFilter {
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: Mood
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   eq: Mood
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: Mood
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: Mood
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [Mood!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: Mood
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: Mood
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   ne: Mood
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: Mood
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [Mood!]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against Mood List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input MoodListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: Mood
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: Mood
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: Mood
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: Mood
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: Mood
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: Mood
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [Mood]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [Mood]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [Mood]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   eq: [Mood]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [Mood]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [Mood]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [Mood]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [Mood]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   ne: [Mood]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [Mood]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [Mood]
 }
 
-\\"\\"\\"An object with a globally unique \`ID\`.\\"\\"\\"
+"""An object with a globally unique \`ID\`."""
 interface Node {
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
-\\"\\"\\"Information about pagination in a connection.\\"\\"\\"
+"""Information about pagination in a connection."""
 type PageInfo {
-  \\"\\"\\"When paginating forwards, the cursor to continue.\\"\\"\\"
+  """When paginating forwards, the cursor to continue."""
   endCursor: Cursor
 
-  \\"\\"\\"When paginating forwards, are there more items?\\"\\"\\"
+  """When paginating forwards, are there more items?"""
   hasNextPage: Boolean!
 
-  \\"\\"\\"When paginating backwards, are there more items?\\"\\"\\"
+  """When paginating backwards, are there more items?"""
   hasPreviousPage: Boolean!
 
-  \\"\\"\\"When paginating backwards, the cursor to continue.\\"\\"\\"
+  """When paginating backwards, the cursor to continue."""
   startCursor: Cursor
 }
 
 type Parent implements Node {
-  \\"\\"\\"Reads and enables pagination through a set of \`Filterable\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Filterable\`."""
   filterablesByParentId(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: FilterableFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`Filterable\`.\\"\\"\\"
+    """The method to use when ordering \`Filterable\`."""
     orderBy: [FilterablesOrderBy!] = [PRIMARY_KEY_ASC]
   ): FilterablesConnection!
   id: Int!
   name: String!
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`Parent\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input ParentFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [ParentFilter!]
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`name\` field.\\"\\"\\"
+  """Filter by the object’s \`name\` field."""
   name: StringFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: ParentFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [ParentFilter!]
 }
 
-\\"\\"\\"A connection to a list of \`Parent\` values.\\"\\"\\"
+"""A connection to a list of \`Parent\` values."""
 type ParentsConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`Parent\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [ParentsEdge!]!
 
-  \\"\\"\\"A list of \`Parent\` objects.\\"\\"\\"
+  """A list of \`Parent\` objects."""
   nodes: [Parent]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`Parent\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`Parent\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`Parent\` edge in the connection.\\"\\"\\"
+"""A \`Parent\` edge in the connection."""
 type ParentsEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`Parent\` at the end of the edge.\\"\\"\\"
+  """The \`Parent\` at the end of the edge."""
   node: Parent
 }
 
-\\"\\"\\"Methods to use when ordering \`Parent\`.\\"\\"\\"
+"""Methods to use when ordering \`Parent\`."""
 enum ParentsOrderBy {
   ID_ASC
   ID_DESC
@@ -4562,704 +4562,704 @@ type Protected implements Node {
   id: Int!
   name: String
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
   otherId: Int
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`Protected\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input ProtectedFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [ProtectedFilter!]
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`name\` field.\\"\\"\\"
+  """Filter by the object’s \`name\` field."""
   name: StringFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: ProtectedFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [ProtectedFilter!]
 
-  \\"\\"\\"Filter by the object’s \`otherId\` field.\\"\\"\\"
+  """Filter by the object’s \`otherId\` field."""
   otherId: IntFilter
 }
 
-\\"\\"\\"A connection to a list of \`Protected\` values.\\"\\"\\"
+"""A connection to a list of \`Protected\` values."""
 type ProtectedsConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`Protected\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [ProtectedsEdge!]!
 
-  \\"\\"\\"A list of \`Protected\` objects.\\"\\"\\"
+  """A list of \`Protected\` objects."""
   nodes: [Protected]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`Protected\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`Protected\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`Protected\` edge in the connection.\\"\\"\\"
+"""A \`Protected\` edge in the connection."""
 type ProtectedsEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`Protected\` at the end of the edge.\\"\\"\\"
+  """The \`Protected\` at the end of the edge."""
   node: Protected
 }
 
-\\"\\"\\"The root query type which gives access points into the data universe.\\"\\"\\"
+"""The root query type which gives access points into the data universe."""
 type Query implements Node {
-  \\"\\"\\"Reads and enables pagination through a set of \`ArrayType\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`ArrayType\`."""
   allArrayTypes(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: ArrayTypeFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`ArrayType\`.\\"\\"\\"
+    """The method to use when ordering \`ArrayType\`."""
     orderBy: [ArrayTypesOrderBy!] = [PRIMARY_KEY_ASC]
   ): ArrayTypesConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`BackwardCompound\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`BackwardCompound\`."""
   allBackwardCompounds(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: BackwardCompoundFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`BackwardCompound\`.\\"\\"\\"
+    """The method to use when ordering \`BackwardCompound\`."""
     orderBy: [BackwardCompoundsOrderBy!] = [PRIMARY_KEY_ASC]
   ): BackwardCompoundsConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Backward\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Backward\`."""
   allBackwards(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: BackwardFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`Backward\`.\\"\\"\\"
+    """The method to use when ordering \`Backward\`."""
     orderBy: [BackwardsOrderBy!] = [PRIMARY_KEY_ASC]
   ): BackwardsConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`ChildNoRelatedFilter\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`ChildNoRelatedFilter\`."""
   allChildNoRelatedFilters(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: ChildNoRelatedFilterFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`ChildNoRelatedFilter\`.\\"\\"\\"
+    """The method to use when ordering \`ChildNoRelatedFilter\`."""
     orderBy: [ChildNoRelatedFiltersOrderBy!] = [PRIMARY_KEY_ASC]
   ): ChildNoRelatedFiltersConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Child\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Child\`."""
   allChildren(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: ChildFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`Child\`.\\"\\"\\"
+    """The method to use when ordering \`Child\`."""
     orderBy: [ChildrenOrderBy!] = [PRIMARY_KEY_ASC]
   ): ChildrenConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`DomainType\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`DomainType\`."""
   allDomainTypes(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: DomainTypeFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`DomainType\`.\\"\\"\\"
+    """The method to use when ordering \`DomainType\`."""
     orderBy: [DomainTypesOrderBy!] = [PRIMARY_KEY_ASC]
   ): DomainTypesConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`EnumArrayType\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`EnumArrayType\`."""
   allEnumArrayTypes(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: EnumArrayTypeFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`EnumArrayType\`.\\"\\"\\"
+    """The method to use when ordering \`EnumArrayType\`."""
     orderBy: [EnumArrayTypesOrderBy!] = [PRIMARY_KEY_ASC]
   ): EnumArrayTypesConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`EnumType\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`EnumType\`."""
   allEnumTypes(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: EnumTypeFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`EnumType\`.\\"\\"\\"
+    """The method to use when ordering \`EnumType\`."""
     orderBy: [EnumTypesOrderBy!] = [PRIMARY_KEY_ASC]
   ): EnumTypesConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Filterable\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Filterable\`."""
   allFilterables(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: FilterableFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`Filterable\`.\\"\\"\\"
+    """The method to use when ordering \`Filterable\`."""
     orderBy: [FilterablesOrderBy!] = [PRIMARY_KEY_ASC]
   ): FilterablesConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`ForwardCompound\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`ForwardCompound\`."""
   allForwardCompounds(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: ForwardCompoundFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`ForwardCompound\`.\\"\\"\\"
+    """The method to use when ordering \`ForwardCompound\`."""
     orderBy: [ForwardCompoundsOrderBy!] = [PRIMARY_KEY_ASC]
   ): ForwardCompoundsConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Forward\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Forward\`."""
   allForwards(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: ForwardFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`Forward\`.\\"\\"\\"
+    """The method to use when ordering \`Forward\`."""
     orderBy: [ForwardsOrderBy!] = [PRIMARY_KEY_ASC]
   ): ForwardsConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`FullyOmitted\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`FullyOmitted\`."""
   allFullyOmitteds(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`FullyOmitted\`.\\"\\"\\"
+    """The method to use when ordering \`FullyOmitted\`."""
     orderBy: [FullyOmittedsOrderBy!] = [PRIMARY_KEY_ASC]
   ): FullyOmittedsConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`JsonbTest\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`JsonbTest\`."""
   allJsonbTests(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: JsonbTestFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`JsonbTest\`.\\"\\"\\"
+    """The method to use when ordering \`JsonbTest\`."""
     orderBy: [JsonbTestsOrderBy!] = [PRIMARY_KEY_ASC]
   ): JsonbTestsConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Junction\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Junction\`."""
   allJunctions(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: JunctionFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`Junction\`.\\"\\"\\"
+    """The method to use when ordering \`Junction\`."""
     orderBy: [JunctionsOrderBy!] = [PRIMARY_KEY_ASC]
   ): JunctionsConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Parent\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Parent\`."""
   allParents(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: ParentFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`Parent\`.\\"\\"\\"
+    """The method to use when ordering \`Parent\`."""
     orderBy: [ParentsOrderBy!] = [PRIMARY_KEY_ASC]
   ): ParentsConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`RangeArrayType\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`RangeArrayType\`."""
   allRangeArrayTypes(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: RangeArrayTypeFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`RangeArrayType\`.\\"\\"\\"
+    """The method to use when ordering \`RangeArrayType\`."""
     orderBy: [RangeArrayTypesOrderBy!] = [PRIMARY_KEY_ASC]
   ): RangeArrayTypesConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`RangeType\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`RangeType\`."""
   allRangeTypes(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: RangeTypeFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`RangeType\`.\\"\\"\\"
+    """The method to use when ordering \`RangeType\`."""
     orderBy: [RangeTypesOrderBy!] = [PRIMARY_KEY_ASC]
   ): RangeTypesConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`SideA\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`SideA\`."""
   allSideAs(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: SideAFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`SideA\`.\\"\\"\\"
+    """The method to use when ordering \`SideA\`."""
     orderBy: [SideAsOrderBy!] = [PRIMARY_KEY_ASC]
   ): SideAsConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`SideB\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`SideB\`."""
   allSideBs(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: SideBFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`SideB\`.\\"\\"\\"
+    """The method to use when ordering \`SideB\`."""
     orderBy: [SideBsOrderBy!] = [PRIMARY_KEY_ASC]
   ): SideBsConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Unfilterable\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Unfilterable\`."""
   allUnfilterables(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`Unfilterable\`.\\"\\"\\"
+    """The method to use when ordering \`Unfilterable\`."""
     orderBy: [UnfilterablesOrderBy!] = [PRIMARY_KEY_ASC]
   ): UnfilterablesConnection
 
-  \\"\\"\\"Reads a single \`ArrayType\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`ArrayType\` using its globally unique \`ID\`."""
   arrayType(
-    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`ArrayType\`.\\"\\"\\"
+    """The globally unique \`ID\` to be used in selecting a single \`ArrayType\`."""
     nodeId: ID!
   ): ArrayType
   arrayTypeById(id: Int!): ArrayType
 
-  \\"\\"\\"Reads a single \`Backward\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`Backward\` using its globally unique \`ID\`."""
   backward(
-    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`Backward\`.\\"\\"\\"
+    """The globally unique \`ID\` to be used in selecting a single \`Backward\`."""
     nodeId: ID!
   ): Backward
   backwardByFilterableId(filterableId: Int!): Backward
   backwardById(id: Int!): Backward
 
-  \\"\\"\\"Reads a single \`BackwardCompound\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`BackwardCompound\` using its globally unique \`ID\`."""
   backwardCompound(
-    \\"\\"\\"
+    """
     The globally unique \`ID\` to be used in selecting a single \`BackwardCompound\`.
-    \\"\\"\\"
+    """
     nodeId: ID!
   ): BackwardCompound
   backwardCompoundByBackwardCompound1AndBackwardCompound2(backwardCompound1: Int!, backwardCompound2: Int!): BackwardCompound
 
-  \\"\\"\\"Reads a single \`Child\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`Child\` using its globally unique \`ID\`."""
   child(
-    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`Child\`.\\"\\"\\"
+    """The globally unique \`ID\` to be used in selecting a single \`Child\`."""
     nodeId: ID!
   ): Child
   childById(id: Int!): Child
 
-  \\"\\"\\"Reads a single \`ChildNoRelatedFilter\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`ChildNoRelatedFilter\` using its globally unique \`ID\`."""
   childNoRelatedFilter(
-    \\"\\"\\"
+    """
     The globally unique \`ID\` to be used in selecting a single \`ChildNoRelatedFilter\`.
-    \\"\\"\\"
+    """
     nodeId: ID!
   ): ChildNoRelatedFilter
   childNoRelatedFilterById(id: Int!): ChildNoRelatedFilter
 
-  \\"\\"\\"Reads a single \`DomainType\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`DomainType\` using its globally unique \`ID\`."""
   domainType(
-    \\"\\"\\"
+    """
     The globally unique \`ID\` to be used in selecting a single \`DomainType\`.
-    \\"\\"\\"
+    """
     nodeId: ID!
   ): DomainType
   domainTypeById(id: Int!): DomainType
 
-  \\"\\"\\"Reads a single \`EnumArrayType\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`EnumArrayType\` using its globally unique \`ID\`."""
   enumArrayType(
-    \\"\\"\\"
+    """
     The globally unique \`ID\` to be used in selecting a single \`EnumArrayType\`.
-    \\"\\"\\"
+    """
     nodeId: ID!
   ): EnumArrayType
   enumArrayTypeById(id: Int!): EnumArrayType
 
-  \\"\\"\\"Reads a single \`EnumType\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`EnumType\` using its globally unique \`ID\`."""
   enumType(
-    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`EnumType\`.\\"\\"\\"
+    """The globally unique \`ID\` to be used in selecting a single \`EnumType\`."""
     nodeId: ID!
   ): EnumType
   enumTypeById(id: Int!): EnumType
 
-  \\"\\"\\"Reads a single \`Filterable\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`Filterable\` using its globally unique \`ID\`."""
   filterable(
-    \\"\\"\\"
+    """
     The globally unique \`ID\` to be used in selecting a single \`Filterable\`.
-    \\"\\"\\"
+    """
     nodeId: ID!
   ): Filterable
   filterableByBackwardCompound1AndBackwardCompound2(backwardCompound1: Int!, backwardCompound2: Int!): Filterable
@@ -5267,247 +5267,247 @@ type Query implements Node {
   filterableByForwardId(forwardId: Int!): Filterable
   filterableById(id: Int!): Filterable
 
-  \\"\\"\\"Reads a single \`FilterableClosure\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`FilterableClosure\` using its globally unique \`ID\`."""
   filterableClosure(
-    \\"\\"\\"
+    """
     The globally unique \`ID\` to be used in selecting a single \`FilterableClosure\`.
-    \\"\\"\\"
+    """
     nodeId: ID!
   ): FilterableClosure
   filterableClosureById(id: Int!): FilterableClosure
 
-  \\"\\"\\"Reads a single \`Forward\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`Forward\` using its globally unique \`ID\`."""
   forward(
-    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`Forward\`.\\"\\"\\"
+    """The globally unique \`ID\` to be used in selecting a single \`Forward\`."""
     nodeId: ID!
   ): Forward
   forwardById(id: Int!): Forward
 
-  \\"\\"\\"Reads a single \`ForwardCompound\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`ForwardCompound\` using its globally unique \`ID\`."""
   forwardCompound(
-    \\"\\"\\"
+    """
     The globally unique \`ID\` to be used in selecting a single \`ForwardCompound\`.
-    \\"\\"\\"
+    """
     nodeId: ID!
   ): ForwardCompound
   forwardCompoundByForwardCompound1AndForwardCompound2(forwardCompound1: Int!, forwardCompound2: Int!): ForwardCompound
 
-  \\"\\"\\"Reads a single \`FullyOmitted\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`FullyOmitted\` using its globally unique \`ID\`."""
   fullyOmitted(
-    \\"\\"\\"
+    """
     The globally unique \`ID\` to be used in selecting a single \`FullyOmitted\`.
-    \\"\\"\\"
+    """
     nodeId: ID!
   ): FullyOmitted
   fullyOmittedById(id: Int!): FullyOmitted
   funcReturnsTableMultiCol(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: FuncReturnsTableMultiColRecordFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
     i: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
   ): FuncReturnsTableMultiColConnection!
   funcReturnsTableOneCol(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: IntFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
     i: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
   ): FuncReturnsTableOneColConnection!
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Filterable\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Filterable\`."""
   funcTaggedFilterableReturnsSetofFilterable(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: FilterableFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
   ): FilterablesConnection!
   funcTaggedFilterableReturnsTableMultiCol(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: FuncTaggedFilterableReturnsTableMultiColRecordFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
   ): FuncTaggedFilterableReturnsTableMultiColConnection!
 
-  \\"\\"\\"Reads a single \`JsonbTest\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`JsonbTest\` using its globally unique \`ID\`."""
   jsonbTest(
-    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`JsonbTest\`.\\"\\"\\"
+    """The globally unique \`ID\` to be used in selecting a single \`JsonbTest\`."""
     nodeId: ID!
   ): JsonbTest
   jsonbTestById(id: Int!): JsonbTest
 
-  \\"\\"\\"Reads a single \`Junction\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`Junction\` using its globally unique \`ID\`."""
   junction(
-    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`Junction\`.\\"\\"\\"
+    """The globally unique \`ID\` to be used in selecting a single \`Junction\`."""
     nodeId: ID!
   ): Junction
   junctionBySideAIdAndSideBId(sideAId: Int!, sideBId: Int!): Junction
 
-  \\"\\"\\"Fetches an object given its globally unique \`ID\`.\\"\\"\\"
+  """Fetches an object given its globally unique \`ID\`."""
   node(
-    \\"\\"\\"The globally unique \`ID\`.\\"\\"\\"
+    """The globally unique \`ID\`."""
     nodeId: ID!
   ): Node
 
-  \\"\\"\\"
+  """
   The root query type must be a \`Node\` to work well with Relay 1 mutations. This just resolves to \`query\`.
-  \\"\\"\\"
+  """
   nodeId: ID!
 
-  \\"\\"\\"Reads a single \`Parent\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`Parent\` using its globally unique \`ID\`."""
   parent(
-    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`Parent\`.\\"\\"\\"
+    """The globally unique \`ID\` to be used in selecting a single \`Parent\`."""
     nodeId: ID!
   ): Parent
   parentById(id: Int!): Parent
 
-  \\"\\"\\"Reads a single \`Protected\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`Protected\` using its globally unique \`ID\`."""
   protected(
-    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`Protected\`.\\"\\"\\"
+    """The globally unique \`ID\` to be used in selecting a single \`Protected\`."""
     nodeId: ID!
   ): Protected
   protectedById(id: Int!): Protected
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Protected\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Protected\`."""
   protectedsByOtherId(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: ProtectedFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
     otherId: Int
   ): ProtectedsConnection!
 
-  \\"\\"\\"
+  """
   Exposes the root query type nested one level down. This is helpful for Relay 1
   which can only query top level fields if they are in a particular form.
-  \\"\\"\\"
+  """
   query: Query!
 
-  \\"\\"\\"Reads a single \`RangeArrayType\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`RangeArrayType\` using its globally unique \`ID\`."""
   rangeArrayType(
-    \\"\\"\\"
+    """
     The globally unique \`ID\` to be used in selecting a single \`RangeArrayType\`.
-    \\"\\"\\"
+    """
     nodeId: ID!
   ): RangeArrayType
   rangeArrayTypeById(id: Int!): RangeArrayType
 
-  \\"\\"\\"Reads a single \`RangeType\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`RangeType\` using its globally unique \`ID\`."""
   rangeType(
-    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`RangeType\`.\\"\\"\\"
+    """The globally unique \`ID\` to be used in selecting a single \`RangeType\`."""
     nodeId: ID!
   ): RangeType
   rangeTypeById(id: Int!): RangeType
 
-  \\"\\"\\"Reads a single \`SideA\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`SideA\` using its globally unique \`ID\`."""
   sideA(
-    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`SideA\`.\\"\\"\\"
+    """The globally unique \`ID\` to be used in selecting a single \`SideA\`."""
     nodeId: ID!
   ): SideA
   sideAByAId(aId: Int!): SideA
 
-  \\"\\"\\"Reads a single \`SideB\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`SideB\` using its globally unique \`ID\`."""
   sideB(
-    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`SideB\`.\\"\\"\\"
+    """The globally unique \`ID\` to be used in selecting a single \`SideB\`."""
     nodeId: ID!
   ): SideB
   sideBByBId(bId: Int!): SideB
 
-  \\"\\"\\"Reads a single \`Unfilterable\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`Unfilterable\` using its globally unique \`ID\`."""
   unfilterable(
-    \\"\\"\\"
+    """
     The globally unique \`ID\` to be used in selecting a single \`Unfilterable\`.
-    \\"\\"\\"
+    """
     nodeId: ID!
   ): Unfilterable
   unfilterableById(id: Int!): Unfilterable
@@ -5519,77 +5519,77 @@ type RangeArrayType implements Node {
   int4RangeArray: [IntRange]
   int8RangeArray: [BigIntRange]
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
   numericRangeArray: [BigFloatRange]
   timestampRangeArray: [DatetimeRange]
   timestamptzRangeArray: [DatetimeRange]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`RangeArrayType\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input RangeArrayTypeFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [RangeArrayTypeFilter!]
 
-  \\"\\"\\"Filter by the object’s \`dateRangeArray\` field.\\"\\"\\"
+  """Filter by the object’s \`dateRangeArray\` field."""
   dateRangeArray: DateRangeListFilter
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`int4RangeArray\` field.\\"\\"\\"
+  """Filter by the object’s \`int4RangeArray\` field."""
   int4RangeArray: IntRangeListFilter
 
-  \\"\\"\\"Filter by the object’s \`int8RangeArray\` field.\\"\\"\\"
+  """Filter by the object’s \`int8RangeArray\` field."""
   int8RangeArray: BigIntRangeListFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: RangeArrayTypeFilter
 
-  \\"\\"\\"Filter by the object’s \`numericRangeArray\` field.\\"\\"\\"
+  """Filter by the object’s \`numericRangeArray\` field."""
   numericRangeArray: BigFloatRangeListFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [RangeArrayTypeFilter!]
 
-  \\"\\"\\"Filter by the object’s \`timestampRangeArray\` field.\\"\\"\\"
+  """Filter by the object’s \`timestampRangeArray\` field."""
   timestampRangeArray: DatetimeRangeListFilter
 
-  \\"\\"\\"Filter by the object’s \`timestamptzRangeArray\` field.\\"\\"\\"
+  """Filter by the object’s \`timestamptzRangeArray\` field."""
   timestamptzRangeArray: DatetimeRangeListFilter
 }
 
-\\"\\"\\"A connection to a list of \`RangeArrayType\` values.\\"\\"\\"
+"""A connection to a list of \`RangeArrayType\` values."""
 type RangeArrayTypesConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`RangeArrayType\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [RangeArrayTypesEdge!]!
 
-  \\"\\"\\"A list of \`RangeArrayType\` objects.\\"\\"\\"
+  """A list of \`RangeArrayType\` objects."""
   nodes: [RangeArrayType]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`RangeArrayType\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`RangeArrayType\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`RangeArrayType\` edge in the connection.\\"\\"\\"
+"""A \`RangeArrayType\` edge in the connection."""
 type RangeArrayTypesEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`RangeArrayType\` at the end of the edge.\\"\\"\\"
+  """The \`RangeArrayType\` at the end of the edge."""
   node: RangeArrayType
 }
 
-\\"\\"\\"Methods to use when ordering \`RangeArrayType\`.\\"\\"\\"
+"""Methods to use when ordering \`RangeArrayType\`."""
 enum RangeArrayTypesOrderBy {
   DATE_RANGE_ARRAY_ASC
   DATE_RANGE_ARRAY_DESC
@@ -5616,77 +5616,77 @@ type RangeType implements Node {
   int4Range: IntRange
   int8Range: BigIntRange
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
   numericRange: BigFloatRange
   timestampRange: DatetimeRange
   timestamptzRange: DatetimeRange
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`RangeType\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input RangeTypeFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [RangeTypeFilter!]
 
-  \\"\\"\\"Filter by the object’s \`dateRange\` field.\\"\\"\\"
+  """Filter by the object’s \`dateRange\` field."""
   dateRange: DateRangeFilter
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`int4Range\` field.\\"\\"\\"
+  """Filter by the object’s \`int4Range\` field."""
   int4Range: IntRangeFilter
 
-  \\"\\"\\"Filter by the object’s \`int8Range\` field.\\"\\"\\"
+  """Filter by the object’s \`int8Range\` field."""
   int8Range: BigIntRangeFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: RangeTypeFilter
 
-  \\"\\"\\"Filter by the object’s \`numericRange\` field.\\"\\"\\"
+  """Filter by the object’s \`numericRange\` field."""
   numericRange: BigFloatRangeFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [RangeTypeFilter!]
 
-  \\"\\"\\"Filter by the object’s \`timestampRange\` field.\\"\\"\\"
+  """Filter by the object’s \`timestampRange\` field."""
   timestampRange: DatetimeRangeFilter
 
-  \\"\\"\\"Filter by the object’s \`timestamptzRange\` field.\\"\\"\\"
+  """Filter by the object’s \`timestamptzRange\` field."""
   timestamptzRange: DatetimeRangeFilter
 }
 
-\\"\\"\\"A connection to a list of \`RangeType\` values.\\"\\"\\"
+"""A connection to a list of \`RangeType\` values."""
 type RangeTypesConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`RangeType\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [RangeTypesEdge!]!
 
-  \\"\\"\\"A list of \`RangeType\` objects.\\"\\"\\"
+  """A list of \`RangeType\` objects."""
   nodes: [RangeType]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`RangeType\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`RangeType\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`RangeType\` edge in the connection.\\"\\"\\"
+"""A \`RangeType\` edge in the connection."""
 type RangeTypesEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`RangeType\` at the end of the edge.\\"\\"\\"
+  """The \`RangeType\` at the end of the edge."""
   node: RangeType
 }
 
-\\"\\"\\"Methods to use when ordering \`RangeType\`.\\"\\"\\"
+"""Methods to use when ordering \`RangeType\`."""
 enum RangeTypesOrderBy {
   DATE_RANGE_ASC
   DATE_RANGE_DESC
@@ -5710,89 +5710,89 @@ enum RangeTypesOrderBy {
 type SideA implements Node {
   aId: Int!
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Junction\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Junction\`."""
   junctionsBySideAId(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: JunctionFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`Junction\`.\\"\\"\\"
+    """The method to use when ordering \`Junction\`."""
     orderBy: [JunctionsOrderBy!] = [PRIMARY_KEY_ASC]
   ): JunctionsConnection!
   name: String!
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`SideA\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input SideAFilter {
-  \\"\\"\\"Filter by the object’s \`aId\` field.\\"\\"\\"
+  """Filter by the object’s \`aId\` field."""
   aId: IntFilter
 
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [SideAFilter!]
 
-  \\"\\"\\"Filter by the object’s \`name\` field.\\"\\"\\"
+  """Filter by the object’s \`name\` field."""
   name: StringFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: SideAFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [SideAFilter!]
 }
 
-\\"\\"\\"A connection to a list of \`SideA\` values.\\"\\"\\"
+"""A connection to a list of \`SideA\` values."""
 type SideAsConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`SideA\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [SideAsEdge!]!
 
-  \\"\\"\\"A list of \`SideA\` objects.\\"\\"\\"
+  """A list of \`SideA\` objects."""
   nodes: [SideA]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`SideA\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`SideA\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`SideA\` edge in the connection.\\"\\"\\"
+"""A \`SideA\` edge in the connection."""
 type SideAsEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`SideA\` at the end of the edge.\\"\\"\\"
+  """The \`SideA\` at the end of the edge."""
   node: SideA
 }
 
-\\"\\"\\"Methods to use when ordering \`SideA\`.\\"\\"\\"
+"""Methods to use when ordering \`SideA\`."""
 enum SideAsOrderBy {
   A_ID_ASC
   A_ID_DESC
@@ -5806,89 +5806,89 @@ enum SideAsOrderBy {
 type SideB implements Node {
   bId: Int!
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Junction\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Junction\`."""
   junctionsBySideBId(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: JunctionFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`Junction\`.\\"\\"\\"
+    """The method to use when ordering \`Junction\`."""
     orderBy: [JunctionsOrderBy!] = [PRIMARY_KEY_ASC]
   ): JunctionsConnection!
   name: String!
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`SideB\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input SideBFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [SideBFilter!]
 
-  \\"\\"\\"Filter by the object’s \`bId\` field.\\"\\"\\"
+  """Filter by the object’s \`bId\` field."""
   bId: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`name\` field.\\"\\"\\"
+  """Filter by the object’s \`name\` field."""
   name: StringFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: SideBFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [SideBFilter!]
 }
 
-\\"\\"\\"A connection to a list of \`SideB\` values.\\"\\"\\"
+"""A connection to a list of \`SideB\` values."""
 type SideBsConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`SideB\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [SideBsEdge!]!
 
-  \\"\\"\\"A list of \`SideB\` objects.\\"\\"\\"
+  """A list of \`SideB\` objects."""
   nodes: [SideB]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`SideB\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`SideB\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`SideB\` edge in the connection.\\"\\"\\"
+"""A \`SideB\` edge in the connection."""
 type SideBsEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`SideB\` at the end of the edge.\\"\\"\\"
+  """The \`SideB\` at the end of the edge."""
   node: SideB
 }
 
-\\"\\"\\"Methods to use when ordering \`SideB\`.\\"\\"\\"
+"""Methods to use when ordering \`SideB\`."""
 enum SideBsOrderBy {
   B_ID_ASC
   B_ID_DESC
@@ -5899,382 +5899,382 @@ enum SideBsOrderBy {
   PRIMARY_KEY_DESC
 }
 
-\\"\\"\\"
+"""
 A filter to be used against String fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input StringFilter {
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: String
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value (case-insensitive).
-  \\"\\"\\"
+  """
   distinctFromInsensitive: String
 
-  \\"\\"\\"Ends with the specified string (case-sensitive).\\"\\"\\"
+  """Ends with the specified string (case-sensitive)."""
   endsWith: String
 
-  \\"\\"\\"Ends with the specified string (case-insensitive).\\"\\"\\"
+  """Ends with the specified string (case-insensitive)."""
   endsWithInsensitive: String
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   eq: String
 
-  \\"\\"\\"Equal to the specified value (case-insensitive).\\"\\"\\"
+  """Equal to the specified value (case-insensitive)."""
   equalToInsensitive: String
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: String
 
-  \\"\\"\\"Greater than the specified value (case-insensitive).\\"\\"\\"
+  """Greater than the specified value (case-insensitive)."""
   greaterThanInsensitive: String
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: String
 
-  \\"\\"\\"Greater than or equal to the specified value (case-insensitive).\\"\\"\\"
+  """Greater than or equal to the specified value (case-insensitive)."""
   greaterThanOrEqualToInsensitive: String
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [String!]
 
-  \\"\\"\\"Included in the specified list (case-insensitive).\\"\\"\\"
-  inInsensitive: [String!]
-
-  \\"\\"\\"Contains the specified string (case-sensitive).\\"\\"\\"
+  """Contains the specified string (case-sensitive)."""
   includes: String
 
-  \\"\\"\\"Contains the specified string (case-insensitive).\\"\\"\\"
+  """Contains the specified string (case-insensitive)."""
   includesInsensitive: String
 
-  \\"\\"\\"
+  """Included in the specified list (case-insensitive)."""
+  inInsensitive: [String!]
+
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: String
 
-  \\"\\"\\"Less than the specified value (case-insensitive).\\"\\"\\"
+  """Less than the specified value (case-insensitive)."""
   lessThanInsensitive: String
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: String
 
-  \\"\\"\\"Less than or equal to the specified value (case-insensitive).\\"\\"\\"
+  """Less than or equal to the specified value (case-insensitive)."""
   lessThanOrEqualToInsensitive: String
 
-  \\"\\"\\"
+  """
   Matches the specified pattern (case-sensitive). An underscore (_) matches any
   single character; a percent sign (%) matches any sequence of zero or more characters.
-  \\"\\"\\"
+  """
   like: String
 
-  \\"\\"\\"
+  """
   Matches the specified pattern (case-insensitive). An underscore (_) matches
   any single character; a percent sign (%) matches any sequence of zero or more characters.
-  \\"\\"\\"
+  """
   likeInsensitive: String
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   ne: String
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: String
 
-  \\"\\"\\"
+  """
   Equal to the specified value, treating null like an ordinary value (case-insensitive).
-  \\"\\"\\"
+  """
   notDistinctFromInsensitive: String
 
-  \\"\\"\\"Does not end with the specified string (case-sensitive).\\"\\"\\"
+  """Does not end with the specified string (case-sensitive)."""
   notEndsWith: String
 
-  \\"\\"\\"Does not end with the specified string (case-insensitive).\\"\\"\\"
+  """Does not end with the specified string (case-insensitive)."""
   notEndsWithInsensitive: String
 
-  \\"\\"\\"Not equal to the specified value (case-insensitive).\\"\\"\\"
+  """Not equal to the specified value (case-insensitive)."""
   notEqualToInsensitive: String
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [String!]
 
-  \\"\\"\\"Not included in the specified list (case-insensitive).\\"\\"\\"
-  notInInsensitive: [String!]
-
-  \\"\\"\\"Does not contain the specified string (case-sensitive).\\"\\"\\"
+  """Does not contain the specified string (case-sensitive)."""
   notIncludes: String
 
-  \\"\\"\\"Does not contain the specified string (case-insensitive).\\"\\"\\"
+  """Does not contain the specified string (case-insensitive)."""
   notIncludesInsensitive: String
 
-  \\"\\"\\"
+  """Not included in the specified list (case-insensitive)."""
+  notInInsensitive: [String!]
+
+  """
   Does not match the specified pattern (case-sensitive). An underscore (_)
   matches any single character; a percent sign (%) matches any sequence of zero
   or more characters.
-  \\"\\"\\"
+  """
   notLike: String
 
-  \\"\\"\\"
+  """
   Does not match the specified pattern (case-insensitive). An underscore (_)
   matches any single character; a percent sign (%) matches any sequence of zero
   or more characters.
-  \\"\\"\\"
+  """
   notLikeInsensitive: String
 
-  \\"\\"\\"Does not start with the specified string (case-sensitive).\\"\\"\\"
+  """Does not start with the specified string (case-sensitive)."""
   notStartsWith: String
 
-  \\"\\"\\"Does not start with the specified string (case-insensitive).\\"\\"\\"
+  """Does not start with the specified string (case-insensitive)."""
   notStartsWithInsensitive: String
 
-  \\"\\"\\"Starts with the specified string (case-sensitive).\\"\\"\\"
+  """Starts with the specified string (case-sensitive)."""
   startsWith: String
 
-  \\"\\"\\"Starts with the specified string (case-insensitive).\\"\\"\\"
+  """Starts with the specified string (case-insensitive)."""
   startsWithInsensitive: String
 }
 
-\\"\\"\\"
+"""
 A filter to be used against String List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input StringListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: String
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: String
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: String
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: String
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: String
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: String
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [String]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [String]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [String]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   eq: [String]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [String]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [String]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [String]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [String]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   ne: [String]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [String]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [String]
 }
 
-\\"\\"\\"
+"""
 The exact time of day, does not include the date. May or may not have a timezone offset.
-\\"\\"\\"
+"""
 scalar Time
 
-\\"\\"\\"
+"""
 A filter to be used against Time fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input TimeFilter {
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: Time
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   eq: Time
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: Time
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: Time
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [Time!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: Time
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: Time
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   ne: Time
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: Time
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [Time!]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against Time List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input TimeListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: Time
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: Time
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: Time
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: Time
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: Time
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: Time
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [Time]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [Time]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [Time]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   eq: [Time]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [Time]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [Time]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [Time]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [Time]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   ne: [Time]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [Time]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [Time]
 }
 
 type Unfilterable implements Node {
-  \\"\\"\\"Reads and enables pagination through a set of \`ChildNoRelatedFilter\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`ChildNoRelatedFilter\`."""
   childNoRelatedFiltersByUnfilterableId(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: ChildNoRelatedFilterFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`ChildNoRelatedFilter\`.\\"\\"\\"
+    """The method to use when ordering \`ChildNoRelatedFilter\`."""
     orderBy: [ChildNoRelatedFiltersOrderBy!] = [PRIMARY_KEY_ASC]
   ): ChildNoRelatedFiltersConnection!
   id: Int!
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
   text: String
 }
 
-\\"\\"\\"A connection to a list of \`Unfilterable\` values.\\"\\"\\"
+"""A connection to a list of \`Unfilterable\` values."""
 type UnfilterablesConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`Unfilterable\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [UnfilterablesEdge!]!
 
-  \\"\\"\\"A list of \`Unfilterable\` objects.\\"\\"\\"
+  """A list of \`Unfilterable\` objects."""
   nodes: [Unfilterable]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`Unfilterable\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`Unfilterable\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`Unfilterable\` edge in the connection.\\"\\"\\"
+"""A \`Unfilterable\` edge in the connection."""
 type UnfilterablesEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`Unfilterable\` at the end of the edge.\\"\\"\\"
+  """The \`Unfilterable\` at the end of the edge."""
   node: Unfilterable
 }
 
-\\"\\"\\"Methods to use when ordering \`Unfilterable\`.\\"\\"\\"
+"""Methods to use when ordering \`Unfilterable\`."""
 enum UnfilterablesOrderBy {
   ID_ASC
   ID_DESC
@@ -6285,114 +6285,114 @@ enum UnfilterablesOrderBy {
   TEXT_DESC
 }
 
-\\"\\"\\"
+"""
 A universally unique identifier as defined by [RFC 4122](https://tools.ietf.org/html/rfc4122).
-\\"\\"\\"
+"""
 scalar UUID
 
-\\"\\"\\"
+"""
 A filter to be used against UUID fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input UUIDFilter {
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: UUID
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   eq: UUID
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: UUID
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: UUID
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [UUID!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: UUID
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: UUID
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   ne: UUID
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: UUID
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [UUID!]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against UUID List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input UUIDListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: UUID
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: UUID
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: UUID
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: UUID
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: UUID
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: UUID
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [UUID]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [UUID]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [UUID]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   eq: [UUID]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [UUID]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [UUID]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [UUID]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [UUID]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   ne: [UUID]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [UUID]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [UUID]
 }
-"
+
 `;

--- a/__tests__/integration/schema/__snapshots__/relationsTrue.test.ts.snap
+++ b/__tests__/integration/schema/__snapshots__/relationsTrue.test.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`prints a schema with the filter plugin and the \`connectionFilterRelations: true\` option 1`] = `
-"type ArrayType implements Node {
+type ArrayType implements Node {
   bit4Array: [BitString]
   boolArray: [Boolean]
   bpchar4Array: [String]
@@ -25,9 +25,9 @@ exports[`prints a schema with the filter plugin and the \`connectionFilterRelati
   moneyArray: [Float]
   nameArray: [String]
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
   numericArray: [BigFloat]
   textArray: [String]
@@ -41,128 +41,128 @@ exports[`prints a schema with the filter plugin and the \`connectionFilterRelati
   xmlArray: [String]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`ArrayType\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input ArrayTypeFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [ArrayTypeFilter!]
 
-  \\"\\"\\"Filter by the object’s \`bit4Array\` field.\\"\\"\\"
+  """Filter by the object’s \`bit4Array\` field."""
   bit4Array: BitStringListFilter
 
-  \\"\\"\\"Filter by the object’s \`boolArray\` field.\\"\\"\\"
+  """Filter by the object’s \`boolArray\` field."""
   boolArray: BooleanListFilter
 
-  \\"\\"\\"Filter by the object’s \`bpchar4Array\` field.\\"\\"\\"
+  """Filter by the object’s \`bpchar4Array\` field."""
   bpchar4Array: StringListFilter
 
-  \\"\\"\\"Filter by the object’s \`char4Array\` field.\\"\\"\\"
+  """Filter by the object’s \`char4Array\` field."""
   char4Array: StringListFilter
 
-  \\"\\"\\"Filter by the object’s \`citextArray\` field.\\"\\"\\"
+  """Filter by the object’s \`citextArray\` field."""
   citextArray: StringListFilter
 
-  \\"\\"\\"Filter by the object’s \`dateArray\` field.\\"\\"\\"
+  """Filter by the object’s \`dateArray\` field."""
   dateArray: DateListFilter
 
-  \\"\\"\\"Filter by the object’s \`float4Array\` field.\\"\\"\\"
+  """Filter by the object’s \`float4Array\` field."""
   float4Array: FloatListFilter
 
-  \\"\\"\\"Filter by the object’s \`float8Array\` field.\\"\\"\\"
+  """Filter by the object’s \`float8Array\` field."""
   float8Array: FloatListFilter
 
-  \\"\\"\\"Filter by the object’s \`hstoreArray\` field.\\"\\"\\"
+  """Filter by the object’s \`hstoreArray\` field."""
   hstoreArray: KeyValueHashListFilter
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`inetArray\` field.\\"\\"\\"
+  """Filter by the object’s \`inetArray\` field."""
   inetArray: InternetAddressListFilter
 
-  \\"\\"\\"Filter by the object’s \`int2Array\` field.\\"\\"\\"
+  """Filter by the object’s \`int2Array\` field."""
   int2Array: IntListFilter
 
-  \\"\\"\\"Filter by the object’s \`int4Array\` field.\\"\\"\\"
+  """Filter by the object’s \`int4Array\` field."""
   int4Array: IntListFilter
 
-  \\"\\"\\"Filter by the object’s \`int8Array\` field.\\"\\"\\"
+  """Filter by the object’s \`int8Array\` field."""
   int8Array: BigIntListFilter
 
-  \\"\\"\\"Filter by the object’s \`intervalArray\` field.\\"\\"\\"
+  """Filter by the object’s \`intervalArray\` field."""
   intervalArray: IntervalListFilter
 
-  \\"\\"\\"Filter by the object’s \`jsonbArray\` field.\\"\\"\\"
+  """Filter by the object’s \`jsonbArray\` field."""
   jsonbArray: JSONListFilter
 
-  \\"\\"\\"Filter by the object’s \`moneyArray\` field.\\"\\"\\"
+  """Filter by the object’s \`moneyArray\` field."""
   moneyArray: FloatListFilter
 
-  \\"\\"\\"Filter by the object’s \`nameArray\` field.\\"\\"\\"
+  """Filter by the object’s \`nameArray\` field."""
   nameArray: StringListFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: ArrayTypeFilter
 
-  \\"\\"\\"Filter by the object’s \`numericArray\` field.\\"\\"\\"
+  """Filter by the object’s \`numericArray\` field."""
   numericArray: BigFloatListFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [ArrayTypeFilter!]
 
-  \\"\\"\\"Filter by the object’s \`textArray\` field.\\"\\"\\"
+  """Filter by the object’s \`textArray\` field."""
   textArray: StringListFilter
 
-  \\"\\"\\"Filter by the object’s \`timeArray\` field.\\"\\"\\"
+  """Filter by the object’s \`timeArray\` field."""
   timeArray: TimeListFilter
 
-  \\"\\"\\"Filter by the object’s \`timestampArray\` field.\\"\\"\\"
+  """Filter by the object’s \`timestampArray\` field."""
   timestampArray: DatetimeListFilter
 
-  \\"\\"\\"Filter by the object’s \`timestamptzArray\` field.\\"\\"\\"
+  """Filter by the object’s \`timestamptzArray\` field."""
   timestamptzArray: DatetimeListFilter
 
-  \\"\\"\\"Filter by the object’s \`timetzArray\` field.\\"\\"\\"
+  """Filter by the object’s \`timetzArray\` field."""
   timetzArray: TimeListFilter
 
-  \\"\\"\\"Filter by the object’s \`uuidArray\` field.\\"\\"\\"
+  """Filter by the object’s \`uuidArray\` field."""
   uuidArray: UUIDListFilter
 
-  \\"\\"\\"Filter by the object’s \`varbitArray\` field.\\"\\"\\"
+  """Filter by the object’s \`varbitArray\` field."""
   varbitArray: BitStringListFilter
 
-  \\"\\"\\"Filter by the object’s \`varcharArray\` field.\\"\\"\\"
+  """Filter by the object’s \`varcharArray\` field."""
   varcharArray: StringListFilter
 }
 
-\\"\\"\\"A connection to a list of \`ArrayType\` values.\\"\\"\\"
+"""A connection to a list of \`ArrayType\` values."""
 type ArrayTypesConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`ArrayType\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [ArrayTypesEdge!]!
 
-  \\"\\"\\"A list of \`ArrayType\` objects.\\"\\"\\"
+  """A list of \`ArrayType\` objects."""
   nodes: [ArrayType]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`ArrayType\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`ArrayType\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`ArrayType\` edge in the connection.\\"\\"\\"
+"""A \`ArrayType\` edge in the connection."""
 type ArrayTypesEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`ArrayType\` at the end of the edge.\\"\\"\\"
+  """The \`ArrayType\` at the end of the edge."""
   node: ArrayType
 }
 
-\\"\\"\\"Methods to use when ordering \`ArrayType\`.\\"\\"\\"
+"""Methods to use when ordering \`ArrayType\`."""
 enum ArrayTypesOrderBy {
   BIT4_ARRAY_ASC
   BIT4_ARRAY_DESC
@@ -234,15 +234,15 @@ enum ArrayTypesOrderBy {
 }
 
 type Backward implements Node {
-  \\"\\"\\"Reads a single \`Filterable\` that is related to this \`Backward\`.\\"\\"\\"
+  """Reads a single \`Filterable\` that is related to this \`Backward\`."""
   filterableByFilterableId: Filterable
   filterableId: Int
   id: Int!
   name: String!
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
@@ -250,75 +250,75 @@ type BackwardCompound implements Node {
   backwardCompound1: Int!
   backwardCompound2: Int!
 
-  \\"\\"\\"
+  """
   Reads a single \`Filterable\` that is related to this \`BackwardCompound\`.
-  \\"\\"\\"
+  """
   filterableByBackwardCompound1AndBackwardCompound2: Filterable
   name: String
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`BackwardCompound\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input BackwardCompoundFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [BackwardCompoundFilter!]
 
-  \\"\\"\\"Filter by the object’s \`backwardCompound1\` field.\\"\\"\\"
+  """Filter by the object’s \`backwardCompound1\` field."""
   backwardCompound1: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`backwardCompound2\` field.\\"\\"\\"
+  """Filter by the object’s \`backwardCompound2\` field."""
   backwardCompound2: IntFilter
 
-  \\"\\"\\"
+  """
   Filter by the object’s \`filterableByBackwardCompound1AndBackwardCompound2\` relation.
-  \\"\\"\\"
+  """
   filterableByBackwardCompound1AndBackwardCompound2: FilterableFilter
 
-  \\"\\"\\"Filter by the object’s \`name\` field.\\"\\"\\"
+  """Filter by the object’s \`name\` field."""
   name: StringFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: BackwardCompoundFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [BackwardCompoundFilter!]
 }
 
-\\"\\"\\"A connection to a list of \`BackwardCompound\` values.\\"\\"\\"
+"""A connection to a list of \`BackwardCompound\` values."""
 type BackwardCompoundsConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`BackwardCompound\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [BackwardCompoundsEdge!]!
 
-  \\"\\"\\"A list of \`BackwardCompound\` objects.\\"\\"\\"
+  """A list of \`BackwardCompound\` objects."""
   nodes: [BackwardCompound]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"
+  """
   The count of *all* \`BackwardCompound\` you could get from the connection.
-  \\"\\"\\"
+  """
   totalCount: Int!
 }
 
-\\"\\"\\"A \`BackwardCompound\` edge in the connection.\\"\\"\\"
+"""A \`BackwardCompound\` edge in the connection."""
 type BackwardCompoundsEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`BackwardCompound\` at the end of the edge.\\"\\"\\"
+  """The \`BackwardCompound\` at the end of the edge."""
   node: BackwardCompound
 }
 
-\\"\\"\\"Methods to use when ordering \`BackwardCompound\`.\\"\\"\\"
+"""Methods to use when ordering \`BackwardCompound\`."""
 enum BackwardCompoundsOrderBy {
   BACKWARD_COMPOUND_1_ASC
   BACKWARD_COMPOUND_1_DESC
@@ -331,62 +331,62 @@ enum BackwardCompoundsOrderBy {
   PRIMARY_KEY_DESC
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`Backward\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input BackwardFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [BackwardFilter!]
 
-  \\"\\"\\"Filter by the object’s \`filterableByFilterableId\` relation.\\"\\"\\"
+  """Filter by the object’s \`filterableByFilterableId\` relation."""
   filterableByFilterableId: FilterableFilter
 
-  \\"\\"\\"A related \`filterableByFilterableId\` exists.\\"\\"\\"
+  """A related \`filterableByFilterableId\` exists."""
   filterableByFilterableIdExists: Boolean
 
-  \\"\\"\\"Filter by the object’s \`filterableId\` field.\\"\\"\\"
+  """Filter by the object’s \`filterableId\` field."""
   filterableId: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`name\` field.\\"\\"\\"
+  """Filter by the object’s \`name\` field."""
   name: StringFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: BackwardFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [BackwardFilter!]
 }
 
-\\"\\"\\"A connection to a list of \`Backward\` values.\\"\\"\\"
+"""A connection to a list of \`Backward\` values."""
 type BackwardsConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`Backward\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [BackwardsEdge!]!
 
-  \\"\\"\\"A list of \`Backward\` objects.\\"\\"\\"
+  """A list of \`Backward\` objects."""
   nodes: [Backward]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`Backward\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`Backward\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`Backward\` edge in the connection.\\"\\"\\"
+"""A \`Backward\` edge in the connection."""
 type BackwardsEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`Backward\` at the end of the edge.\\"\\"\\"
+  """The \`Backward\` at the end of the edge."""
   node: Backward
 }
 
-\\"\\"\\"Methods to use when ordering \`Backward\`.\\"\\"\\"
+"""Methods to use when ordering \`Backward\`."""
 enum BackwardsOrderBy {
   FILTERABLE_ID_ASC
   FILTERABLE_ID_DESC
@@ -399,1043 +399,1043 @@ enum BackwardsOrderBy {
   PRIMARY_KEY_DESC
 }
 
-\\"\\"\\"
+"""
 A floating point number that requires more precision than IEEE 754 binary 64
-\\"\\"\\"
+"""
 scalar BigFloat
 
-\\"\\"\\"
+"""
 A filter to be used against BigFloat fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input BigFloatFilter {
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: BigFloat
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: BigFloat
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: BigFloat
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: BigFloat
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [BigFloat!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: BigFloat
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: BigFloat
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: BigFloat
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: BigFloat
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [BigFloat!]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against BigFloat List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input BigFloatListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: BigFloat
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: BigFloat
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: BigFloat
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: BigFloat
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: BigFloat
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: BigFloat
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [BigFloat]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [BigFloat]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [BigFloat]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [BigFloat]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [BigFloat]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [BigFloat]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [BigFloat]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [BigFloat]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [BigFloat]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [BigFloat]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [BigFloat]
 }
 
-\\"\\"\\"A range of \`BigFloat\`.\\"\\"\\"
+"""A range of \`BigFloat\`."""
 type BigFloatRange {
-  \\"\\"\\"The ending bound of our range.\\"\\"\\"
+  """The ending bound of our range."""
   end: BigFloatRangeBound
 
-  \\"\\"\\"The starting bound of our range.\\"\\"\\"
+  """The starting bound of our range."""
   start: BigFloatRangeBound
 }
 
-\\"\\"\\"
+"""
 The value at one end of a range. A range can either include this value, or not.
-\\"\\"\\"
+"""
 type BigFloatRangeBound {
-  \\"\\"\\"Whether or not the value of this bound is included in the range.\\"\\"\\"
+  """Whether or not the value of this bound is included in the range."""
   inclusive: Boolean!
 
-  \\"\\"\\"The value at one end of our range.\\"\\"\\"
+  """The value at one end of our range."""
   value: BigFloat!
 }
 
-\\"\\"\\"
+"""
 The value at one end of a range. A range can either include this value, or not.
-\\"\\"\\"
+"""
 input BigFloatRangeBoundInput {
-  \\"\\"\\"Whether or not the value of this bound is included in the range.\\"\\"\\"
+  """Whether or not the value of this bound is included in the range."""
   inclusive: Boolean!
 
-  \\"\\"\\"The value at one end of our range.\\"\\"\\"
+  """The value at one end of our range."""
   value: BigFloat!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against BigFloatRange fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input BigFloatRangeFilter {
-  \\"\\"\\"Adjacent to the specified range.\\"\\"\\"
+  """Adjacent to the specified range."""
   adjacentTo: BigFloatRangeInput
 
-  \\"\\"\\"Contained by the specified range.\\"\\"\\"
+  """Contained by the specified range."""
   containedBy: BigFloatRangeInput
 
-  \\"\\"\\"Contains the specified range.\\"\\"\\"
+  """Contains the specified range."""
   contains: BigFloatRangeInput
 
-  \\"\\"\\"Contains the specified value.\\"\\"\\"
+  """Contains the specified value."""
   containsElement: BigFloat
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: BigFloatRangeInput
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: BigFloatRangeInput
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: BigFloatRangeInput
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: BigFloatRangeInput
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [BigFloatRangeInput!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: BigFloatRangeInput
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: BigFloatRangeInput
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: BigFloatRangeInput
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: BigFloatRangeInput
 
-  \\"\\"\\"Does not extend left of the specified range.\\"\\"\\"
+  """Does not extend left of the specified range."""
   notExtendsLeftOf: BigFloatRangeInput
 
-  \\"\\"\\"Does not extend right of the specified range.\\"\\"\\"
+  """Does not extend right of the specified range."""
   notExtendsRightOf: BigFloatRangeInput
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [BigFloatRangeInput!]
 
-  \\"\\"\\"Overlaps the specified range.\\"\\"\\"
+  """Overlaps the specified range."""
   overlaps: BigFloatRangeInput
 
-  \\"\\"\\"Strictly left of the specified range.\\"\\"\\"
+  """Strictly left of the specified range."""
   strictlyLeftOf: BigFloatRangeInput
 
-  \\"\\"\\"Strictly right of the specified range.\\"\\"\\"
+  """Strictly right of the specified range."""
   strictlyRightOf: BigFloatRangeInput
 }
 
-\\"\\"\\"A range of \`BigFloat\`.\\"\\"\\"
+"""A range of \`BigFloat\`."""
 input BigFloatRangeInput {
-  \\"\\"\\"The ending bound of our range.\\"\\"\\"
+  """The ending bound of our range."""
   end: BigFloatRangeBoundInput
 
-  \\"\\"\\"The starting bound of our range.\\"\\"\\"
+  """The starting bound of our range."""
   start: BigFloatRangeBoundInput
 }
 
-\\"\\"\\"
+"""
 A filter to be used against BigFloatRange List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input BigFloatRangeListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: BigFloatRangeInput
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: BigFloatRangeInput
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: BigFloatRangeInput
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: BigFloatRangeInput
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: BigFloatRangeInput
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: BigFloatRangeInput
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [BigFloatRangeInput]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [BigFloatRangeInput]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [BigFloatRangeInput]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [BigFloatRangeInput]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [BigFloatRangeInput]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [BigFloatRangeInput]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [BigFloatRangeInput]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [BigFloatRangeInput]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [BigFloatRangeInput]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [BigFloatRangeInput]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [BigFloatRangeInput]
 }
 
-\\"\\"\\"
+"""
 A signed eight-byte integer. The upper big integer values are greater than the
 max value for a JavaScript number. Therefore all big integers will be output as
 strings and not numbers.
-\\"\\"\\"
+"""
 scalar BigInt
 
-\\"\\"\\"
+"""
 A filter to be used against BigInt fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input BigIntFilter {
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: BigInt
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: BigInt
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: BigInt
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: BigInt
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [BigInt!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: BigInt
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: BigInt
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: BigInt
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: BigInt
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [BigInt!]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against BigInt List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input BigIntListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: BigInt
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: BigInt
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: BigInt
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: BigInt
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: BigInt
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: BigInt
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [BigInt]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [BigInt]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [BigInt]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [BigInt]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [BigInt]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [BigInt]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [BigInt]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [BigInt]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [BigInt]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [BigInt]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [BigInt]
 }
 
-\\"\\"\\"A range of \`BigInt\`.\\"\\"\\"
+"""A range of \`BigInt\`."""
 type BigIntRange {
-  \\"\\"\\"The ending bound of our range.\\"\\"\\"
+  """The ending bound of our range."""
   end: BigIntRangeBound
 
-  \\"\\"\\"The starting bound of our range.\\"\\"\\"
+  """The starting bound of our range."""
   start: BigIntRangeBound
 }
 
-\\"\\"\\"
+"""
 The value at one end of a range. A range can either include this value, or not.
-\\"\\"\\"
+"""
 type BigIntRangeBound {
-  \\"\\"\\"Whether or not the value of this bound is included in the range.\\"\\"\\"
+  """Whether or not the value of this bound is included in the range."""
   inclusive: Boolean!
 
-  \\"\\"\\"The value at one end of our range.\\"\\"\\"
+  """The value at one end of our range."""
   value: BigInt!
 }
 
-\\"\\"\\"
+"""
 The value at one end of a range. A range can either include this value, or not.
-\\"\\"\\"
+"""
 input BigIntRangeBoundInput {
-  \\"\\"\\"Whether or not the value of this bound is included in the range.\\"\\"\\"
+  """Whether or not the value of this bound is included in the range."""
   inclusive: Boolean!
 
-  \\"\\"\\"The value at one end of our range.\\"\\"\\"
+  """The value at one end of our range."""
   value: BigInt!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against BigIntRange fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input BigIntRangeFilter {
-  \\"\\"\\"Adjacent to the specified range.\\"\\"\\"
+  """Adjacent to the specified range."""
   adjacentTo: BigIntRangeInput
 
-  \\"\\"\\"Contained by the specified range.\\"\\"\\"
+  """Contained by the specified range."""
   containedBy: BigIntRangeInput
 
-  \\"\\"\\"Contains the specified range.\\"\\"\\"
+  """Contains the specified range."""
   contains: BigIntRangeInput
 
-  \\"\\"\\"Contains the specified value.\\"\\"\\"
+  """Contains the specified value."""
   containsElement: BigInt
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: BigIntRangeInput
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: BigIntRangeInput
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: BigIntRangeInput
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: BigIntRangeInput
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [BigIntRangeInput!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: BigIntRangeInput
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: BigIntRangeInput
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: BigIntRangeInput
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: BigIntRangeInput
 
-  \\"\\"\\"Does not extend left of the specified range.\\"\\"\\"
+  """Does not extend left of the specified range."""
   notExtendsLeftOf: BigIntRangeInput
 
-  \\"\\"\\"Does not extend right of the specified range.\\"\\"\\"
+  """Does not extend right of the specified range."""
   notExtendsRightOf: BigIntRangeInput
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [BigIntRangeInput!]
 
-  \\"\\"\\"Overlaps the specified range.\\"\\"\\"
+  """Overlaps the specified range."""
   overlaps: BigIntRangeInput
 
-  \\"\\"\\"Strictly left of the specified range.\\"\\"\\"
+  """Strictly left of the specified range."""
   strictlyLeftOf: BigIntRangeInput
 
-  \\"\\"\\"Strictly right of the specified range.\\"\\"\\"
+  """Strictly right of the specified range."""
   strictlyRightOf: BigIntRangeInput
 }
 
-\\"\\"\\"A range of \`BigInt\`.\\"\\"\\"
+"""A range of \`BigInt\`."""
 input BigIntRangeInput {
-  \\"\\"\\"The ending bound of our range.\\"\\"\\"
+  """The ending bound of our range."""
   end: BigIntRangeBoundInput
 
-  \\"\\"\\"The starting bound of our range.\\"\\"\\"
+  """The starting bound of our range."""
   start: BigIntRangeBoundInput
 }
 
-\\"\\"\\"
+"""
 A filter to be used against BigIntRange List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input BigIntRangeListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: BigIntRangeInput
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: BigIntRangeInput
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: BigIntRangeInput
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: BigIntRangeInput
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: BigIntRangeInput
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: BigIntRangeInput
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [BigIntRangeInput]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [BigIntRangeInput]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [BigIntRangeInput]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [BigIntRangeInput]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [BigIntRangeInput]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [BigIntRangeInput]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [BigIntRangeInput]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [BigIntRangeInput]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [BigIntRangeInput]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [BigIntRangeInput]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [BigIntRangeInput]
 }
 
-\\"\\"\\"A string representing a series of binary bits\\"\\"\\"
+"""A string representing a series of binary bits"""
 scalar BitString
 
-\\"\\"\\"
+"""
 A filter to be used against BitString fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input BitStringFilter {
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: BitString
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: BitString
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: BitString
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: BitString
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [BitString!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: BitString
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: BitString
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: BitString
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: BitString
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [BitString!]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against BitString List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input BitStringListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: BitString
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: BitString
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: BitString
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: BitString
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: BitString
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: BitString
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [BitString]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [BitString]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [BitString]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [BitString]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [BitString]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [BitString]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [BitString]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [BitString]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [BitString]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [BitString]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [BitString]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against Boolean fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input BooleanFilter {
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: Boolean
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: Boolean
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: Boolean
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: Boolean
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [Boolean!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: Boolean
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: Boolean
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: Boolean
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: Boolean
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [Boolean!]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against Boolean List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input BooleanListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: Boolean
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: Boolean
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: Boolean
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: Boolean
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: Boolean
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: Boolean
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [Boolean]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [Boolean]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [Boolean]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [Boolean]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [Boolean]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [Boolean]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [Boolean]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [Boolean]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [Boolean]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [Boolean]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [Boolean]
 }
 
 scalar Char4Domain
 
-\\"\\"\\"
+"""
 A filter to be used against Char4Domain fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input Char4DomainFilter {
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: Char4Domain
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value (case-insensitive).
-  \\"\\"\\"
+  """
   distinctFromInsensitive: Char4Domain
 
-  \\"\\"\\"Ends with the specified string (case-sensitive).\\"\\"\\"
+  """Ends with the specified string (case-sensitive)."""
   endsWith: Char4Domain
 
-  \\"\\"\\"Ends with the specified string (case-insensitive).\\"\\"\\"
+  """Ends with the specified string (case-insensitive)."""
   endsWithInsensitive: Char4Domain
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: Char4Domain
 
-  \\"\\"\\"Equal to the specified value (case-insensitive).\\"\\"\\"
+  """Equal to the specified value (case-insensitive)."""
   equalToInsensitive: Char4Domain
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: Char4Domain
 
-  \\"\\"\\"Greater than the specified value (case-insensitive).\\"\\"\\"
+  """Greater than the specified value (case-insensitive)."""
   greaterThanInsensitive: Char4Domain
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: Char4Domain
 
-  \\"\\"\\"Greater than or equal to the specified value (case-insensitive).\\"\\"\\"
+  """Greater than or equal to the specified value (case-insensitive)."""
   greaterThanOrEqualToInsensitive: Char4Domain
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [Char4Domain!]
 
-  \\"\\"\\"Included in the specified list (case-insensitive).\\"\\"\\"
-  inInsensitive: [Char4Domain!]
-
-  \\"\\"\\"Contains the specified string (case-sensitive).\\"\\"\\"
+  """Contains the specified string (case-sensitive)."""
   includes: Char4Domain
 
-  \\"\\"\\"Contains the specified string (case-insensitive).\\"\\"\\"
+  """Contains the specified string (case-insensitive)."""
   includesInsensitive: Char4Domain
 
-  \\"\\"\\"
+  """Included in the specified list (case-insensitive)."""
+  inInsensitive: [Char4Domain!]
+
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: Char4Domain
 
-  \\"\\"\\"Less than the specified value (case-insensitive).\\"\\"\\"
+  """Less than the specified value (case-insensitive)."""
   lessThanInsensitive: Char4Domain
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: Char4Domain
 
-  \\"\\"\\"Less than or equal to the specified value (case-insensitive).\\"\\"\\"
+  """Less than or equal to the specified value (case-insensitive)."""
   lessThanOrEqualToInsensitive: Char4Domain
 
-  \\"\\"\\"
+  """
   Matches the specified pattern (case-sensitive). An underscore (_) matches any
   single character; a percent sign (%) matches any sequence of zero or more characters.
-  \\"\\"\\"
+  """
   like: Char4Domain
 
-  \\"\\"\\"
+  """
   Matches the specified pattern (case-insensitive). An underscore (_) matches
   any single character; a percent sign (%) matches any sequence of zero or more characters.
-  \\"\\"\\"
+  """
   likeInsensitive: Char4Domain
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: Char4Domain
 
-  \\"\\"\\"
+  """
   Equal to the specified value, treating null like an ordinary value (case-insensitive).
-  \\"\\"\\"
+  """
   notDistinctFromInsensitive: Char4Domain
 
-  \\"\\"\\"Does not end with the specified string (case-sensitive).\\"\\"\\"
+  """Does not end with the specified string (case-sensitive)."""
   notEndsWith: Char4Domain
 
-  \\"\\"\\"Does not end with the specified string (case-insensitive).\\"\\"\\"
+  """Does not end with the specified string (case-insensitive)."""
   notEndsWithInsensitive: Char4Domain
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: Char4Domain
 
-  \\"\\"\\"Not equal to the specified value (case-insensitive).\\"\\"\\"
+  """Not equal to the specified value (case-insensitive)."""
   notEqualToInsensitive: Char4Domain
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [Char4Domain!]
 
-  \\"\\"\\"Not included in the specified list (case-insensitive).\\"\\"\\"
-  notInInsensitive: [Char4Domain!]
-
-  \\"\\"\\"Does not contain the specified string (case-sensitive).\\"\\"\\"
+  """Does not contain the specified string (case-sensitive)."""
   notIncludes: Char4Domain
 
-  \\"\\"\\"Does not contain the specified string (case-insensitive).\\"\\"\\"
+  """Does not contain the specified string (case-insensitive)."""
   notIncludesInsensitive: Char4Domain
 
-  \\"\\"\\"
+  """Not included in the specified list (case-insensitive)."""
+  notInInsensitive: [Char4Domain!]
+
+  """
   Does not match the specified pattern (case-sensitive). An underscore (_)
   matches any single character; a percent sign (%) matches any sequence of zero
   or more characters.
-  \\"\\"\\"
+  """
   notLike: Char4Domain
 
-  \\"\\"\\"
+  """
   Does not match the specified pattern (case-insensitive). An underscore (_)
   matches any single character; a percent sign (%) matches any sequence of zero
   or more characters.
-  \\"\\"\\"
+  """
   notLikeInsensitive: Char4Domain
 
-  \\"\\"\\"Does not start with the specified string (case-sensitive).\\"\\"\\"
+  """Does not start with the specified string (case-sensitive)."""
   notStartsWith: Char4Domain
 
-  \\"\\"\\"Does not start with the specified string (case-insensitive).\\"\\"\\"
+  """Does not start with the specified string (case-insensitive)."""
   notStartsWithInsensitive: Char4Domain
 
-  \\"\\"\\"Starts with the specified string (case-sensitive).\\"\\"\\"
+  """Starts with the specified string (case-sensitive)."""
   startsWith: Char4Domain
 
-  \\"\\"\\"Starts with the specified string (case-insensitive).\\"\\"\\"
+  """Starts with the specified string (case-insensitive)."""
   startsWithInsensitive: Char4Domain
 }
 
 type Child implements Node {
-  \\"\\"\\"Reads a single \`Filterable\` that is related to this \`Child\`.\\"\\"\\"
+  """Reads a single \`Filterable\` that is related to this \`Child\`."""
   filterableByFilterableId: Filterable
   filterableId: Int
   id: Int!
   name: String!
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`Child\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input ChildFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [ChildFilter!]
 
-  \\"\\"\\"Filter by the object’s \`filterableByFilterableId\` relation.\\"\\"\\"
+  """Filter by the object’s \`filterableByFilterableId\` relation."""
   filterableByFilterableId: FilterableFilter
 
-  \\"\\"\\"A related \`filterableByFilterableId\` exists.\\"\\"\\"
+  """A related \`filterableByFilterableId\` exists."""
   filterableByFilterableIdExists: Boolean
 
-  \\"\\"\\"Filter by the object’s \`filterableId\` field.\\"\\"\\"
+  """Filter by the object’s \`filterableId\` field."""
   filterableId: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`name\` field.\\"\\"\\"
+  """Filter by the object’s \`name\` field."""
   name: StringFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: ChildFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [ChildFilter!]
 }
 
 type ChildNoRelatedFilter implements Node {
-  \\"\\"\\"
+  """
   Reads a single \`Filterable\` that is related to this \`ChildNoRelatedFilter\`.
-  \\"\\"\\"
+  """
   filterableByFilterableId: Filterable
   filterableId: Int
   id: Int!
   name: String!
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 
-  \\"\\"\\"
+  """
   Reads a single \`Unfilterable\` that is related to this \`ChildNoRelatedFilter\`.
-  \\"\\"\\"
+  """
   unfilterableByUnfilterableId: Unfilterable
   unfilterableId: Int
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`ChildNoRelatedFilter\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input ChildNoRelatedFilterFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [ChildNoRelatedFilterFilter!]
 
-  \\"\\"\\"Filter by the object’s \`filterableId\` field.\\"\\"\\"
+  """Filter by the object’s \`filterableId\` field."""
   filterableId: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`name\` field.\\"\\"\\"
+  """Filter by the object’s \`name\` field."""
   name: StringFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: ChildNoRelatedFilterFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [ChildNoRelatedFilterFilter!]
 
-  \\"\\"\\"Filter by the object’s \`unfilterableId\` field.\\"\\"\\"
+  """Filter by the object’s \`unfilterableId\` field."""
   unfilterableId: IntFilter
 }
 
-\\"\\"\\"A connection to a list of \`ChildNoRelatedFilter\` values.\\"\\"\\"
+"""A connection to a list of \`ChildNoRelatedFilter\` values."""
 type ChildNoRelatedFiltersConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`ChildNoRelatedFilter\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [ChildNoRelatedFiltersEdge!]!
 
-  \\"\\"\\"A list of \`ChildNoRelatedFilter\` objects.\\"\\"\\"
+  """A list of \`ChildNoRelatedFilter\` objects."""
   nodes: [ChildNoRelatedFilter]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"
+  """
   The count of *all* \`ChildNoRelatedFilter\` you could get from the connection.
-  \\"\\"\\"
+  """
   totalCount: Int!
 }
 
-\\"\\"\\"A \`ChildNoRelatedFilter\` edge in the connection.\\"\\"\\"
+"""A \`ChildNoRelatedFilter\` edge in the connection."""
 type ChildNoRelatedFiltersEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`ChildNoRelatedFilter\` at the end of the edge.\\"\\"\\"
+  """The \`ChildNoRelatedFilter\` at the end of the edge."""
   node: ChildNoRelatedFilter
 }
 
-\\"\\"\\"Methods to use when ordering \`ChildNoRelatedFilter\`.\\"\\"\\"
+"""Methods to use when ordering \`ChildNoRelatedFilter\`."""
 enum ChildNoRelatedFiltersOrderBy {
   FILTERABLE_ID_ASC
   FILTERABLE_ID_DESC
@@ -1450,33 +1450,33 @@ enum ChildNoRelatedFiltersOrderBy {
   UNFILTERABLE_ID_DESC
 }
 
-\\"\\"\\"A connection to a list of \`Child\` values.\\"\\"\\"
+"""A connection to a list of \`Child\` values."""
 type ChildrenConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`Child\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [ChildrenEdge!]!
 
-  \\"\\"\\"A list of \`Child\` objects.\\"\\"\\"
+  """A list of \`Child\` objects."""
   nodes: [Child]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`Child\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`Child\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`Child\` edge in the connection.\\"\\"\\"
+"""A \`Child\` edge in the connection."""
 type ChildrenEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`Child\` at the end of the edge.\\"\\"\\"
+  """The \`Child\` at the end of the edge."""
   node: Child
 }
 
-\\"\\"\\"Methods to use when ordering \`Child\`.\\"\\"\\"
+"""Methods to use when ordering \`Child\`."""
 enum ChildrenOrderBy {
   FILTERABLE_ID_ASC
   FILTERABLE_ID_DESC
@@ -1494,633 +1494,633 @@ type Composite {
   b: String
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`Composite\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input CompositeFilter {
-  \\"\\"\\"Filter by the object’s \`a\` field.\\"\\"\\"
+  """Filter by the object’s \`a\` field."""
   a: IntFilter
 
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [CompositeFilter!]
 
-  \\"\\"\\"Filter by the object’s \`b\` field.\\"\\"\\"
+  """Filter by the object’s \`b\` field."""
   b: StringFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: CompositeFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [CompositeFilter!]
 }
 
-\\"\\"\\"A location in a connection that can be used for resuming pagination.\\"\\"\\"
+"""A location in a connection that can be used for resuming pagination."""
 scalar Cursor
 
-\\"\\"\\"The day, does not include a time.\\"\\"\\"
+"""The day, does not include a time."""
 scalar Date
 
 scalar DateDomain
 
-\\"\\"\\"
+"""
 A filter to be used against DateDomain fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input DateDomainFilter {
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: DateDomain
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: DateDomain
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: DateDomain
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: DateDomain
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [DateDomain!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: DateDomain
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: DateDomain
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: DateDomain
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: DateDomain
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [DateDomain!]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against Date fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input DateFilter {
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: Date
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: Date
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: Date
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: Date
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [Date!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: Date
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: Date
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: Date
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: Date
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [Date!]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against Date List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input DateListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: Date
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: Date
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: Date
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: Date
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: Date
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: Date
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [Date]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [Date]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [Date]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [Date]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [Date]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [Date]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [Date]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [Date]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [Date]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [Date]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [Date]
 }
 
-\\"\\"\\"A range of \`Date\`.\\"\\"\\"
+"""A range of \`Date\`."""
 type DateRange {
-  \\"\\"\\"The ending bound of our range.\\"\\"\\"
+  """The ending bound of our range."""
   end: DateRangeBound
 
-  \\"\\"\\"The starting bound of our range.\\"\\"\\"
+  """The starting bound of our range."""
   start: DateRangeBound
 }
 
-\\"\\"\\"
+"""
 The value at one end of a range. A range can either include this value, or not.
-\\"\\"\\"
+"""
 type DateRangeBound {
-  \\"\\"\\"Whether or not the value of this bound is included in the range.\\"\\"\\"
+  """Whether or not the value of this bound is included in the range."""
   inclusive: Boolean!
 
-  \\"\\"\\"The value at one end of our range.\\"\\"\\"
+  """The value at one end of our range."""
   value: Date!
 }
 
-\\"\\"\\"
+"""
 The value at one end of a range. A range can either include this value, or not.
-\\"\\"\\"
+"""
 input DateRangeBoundInput {
-  \\"\\"\\"Whether or not the value of this bound is included in the range.\\"\\"\\"
+  """Whether or not the value of this bound is included in the range."""
   inclusive: Boolean!
 
-  \\"\\"\\"The value at one end of our range.\\"\\"\\"
+  """The value at one end of our range."""
   value: Date!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against DateRange fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input DateRangeFilter {
-  \\"\\"\\"Adjacent to the specified range.\\"\\"\\"
+  """Adjacent to the specified range."""
   adjacentTo: DateRangeInput
 
-  \\"\\"\\"Contained by the specified range.\\"\\"\\"
+  """Contained by the specified range."""
   containedBy: DateRangeInput
 
-  \\"\\"\\"Contains the specified range.\\"\\"\\"
+  """Contains the specified range."""
   contains: DateRangeInput
 
-  \\"\\"\\"Contains the specified value.\\"\\"\\"
+  """Contains the specified value."""
   containsElement: Date
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: DateRangeInput
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: DateRangeInput
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: DateRangeInput
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: DateRangeInput
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [DateRangeInput!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: DateRangeInput
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: DateRangeInput
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: DateRangeInput
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: DateRangeInput
 
-  \\"\\"\\"Does not extend left of the specified range.\\"\\"\\"
+  """Does not extend left of the specified range."""
   notExtendsLeftOf: DateRangeInput
 
-  \\"\\"\\"Does not extend right of the specified range.\\"\\"\\"
+  """Does not extend right of the specified range."""
   notExtendsRightOf: DateRangeInput
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [DateRangeInput!]
 
-  \\"\\"\\"Overlaps the specified range.\\"\\"\\"
+  """Overlaps the specified range."""
   overlaps: DateRangeInput
 
-  \\"\\"\\"Strictly left of the specified range.\\"\\"\\"
+  """Strictly left of the specified range."""
   strictlyLeftOf: DateRangeInput
 
-  \\"\\"\\"Strictly right of the specified range.\\"\\"\\"
+  """Strictly right of the specified range."""
   strictlyRightOf: DateRangeInput
 }
 
-\\"\\"\\"A range of \`Date\`.\\"\\"\\"
+"""A range of \`Date\`."""
 input DateRangeInput {
-  \\"\\"\\"The ending bound of our range.\\"\\"\\"
+  """The ending bound of our range."""
   end: DateRangeBoundInput
 
-  \\"\\"\\"The starting bound of our range.\\"\\"\\"
+  """The starting bound of our range."""
   start: DateRangeBoundInput
 }
 
-\\"\\"\\"
+"""
 A filter to be used against DateRange List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input DateRangeListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: DateRangeInput
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: DateRangeInput
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: DateRangeInput
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: DateRangeInput
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: DateRangeInput
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: DateRangeInput
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [DateRangeInput]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [DateRangeInput]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [DateRangeInput]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [DateRangeInput]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [DateRangeInput]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [DateRangeInput]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [DateRangeInput]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [DateRangeInput]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [DateRangeInput]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [DateRangeInput]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [DateRangeInput]
 }
 
-\\"\\"\\"
+"""
 A point in time as described by the [ISO
 8601](https://en.wikipedia.org/wiki/ISO_8601) standard. May or may not include a timezone.
-\\"\\"\\"
+"""
 scalar Datetime
 
-\\"\\"\\"
+"""
 A filter to be used against Datetime fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input DatetimeFilter {
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: Datetime
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: Datetime
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: Datetime
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: Datetime
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [Datetime!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: Datetime
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: Datetime
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: Datetime
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: Datetime
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [Datetime!]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against Datetime List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input DatetimeListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: Datetime
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: Datetime
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: Datetime
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: Datetime
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: Datetime
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: Datetime
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [Datetime]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [Datetime]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [Datetime]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [Datetime]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [Datetime]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [Datetime]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [Datetime]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [Datetime]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [Datetime]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [Datetime]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [Datetime]
 }
 
-\\"\\"\\"A range of \`Datetime\`.\\"\\"\\"
+"""A range of \`Datetime\`."""
 type DatetimeRange {
-  \\"\\"\\"The ending bound of our range.\\"\\"\\"
+  """The ending bound of our range."""
   end: DatetimeRangeBound
 
-  \\"\\"\\"The starting bound of our range.\\"\\"\\"
+  """The starting bound of our range."""
   start: DatetimeRangeBound
 }
 
-\\"\\"\\"
+"""
 The value at one end of a range. A range can either include this value, or not.
-\\"\\"\\"
+"""
 type DatetimeRangeBound {
-  \\"\\"\\"Whether or not the value of this bound is included in the range.\\"\\"\\"
+  """Whether or not the value of this bound is included in the range."""
   inclusive: Boolean!
 
-  \\"\\"\\"The value at one end of our range.\\"\\"\\"
+  """The value at one end of our range."""
   value: Datetime!
 }
 
-\\"\\"\\"
+"""
 The value at one end of a range. A range can either include this value, or not.
-\\"\\"\\"
+"""
 input DatetimeRangeBoundInput {
-  \\"\\"\\"Whether or not the value of this bound is included in the range.\\"\\"\\"
+  """Whether or not the value of this bound is included in the range."""
   inclusive: Boolean!
 
-  \\"\\"\\"The value at one end of our range.\\"\\"\\"
+  """The value at one end of our range."""
   value: Datetime!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against DatetimeRange fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input DatetimeRangeFilter {
-  \\"\\"\\"Adjacent to the specified range.\\"\\"\\"
+  """Adjacent to the specified range."""
   adjacentTo: DatetimeRangeInput
 
-  \\"\\"\\"Contained by the specified range.\\"\\"\\"
+  """Contained by the specified range."""
   containedBy: DatetimeRangeInput
 
-  \\"\\"\\"Contains the specified range.\\"\\"\\"
+  """Contains the specified range."""
   contains: DatetimeRangeInput
 
-  \\"\\"\\"Contains the specified value.\\"\\"\\"
+  """Contains the specified value."""
   containsElement: Datetime
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: DatetimeRangeInput
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: DatetimeRangeInput
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: DatetimeRangeInput
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: DatetimeRangeInput
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [DatetimeRangeInput!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: DatetimeRangeInput
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: DatetimeRangeInput
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: DatetimeRangeInput
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: DatetimeRangeInput
 
-  \\"\\"\\"Does not extend left of the specified range.\\"\\"\\"
+  """Does not extend left of the specified range."""
   notExtendsLeftOf: DatetimeRangeInput
 
-  \\"\\"\\"Does not extend right of the specified range.\\"\\"\\"
+  """Does not extend right of the specified range."""
   notExtendsRightOf: DatetimeRangeInput
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [DatetimeRangeInput!]
 
-  \\"\\"\\"Overlaps the specified range.\\"\\"\\"
+  """Overlaps the specified range."""
   overlaps: DatetimeRangeInput
 
-  \\"\\"\\"Strictly left of the specified range.\\"\\"\\"
+  """Strictly left of the specified range."""
   strictlyLeftOf: DatetimeRangeInput
 
-  \\"\\"\\"Strictly right of the specified range.\\"\\"\\"
+  """Strictly right of the specified range."""
   strictlyRightOf: DatetimeRangeInput
 }
 
-\\"\\"\\"A range of \`Datetime\`.\\"\\"\\"
+"""A range of \`Datetime\`."""
 input DatetimeRangeInput {
-  \\"\\"\\"The ending bound of our range.\\"\\"\\"
+  """The ending bound of our range."""
   end: DatetimeRangeBoundInput
 
-  \\"\\"\\"The starting bound of our range.\\"\\"\\"
+  """The starting bound of our range."""
   start: DatetimeRangeBoundInput
 }
 
-\\"\\"\\"
+"""
 A filter to be used against DatetimeRange List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input DatetimeRangeListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: DatetimeRangeInput
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: DatetimeRangeInput
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: DatetimeRangeInput
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: DatetimeRangeInput
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: DatetimeRangeInput
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: DatetimeRangeInput
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [DatetimeRangeInput]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [DatetimeRangeInput]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [DatetimeRangeInput]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [DatetimeRangeInput]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [DatetimeRangeInput]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [DatetimeRangeInput]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [DatetimeRangeInput]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [DatetimeRangeInput]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [DatetimeRangeInput]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [DatetimeRangeInput]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [DatetimeRangeInput]
 }
 
@@ -2130,65 +2130,65 @@ type DomainType implements Node {
   id: Int!
   int4Domain: Int4Domain
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`DomainType\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input DomainTypeFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [DomainTypeFilter!]
 
-  \\"\\"\\"Filter by the object’s \`char4Domain\` field.\\"\\"\\"
+  """Filter by the object’s \`char4Domain\` field."""
   char4Domain: Char4DomainFilter
 
-  \\"\\"\\"Filter by the object’s \`dateDomain\` field.\\"\\"\\"
+  """Filter by the object’s \`dateDomain\` field."""
   dateDomain: DateDomainFilter
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`int4Domain\` field.\\"\\"\\"
+  """Filter by the object’s \`int4Domain\` field."""
   int4Domain: Int4DomainFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: DomainTypeFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [DomainTypeFilter!]
 }
 
-\\"\\"\\"A connection to a list of \`DomainType\` values.\\"\\"\\"
+"""A connection to a list of \`DomainType\` values."""
 type DomainTypesConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`DomainType\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [DomainTypesEdge!]!
 
-  \\"\\"\\"A list of \`DomainType\` objects.\\"\\"\\"
+  """A list of \`DomainType\` objects."""
   nodes: [DomainType]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`DomainType\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`DomainType\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`DomainType\` edge in the connection.\\"\\"\\"
+"""A \`DomainType\` edge in the connection."""
 type DomainTypesEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`DomainType\` at the end of the edge.\\"\\"\\"
+  """The \`DomainType\` at the end of the edge."""
   node: DomainType
 }
 
-\\"\\"\\"Methods to use when ordering \`DomainType\`.\\"\\"\\"
+"""Methods to use when ordering \`DomainType\`."""
 enum DomainTypesOrderBy {
   CHAR4_DOMAIN_ASC
   CHAR4_DOMAIN_DESC
@@ -2207,59 +2207,59 @@ type EnumArrayType implements Node {
   enumArray: [Mood]
   id: Int!
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`EnumArrayType\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input EnumArrayTypeFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [EnumArrayTypeFilter!]
 
-  \\"\\"\\"Filter by the object’s \`enumArray\` field.\\"\\"\\"
+  """Filter by the object’s \`enumArray\` field."""
   enumArray: MoodListFilter
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: EnumArrayTypeFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [EnumArrayTypeFilter!]
 }
 
-\\"\\"\\"A connection to a list of \`EnumArrayType\` values.\\"\\"\\"
+"""A connection to a list of \`EnumArrayType\` values."""
 type EnumArrayTypesConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`EnumArrayType\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [EnumArrayTypesEdge!]!
 
-  \\"\\"\\"A list of \`EnumArrayType\` objects.\\"\\"\\"
+  """A list of \`EnumArrayType\` objects."""
   nodes: [EnumArrayType]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`EnumArrayType\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`EnumArrayType\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`EnumArrayType\` edge in the connection.\\"\\"\\"
+"""A \`EnumArrayType\` edge in the connection."""
 type EnumArrayTypesEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`EnumArrayType\` at the end of the edge.\\"\\"\\"
+  """The \`EnumArrayType\` at the end of the edge."""
   node: EnumArrayType
 }
 
-\\"\\"\\"Methods to use when ordering \`EnumArrayType\`.\\"\\"\\"
+"""Methods to use when ordering \`EnumArrayType\`."""
 enum EnumArrayTypesOrderBy {
   ENUM_ARRAY_ASC
   ENUM_ARRAY_DESC
@@ -2274,59 +2274,59 @@ type EnumType implements Node {
   enum: Mood
   id: Int!
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`EnumType\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input EnumTypeFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [EnumTypeFilter!]
 
-  \\"\\"\\"Filter by the object’s \`enum\` field.\\"\\"\\"
+  """Filter by the object’s \`enum\` field."""
   enum: MoodFilter
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: EnumTypeFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [EnumTypeFilter!]
 }
 
-\\"\\"\\"A connection to a list of \`EnumType\` values.\\"\\"\\"
+"""A connection to a list of \`EnumType\` values."""
 type EnumTypesConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`EnumType\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [EnumTypesEdge!]!
 
-  \\"\\"\\"A list of \`EnumType\` objects.\\"\\"\\"
+  """A list of \`EnumType\` objects."""
   nodes: [EnumType]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`EnumType\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`EnumType\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`EnumType\` edge in the connection.\\"\\"\\"
+"""A \`EnumType\` edge in the connection."""
 type EnumTypesEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`EnumType\` at the end of the edge.\\"\\"\\"
+  """The \`EnumType\` at the end of the edge."""
   node: EnumType
 }
 
-\\"\\"\\"Methods to use when ordering \`EnumType\`.\\"\\"\\"
+"""Methods to use when ordering \`EnumType\`."""
 enum EnumTypesOrderBy {
   ENUM_ASC
   ENUM_DESC
@@ -2338,14 +2338,14 @@ enum EnumTypesOrderBy {
 }
 
 type Filterable implements Node {
-  \\"\\"\\"Reads a single \`Backward\` that is related to this \`Filterable\`.\\"\\"\\"
+  """Reads a single \`Backward\` that is related to this \`Filterable\`."""
   backwardByFilterableId: Backward
   backwardCompound1: Int
   backwardCompound2: Int
 
-  \\"\\"\\"
+  """
   Reads a single \`BackwardCompound\` that is related to this \`Filterable\`.
-  \\"\\"\\"
+  """
   backwardCompoundByBackwardCompound1AndBackwardCompound2: BackwardCompound
   bit4: BitString
   bool: Boolean
@@ -2353,61 +2353,61 @@ type Filterable implements Node {
   bytea: String
   char4: String
 
-  \\"\\"\\"Reads and enables pagination through a set of \`ChildNoRelatedFilter\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`ChildNoRelatedFilter\`."""
   childNoRelatedFiltersByFilterableId(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: ChildNoRelatedFilterFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`ChildNoRelatedFilter\`.\\"\\"\\"
+    """The method to use when ordering \`ChildNoRelatedFilter\`."""
     orderBy: [ChildNoRelatedFiltersOrderBy!] = [PRIMARY_KEY_ASC]
   ): ChildNoRelatedFiltersConnection!
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Child\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Child\`."""
   childrenByFilterableId(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: ChildFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`Child\`.\\"\\"\\"
+    """The method to use when ordering \`Child\`."""
     orderBy: [ChildrenOrderBy!] = [PRIMARY_KEY_ASC]
   ): ChildrenConnection!
   cidr: String
@@ -2418,126 +2418,126 @@ type Filterable implements Node {
   computedChild: Child
   computedIntArray: [Int]
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Child\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Child\`."""
   computedSetofChild(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: ChildFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
   ): ChildrenConnection!
   computedSetofInt(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: IntFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
   ): FilterableComputedSetofIntConnection!
   computedTaggedFilterable: Int
   computedWithRequiredArg(i: Int!): Int
   date: Date
 
-  \\"\\"\\"Reads and enables pagination through a set of \`FilterableClosure\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`FilterableClosure\`."""
   filterableClosuresByAncestorId(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: FilterableClosureFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`FilterableClosure\`.\\"\\"\\"
+    """The method to use when ordering \`FilterableClosure\`."""
     orderBy: [FilterableClosuresOrderBy!] = [PRIMARY_KEY_ASC]
   ): FilterableClosuresConnection!
 
-  \\"\\"\\"Reads and enables pagination through a set of \`FilterableClosure\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`FilterableClosure\`."""
   filterableClosuresByDescendantId(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: FilterableClosureFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`FilterableClosure\`.\\"\\"\\"
+    """The method to use when ordering \`FilterableClosure\`."""
     orderBy: [FilterableClosuresOrderBy!] = [PRIMARY_KEY_ASC]
   ): FilterableClosuresConnection!
   float4: Float
   float8: Float
 
-  \\"\\"\\"Reads a single \`Forward\` that is related to this \`Filterable\`.\\"\\"\\"
+  """Reads a single \`Forward\` that is related to this \`Filterable\`."""
   forwardByForwardId: Forward
   forwardColumn: Forward
   forwardCompound1: Int
   forwardCompound2: Int
 
-  \\"\\"\\"Reads a single \`ForwardCompound\` that is related to this \`Filterable\`.\\"\\"\\"
+  """Reads a single \`ForwardCompound\` that is related to this \`Filterable\`."""
   forwardCompoundByForwardCompound1AndForwardCompound2: ForwardCompound
   forwardId: Int
   hstore: KeyValueHash
@@ -2553,13 +2553,13 @@ type Filterable implements Node {
   money: Float
   name: String
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
   numeric: BigFloat
 
-  \\"\\"\\"Reads a single \`Parent\` that is related to this \`Filterable\`.\\"\\"\\"
+  """Reads a single \`Parent\` that is related to this \`Filterable\`."""
   parentByParentId: Parent
   parentId: Int
   text: String
@@ -2579,84 +2579,84 @@ type FilterableClosure implements Node {
   depth: Int!
   descendantId: Int!
 
-  \\"\\"\\"
+  """
   Reads a single \`Filterable\` that is related to this \`FilterableClosure\`.
-  \\"\\"\\"
+  """
   filterableByAncestorId: Filterable
 
-  \\"\\"\\"
+  """
   Reads a single \`Filterable\` that is related to this \`FilterableClosure\`.
-  \\"\\"\\"
+  """
   filterableByDescendantId: Filterable
   id: Int!
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`FilterableClosure\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input FilterableClosureFilter {
-  \\"\\"\\"Filter by the object’s \`ancestorId\` field.\\"\\"\\"
+  """Filter by the object’s \`ancestorId\` field."""
   ancestorId: IntFilter
 
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [FilterableClosureFilter!]
 
-  \\"\\"\\"Filter by the object’s \`depth\` field.\\"\\"\\"
+  """Filter by the object’s \`depth\` field."""
   depth: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`descendantId\` field.\\"\\"\\"
+  """Filter by the object’s \`descendantId\` field."""
   descendantId: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`filterableByAncestorId\` relation.\\"\\"\\"
+  """Filter by the object’s \`filterableByAncestorId\` relation."""
   filterableByAncestorId: FilterableFilter
 
-  \\"\\"\\"Filter by the object’s \`filterableByDescendantId\` relation.\\"\\"\\"
+  """Filter by the object’s \`filterableByDescendantId\` relation."""
   filterableByDescendantId: FilterableFilter
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: FilterableClosureFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [FilterableClosureFilter!]
 }
 
-\\"\\"\\"A connection to a list of \`FilterableClosure\` values.\\"\\"\\"
+"""A connection to a list of \`FilterableClosure\` values."""
 type FilterableClosuresConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`FilterableClosure\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [FilterableClosuresEdge!]!
 
-  \\"\\"\\"A list of \`FilterableClosure\` objects.\\"\\"\\"
+  """A list of \`FilterableClosure\` objects."""
   nodes: [FilterableClosure]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"
+  """
   The count of *all* \`FilterableClosure\` you could get from the connection.
-  \\"\\"\\"
+  """
   totalCount: Int!
 }
 
-\\"\\"\\"A \`FilterableClosure\` edge in the connection.\\"\\"\\"
+"""A \`FilterableClosure\` edge in the connection."""
 type FilterableClosuresEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`FilterableClosure\` at the end of the edge.\\"\\"\\"
+  """The \`FilterableClosure\` at the end of the edge."""
   node: FilterableClosure
 }
 
-\\"\\"\\"Methods to use when ordering \`FilterableClosure\`.\\"\\"\\"
+"""Methods to use when ordering \`FilterableClosure\`."""
 enum FilterableClosuresOrderBy {
   ANCESTOR_ID_ASC
   ANCESTOR_ID_DESC
@@ -2671,237 +2671,237 @@ enum FilterableClosuresOrderBy {
   PRIMARY_KEY_DESC
 }
 
-\\"\\"\\"A connection to a list of \`Int\` values.\\"\\"\\"
+"""A connection to a list of \`Int\` values."""
 type FilterableComputedSetofIntConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`Int\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [FilterableComputedSetofIntEdge!]!
 
-  \\"\\"\\"A list of \`Int\` objects.\\"\\"\\"
+  """A list of \`Int\` objects."""
   nodes: [Int]!
 
-  \\"\\"\\"The count of *all* \`Int\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`Int\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`Int\` edge in the connection.\\"\\"\\"
+"""A \`Int\` edge in the connection."""
 type FilterableComputedSetofIntEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`Int\` at the end of the edge.\\"\\"\\"
+  """The \`Int\` at the end of the edge."""
   node: Int
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`Filterable\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input FilterableFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [FilterableFilter!]
 
-  \\"\\"\\"Filter by the object’s \`backwardByFilterableId\` relation.\\"\\"\\"
+  """Filter by the object’s \`backwardByFilterableId\` relation."""
   backwardByFilterableId: BackwardFilter
 
-  \\"\\"\\"A related \`backwardByFilterableId\` exists.\\"\\"\\"
+  """A related \`backwardByFilterableId\` exists."""
   backwardByFilterableIdExists: Boolean
 
-  \\"\\"\\"Filter by the object’s \`backwardCompound1\` field.\\"\\"\\"
+  """Filter by the object’s \`backwardCompound1\` field."""
   backwardCompound1: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`backwardCompound2\` field.\\"\\"\\"
+  """Filter by the object’s \`backwardCompound2\` field."""
   backwardCompound2: IntFilter
 
-  \\"\\"\\"
+  """
   Filter by the object’s \`backwardCompoundByBackwardCompound1AndBackwardCompound2\` relation.
-  \\"\\"\\"
+  """
   backwardCompoundByBackwardCompound1AndBackwardCompound2: BackwardCompoundFilter
 
-  \\"\\"\\"
+  """
   A related \`backwardCompoundByBackwardCompound1AndBackwardCompound2\` exists.
-  \\"\\"\\"
+  """
   backwardCompoundByBackwardCompound1AndBackwardCompound2Exists: Boolean
 
-  \\"\\"\\"Filter by the object’s \`bit4\` field.\\"\\"\\"
+  """Filter by the object’s \`bit4\` field."""
   bit4: BitStringFilter
 
-  \\"\\"\\"Filter by the object’s \`bool\` field.\\"\\"\\"
+  """Filter by the object’s \`bool\` field."""
   bool: BooleanFilter
 
-  \\"\\"\\"Filter by the object’s \`bpchar4\` field.\\"\\"\\"
+  """Filter by the object’s \`bpchar4\` field."""
   bpchar4: StringFilter
 
-  \\"\\"\\"Filter by the object’s \`char4\` field.\\"\\"\\"
+  """Filter by the object’s \`char4\` field."""
   char4: StringFilter
 
-  \\"\\"\\"Filter by the object’s \`childrenByFilterableId\` relation.\\"\\"\\"
+  """Filter by the object’s \`childrenByFilterableId\` relation."""
   childrenByFilterableId: FilterableToManyChildFilter
 
-  \\"\\"\\"Some related \`childrenByFilterableId\` exist.\\"\\"\\"
+  """Some related \`childrenByFilterableId\` exist."""
   childrenByFilterableIdExist: Boolean
 
-  \\"\\"\\"Filter by the object’s \`citext\` field.\\"\\"\\"
+  """Filter by the object’s \`citext\` field."""
   citext: StringFilter
 
-  \\"\\"\\"Filter by the object’s \`compositeColumn\` field.\\"\\"\\"
+  """Filter by the object’s \`compositeColumn\` field."""
   compositeColumn: CompositeFilter
 
-  \\"\\"\\"Filter by the object’s \`computed\` field.\\"\\"\\"
+  """Filter by the object’s \`computed\` field."""
   computed: StringFilter
 
-  \\"\\"\\"Filter by the object’s \`computedIntArray\` field.\\"\\"\\"
+  """Filter by the object’s \`computedIntArray\` field."""
   computedIntArray: IntListFilter
 
-  \\"\\"\\"Filter by the object’s \`computedTaggedFilterable\` field.\\"\\"\\"
+  """Filter by the object’s \`computedTaggedFilterable\` field."""
   computedTaggedFilterable: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`date\` field.\\"\\"\\"
+  """Filter by the object’s \`date\` field."""
   date: DateFilter
 
-  \\"\\"\\"Filter by the object’s \`filterableClosuresByAncestorId\` relation.\\"\\"\\"
+  """Filter by the object’s \`filterableClosuresByAncestorId\` relation."""
   filterableClosuresByAncestorId: FilterableToManyFilterableClosureFilter
 
-  \\"\\"\\"Some related \`filterableClosuresByAncestorId\` exist.\\"\\"\\"
+  """Some related \`filterableClosuresByAncestorId\` exist."""
   filterableClosuresByAncestorIdExist: Boolean
 
-  \\"\\"\\"Filter by the object’s \`filterableClosuresByDescendantId\` relation.\\"\\"\\"
+  """Filter by the object’s \`filterableClosuresByDescendantId\` relation."""
   filterableClosuresByDescendantId: FilterableToManyFilterableClosureFilter
 
-  \\"\\"\\"Some related \`filterableClosuresByDescendantId\` exist.\\"\\"\\"
+  """Some related \`filterableClosuresByDescendantId\` exist."""
   filterableClosuresByDescendantIdExist: Boolean
 
-  \\"\\"\\"Filter by the object’s \`float4\` field.\\"\\"\\"
+  """Filter by the object’s \`float4\` field."""
   float4: FloatFilter
 
-  \\"\\"\\"Filter by the object’s \`float8\` field.\\"\\"\\"
+  """Filter by the object’s \`float8\` field."""
   float8: FloatFilter
 
-  \\"\\"\\"Filter by the object’s \`forwardByForwardId\` relation.\\"\\"\\"
+  """Filter by the object’s \`forwardByForwardId\` relation."""
   forwardByForwardId: ForwardFilter
 
-  \\"\\"\\"A related \`forwardByForwardId\` exists.\\"\\"\\"
+  """A related \`forwardByForwardId\` exists."""
   forwardByForwardIdExists: Boolean
 
-  \\"\\"\\"Filter by the object’s \`forwardCompound1\` field.\\"\\"\\"
+  """Filter by the object’s \`forwardCompound1\` field."""
   forwardCompound1: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`forwardCompound2\` field.\\"\\"\\"
+  """Filter by the object’s \`forwardCompound2\` field."""
   forwardCompound2: IntFilter
 
-  \\"\\"\\"
+  """
   Filter by the object’s \`forwardCompoundByForwardCompound1AndForwardCompound2\` relation.
-  \\"\\"\\"
+  """
   forwardCompoundByForwardCompound1AndForwardCompound2: ForwardCompoundFilter
 
-  \\"\\"\\"
+  """
   A related \`forwardCompoundByForwardCompound1AndForwardCompound2\` exists.
-  \\"\\"\\"
+  """
   forwardCompoundByForwardCompound1AndForwardCompound2Exists: Boolean
 
-  \\"\\"\\"Filter by the object’s \`forwardId\` field.\\"\\"\\"
+  """Filter by the object’s \`forwardId\` field."""
   forwardId: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`hstore\` field.\\"\\"\\"
+  """Filter by the object’s \`hstore\` field."""
   hstore: KeyValueHashFilter
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`inet\` field.\\"\\"\\"
+  """Filter by the object’s \`inet\` field."""
   inet: InternetAddressFilter
 
-  \\"\\"\\"Filter by the object’s \`int2\` field.\\"\\"\\"
+  """Filter by the object’s \`int2\` field."""
   int2: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`int4\` field.\\"\\"\\"
+  """Filter by the object’s \`int4\` field."""
   int4: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`int8\` field.\\"\\"\\"
+  """Filter by the object’s \`int8\` field."""
   int8: BigIntFilter
 
-  \\"\\"\\"Filter by the object’s \`interval\` field.\\"\\"\\"
+  """Filter by the object’s \`interval\` field."""
   interval: IntervalFilter
 
-  \\"\\"\\"Filter by the object’s \`jsonb\` field.\\"\\"\\"
+  """Filter by the object’s \`jsonb\` field."""
   jsonb: JSONFilter
 
-  \\"\\"\\"Filter by the object’s \`money\` field.\\"\\"\\"
+  """Filter by the object’s \`money\` field."""
   money: FloatFilter
 
-  \\"\\"\\"Filter by the object’s \`name\` field.\\"\\"\\"
+  """Filter by the object’s \`name\` field."""
   name: StringFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: FilterableFilter
 
-  \\"\\"\\"Filter by the object’s \`numeric\` field.\\"\\"\\"
+  """Filter by the object’s \`numeric\` field."""
   numeric: BigFloatFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [FilterableFilter!]
 
-  \\"\\"\\"Filter by the object’s \`parentByParentId\` relation.\\"\\"\\"
+  """Filter by the object’s \`parentByParentId\` relation."""
   parentByParentId: ParentFilter
 
-  \\"\\"\\"A related \`parentByParentId\` exists.\\"\\"\\"
+  """A related \`parentByParentId\` exists."""
   parentByParentIdExists: Boolean
 
-  \\"\\"\\"Filter by the object’s \`parentId\` field.\\"\\"\\"
+  """Filter by the object’s \`parentId\` field."""
   parentId: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`text\` field.\\"\\"\\"
+  """Filter by the object’s \`text\` field."""
   text: StringFilter
 
-  \\"\\"\\"Filter by the object’s \`time\` field.\\"\\"\\"
+  """Filter by the object’s \`time\` field."""
   time: TimeFilter
 
-  \\"\\"\\"Filter by the object’s \`timestamp\` field.\\"\\"\\"
+  """Filter by the object’s \`timestamp\` field."""
   timestamp: DatetimeFilter
 
-  \\"\\"\\"Filter by the object’s \`timestamptz\` field.\\"\\"\\"
+  """Filter by the object’s \`timestamptz\` field."""
   timestamptz: DatetimeFilter
 
-  \\"\\"\\"Filter by the object’s \`timetz\` field.\\"\\"\\"
+  """Filter by the object’s \`timetz\` field."""
   timetz: TimeFilter
 
-  \\"\\"\\"Filter by the object’s \`uuid\` field.\\"\\"\\"
+  """Filter by the object’s \`uuid\` field."""
   uuid: UUIDFilter
 
-  \\"\\"\\"Filter by the object’s \`varbit\` field.\\"\\"\\"
+  """Filter by the object’s \`varbit\` field."""
   varbit: BitStringFilter
 
-  \\"\\"\\"Filter by the object’s \`varchar\` field.\\"\\"\\"
+  """Filter by the object’s \`varchar\` field."""
   varchar: StringFilter
 }
 
-\\"\\"\\"A connection to a list of \`Filterable\` values.\\"\\"\\"
+"""A connection to a list of \`Filterable\` values."""
 type FilterablesConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`Filterable\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [FilterablesEdge!]!
 
-  \\"\\"\\"A list of \`Filterable\` objects.\\"\\"\\"
+  """A list of \`Filterable\` objects."""
   nodes: [Filterable]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`Filterable\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`Filterable\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`Filterable\` edge in the connection.\\"\\"\\"
+"""A \`Filterable\` edge in the connection."""
 type FilterablesEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`Filterable\` at the end of the edge.\\"\\"\\"
+  """The \`Filterable\` at the end of the edge."""
   node: Filterable
 }
 
-\\"\\"\\"Methods to use when ordering \`Filterable\`.\\"\\"\\"
+"""Methods to use when ordering \`Filterable\`."""
 enum FilterablesOrderBy {
   BACKWARD_COMPOUND_1_ASC
   BACKWARD_COMPOUND_1_DESC
@@ -2990,236 +2990,236 @@ enum FilterablesOrderBy {
   XML_DESC
 }
 
-\\"\\"\\"
+"""
 A filter to be used against many \`Child\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input FilterableToManyChildFilter {
-  \\"\\"\\"
+  """
   Every related \`Child\` matches the filter criteria. All fields are combined with a logical ‘and.’
-  \\"\\"\\"
+  """
   every: ChildFilter
 
-  \\"\\"\\"
+  """
   No related \`Child\` matches the filter criteria. All fields are combined with a logical ‘and.’
-  \\"\\"\\"
+  """
   none: ChildFilter
 
-  \\"\\"\\"
+  """
   Some related \`Child\` matches the filter criteria. All fields are combined with a logical ‘and.’
-  \\"\\"\\"
+  """
   some: ChildFilter
 }
 
-\\"\\"\\"
+"""
 A filter to be used against many \`FilterableClosure\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input FilterableToManyFilterableClosureFilter {
-  \\"\\"\\"
+  """
   Every related \`FilterableClosure\` matches the filter criteria. All fields are combined with a logical ‘and.’
-  \\"\\"\\"
+  """
   every: FilterableClosureFilter
 
-  \\"\\"\\"
+  """
   No related \`FilterableClosure\` matches the filter criteria. All fields are combined with a logical ‘and.’
-  \\"\\"\\"
+  """
   none: FilterableClosureFilter
 
-  \\"\\"\\"
+  """
   Some related \`FilterableClosure\` matches the filter criteria. All fields are combined with a logical ‘and.’
-  \\"\\"\\"
+  """
   some: FilterableClosureFilter
 }
 
-\\"\\"\\"
+"""
 A filter to be used against Float fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input FloatFilter {
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: Float
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: Float
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: Float
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: Float
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [Float!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: Float
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: Float
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: Float
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: Float
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [Float!]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against Float List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input FloatListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: Float
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: Float
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: Float
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: Float
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: Float
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: Float
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [Float]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [Float]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [Float]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [Float]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [Float]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [Float]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [Float]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [Float]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [Float]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [Float]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [Float]
 }
 
 type Forward implements Node {
-  \\"\\"\\"Reads a single \`Filterable\` that is related to this \`Forward\`.\\"\\"\\"
+  """Reads a single \`Filterable\` that is related to this \`Forward\`."""
   filterableByForwardId: Filterable
   id: Int!
   name: String!
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
 type ForwardCompound implements Node {
-  \\"\\"\\"Reads a single \`Filterable\` that is related to this \`ForwardCompound\`.\\"\\"\\"
+  """Reads a single \`Filterable\` that is related to this \`ForwardCompound\`."""
   filterableByForwardCompound1AndForwardCompound2: Filterable
   forwardCompound1: Int!
   forwardCompound2: Int!
   name: String
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`ForwardCompound\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input ForwardCompoundFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [ForwardCompoundFilter!]
 
-  \\"\\"\\"
+  """
   Filter by the object’s \`filterableByForwardCompound1AndForwardCompound2\` relation.
-  \\"\\"\\"
+  """
   filterableByForwardCompound1AndForwardCompound2: FilterableFilter
 
-  \\"\\"\\"A related \`filterableByForwardCompound1AndForwardCompound2\` exists.\\"\\"\\"
+  """A related \`filterableByForwardCompound1AndForwardCompound2\` exists."""
   filterableByForwardCompound1AndForwardCompound2Exists: Boolean
 
-  \\"\\"\\"Filter by the object’s \`forwardCompound1\` field.\\"\\"\\"
+  """Filter by the object’s \`forwardCompound1\` field."""
   forwardCompound1: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`forwardCompound2\` field.\\"\\"\\"
+  """Filter by the object’s \`forwardCompound2\` field."""
   forwardCompound2: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`name\` field.\\"\\"\\"
+  """Filter by the object’s \`name\` field."""
   name: StringFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: ForwardCompoundFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [ForwardCompoundFilter!]
 }
 
-\\"\\"\\"A connection to a list of \`ForwardCompound\` values.\\"\\"\\"
+"""A connection to a list of \`ForwardCompound\` values."""
 type ForwardCompoundsConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`ForwardCompound\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [ForwardCompoundsEdge!]!
 
-  \\"\\"\\"A list of \`ForwardCompound\` objects.\\"\\"\\"
+  """A list of \`ForwardCompound\` objects."""
   nodes: [ForwardCompound]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"
+  """
   The count of *all* \`ForwardCompound\` you could get from the connection.
-  \\"\\"\\"
+  """
   totalCount: Int!
 }
 
-\\"\\"\\"A \`ForwardCompound\` edge in the connection.\\"\\"\\"
+"""A \`ForwardCompound\` edge in the connection."""
 type ForwardCompoundsEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`ForwardCompound\` at the end of the edge.\\"\\"\\"
+  """The \`ForwardCompound\` at the end of the edge."""
   node: ForwardCompound
 }
 
-\\"\\"\\"Methods to use when ordering \`ForwardCompound\`.\\"\\"\\"
+"""Methods to use when ordering \`ForwardCompound\`."""
 enum ForwardCompoundsOrderBy {
   FORWARD_COMPOUND_1_ASC
   FORWARD_COMPOUND_1_DESC
@@ -3232,59 +3232,59 @@ enum ForwardCompoundsOrderBy {
   PRIMARY_KEY_DESC
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`Forward\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input ForwardFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [ForwardFilter!]
 
-  \\"\\"\\"Filter by the object’s \`filterableByForwardId\` relation.\\"\\"\\"
+  """Filter by the object’s \`filterableByForwardId\` relation."""
   filterableByForwardId: FilterableFilter
 
-  \\"\\"\\"A related \`filterableByForwardId\` exists.\\"\\"\\"
+  """A related \`filterableByForwardId\` exists."""
   filterableByForwardIdExists: Boolean
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`name\` field.\\"\\"\\"
+  """Filter by the object’s \`name\` field."""
   name: StringFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: ForwardFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [ForwardFilter!]
 }
 
-\\"\\"\\"A connection to a list of \`Forward\` values.\\"\\"\\"
+"""A connection to a list of \`Forward\` values."""
 type ForwardsConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`Forward\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [ForwardsEdge!]!
 
-  \\"\\"\\"A list of \`Forward\` objects.\\"\\"\\"
+  """A list of \`Forward\` objects."""
   nodes: [Forward]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`Forward\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`Forward\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`Forward\` edge in the connection.\\"\\"\\"
+"""A \`Forward\` edge in the connection."""
 type ForwardsEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`Forward\` at the end of the edge.\\"\\"\\"
+  """The \`Forward\` at the end of the edge."""
   node: Forward
 }
 
-\\"\\"\\"Methods to use when ordering \`Forward\`.\\"\\"\\"
+"""Methods to use when ordering \`Forward\`."""
 enum ForwardsOrderBy {
   ID_ASC
   ID_DESC
@@ -3298,40 +3298,40 @@ enum ForwardsOrderBy {
 type FullyOmitted implements Node {
   id: Int!
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
   text: String
 }
 
-\\"\\"\\"A connection to a list of \`FullyOmitted\` values.\\"\\"\\"
+"""A connection to a list of \`FullyOmitted\` values."""
 type FullyOmittedsConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`FullyOmitted\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [FullyOmittedsEdge!]!
 
-  \\"\\"\\"A list of \`FullyOmitted\` objects.\\"\\"\\"
+  """A list of \`FullyOmitted\` objects."""
   nodes: [FullyOmitted]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`FullyOmitted\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`FullyOmitted\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`FullyOmitted\` edge in the connection.\\"\\"\\"
+"""A \`FullyOmitted\` edge in the connection."""
 type FullyOmittedsEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`FullyOmitted\` at the end of the edge.\\"\\"\\"
+  """The \`FullyOmitted\` at the end of the edge."""
   node: FullyOmitted
 }
 
-\\"\\"\\"Methods to use when ordering \`FullyOmitted\`.\\"\\"\\"
+"""Methods to use when ordering \`FullyOmitted\`."""
 enum FullyOmittedsOrderBy {
   ID_ASC
   ID_DESC
@@ -3342,746 +3342,746 @@ enum FullyOmittedsOrderBy {
   TEXT_DESC
 }
 
-\\"\\"\\"A connection to a list of \`FuncReturnsTableMultiColRecord\` values.\\"\\"\\"
+"""A connection to a list of \`FuncReturnsTableMultiColRecord\` values."""
 type FuncReturnsTableMultiColConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`FuncReturnsTableMultiColRecord\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [FuncReturnsTableMultiColEdge!]!
 
-  \\"\\"\\"A list of \`FuncReturnsTableMultiColRecord\` objects.\\"\\"\\"
+  """A list of \`FuncReturnsTableMultiColRecord\` objects."""
   nodes: [FuncReturnsTableMultiColRecord]!
 
-  \\"\\"\\"
+  """
   The count of *all* \`FuncReturnsTableMultiColRecord\` you could get from the connection.
-  \\"\\"\\"
+  """
   totalCount: Int!
 }
 
-\\"\\"\\"A \`FuncReturnsTableMultiColRecord\` edge in the connection.\\"\\"\\"
+"""A \`FuncReturnsTableMultiColRecord\` edge in the connection."""
 type FuncReturnsTableMultiColEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`FuncReturnsTableMultiColRecord\` at the end of the edge.\\"\\"\\"
+  """The \`FuncReturnsTableMultiColRecord\` at the end of the edge."""
   node: FuncReturnsTableMultiColRecord
 }
 
-\\"\\"\\"The return type of our \`funcReturnsTableMultiCol\` query.\\"\\"\\"
+"""The return type of our \`funcReturnsTableMultiCol\` query."""
 type FuncReturnsTableMultiColRecord {
   col1: Int
   col2: String
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`FuncReturnsTableMultiColRecord\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input FuncReturnsTableMultiColRecordFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [FuncReturnsTableMultiColRecordFilter!]
 
-  \\"\\"\\"Filter by the object’s \`col1\` field.\\"\\"\\"
+  """Filter by the object’s \`col1\` field."""
   col1: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`col2\` field.\\"\\"\\"
+  """Filter by the object’s \`col2\` field."""
   col2: StringFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: FuncReturnsTableMultiColRecordFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [FuncReturnsTableMultiColRecordFilter!]
 }
 
-\\"\\"\\"A connection to a list of \`Int\` values.\\"\\"\\"
+"""A connection to a list of \`Int\` values."""
 type FuncReturnsTableOneColConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`Int\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [FuncReturnsTableOneColEdge!]!
 
-  \\"\\"\\"A list of \`Int\` objects.\\"\\"\\"
+  """A list of \`Int\` objects."""
   nodes: [Int]!
 
-  \\"\\"\\"The count of *all* \`Int\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`Int\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`Int\` edge in the connection.\\"\\"\\"
+"""A \`Int\` edge in the connection."""
 type FuncReturnsTableOneColEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`Int\` at the end of the edge.\\"\\"\\"
+  """The \`Int\` at the end of the edge."""
   node: Int
 }
 
-\\"\\"\\"
+"""
 A connection to a list of \`FuncTaggedFilterableReturnsTableMultiColRecord\` values.
-\\"\\"\\"
+"""
 type FuncTaggedFilterableReturnsTableMultiColConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`FuncTaggedFilterableReturnsTableMultiColRecord\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [FuncTaggedFilterableReturnsTableMultiColEdge!]!
 
-  \\"\\"\\"A list of \`FuncTaggedFilterableReturnsTableMultiColRecord\` objects.\\"\\"\\"
+  """A list of \`FuncTaggedFilterableReturnsTableMultiColRecord\` objects."""
   nodes: [FuncTaggedFilterableReturnsTableMultiColRecord]!
 
-  \\"\\"\\"
+  """
   The count of *all* \`FuncTaggedFilterableReturnsTableMultiColRecord\` you could get from the connection.
-  \\"\\"\\"
+  """
   totalCount: Int!
 }
 
-\\"\\"\\"
+"""
 A \`FuncTaggedFilterableReturnsTableMultiColRecord\` edge in the connection.
-\\"\\"\\"
+"""
 type FuncTaggedFilterableReturnsTableMultiColEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"
+  """
   The \`FuncTaggedFilterableReturnsTableMultiColRecord\` at the end of the edge.
-  \\"\\"\\"
+  """
   node: FuncTaggedFilterableReturnsTableMultiColRecord
 }
 
-\\"\\"\\"
+"""
 The return type of our \`funcTaggedFilterableReturnsTableMultiCol\` query.
-\\"\\"\\"
+"""
 type FuncTaggedFilterableReturnsTableMultiColRecord {
   col1: Int
   col2: String
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`FuncTaggedFilterableReturnsTableMultiColRecord\`
 object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input FuncTaggedFilterableReturnsTableMultiColRecordFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [FuncTaggedFilterableReturnsTableMultiColRecordFilter!]
 
-  \\"\\"\\"Filter by the object’s \`col1\` field.\\"\\"\\"
+  """Filter by the object’s \`col1\` field."""
   col1: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`col2\` field.\\"\\"\\"
+  """Filter by the object’s \`col2\` field."""
   col2: StringFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: FuncTaggedFilterableReturnsTableMultiColRecordFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [FuncTaggedFilterableReturnsTableMultiColRecordFilter!]
 }
 
 scalar Int4Domain
 
-\\"\\"\\"
+"""
 A filter to be used against Int4Domain fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input Int4DomainFilter {
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: Int4Domain
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: Int4Domain
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: Int4Domain
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: Int4Domain
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [Int4Domain!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: Int4Domain
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: Int4Domain
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: Int4Domain
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: Int4Domain
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [Int4Domain!]
 }
 
-\\"\\"\\"An IPv4 or IPv6 host address, and optionally its subnet.\\"\\"\\"
+"""An IPv4 or IPv6 host address, and optionally its subnet."""
 scalar InternetAddress
 
-\\"\\"\\"
+"""
 A filter to be used against InternetAddress fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input InternetAddressFilter {
-  \\"\\"\\"Contained by the specified internet address.\\"\\"\\"
+  """Contained by the specified internet address."""
   containedBy: InternetAddress
 
-  \\"\\"\\"Contained by or equal to the specified internet address.\\"\\"\\"
+  """Contained by or equal to the specified internet address."""
   containedByOrEqualTo: InternetAddress
 
-  \\"\\"\\"Contains the specified internet address.\\"\\"\\"
+  """Contains the specified internet address."""
   contains: InternetAddress
 
-  \\"\\"\\"Contains or contained by the specified internet address.\\"\\"\\"
+  """Contains or contained by the specified internet address."""
   containsOrContainedBy: InternetAddress
 
-  \\"\\"\\"Contains or equal to the specified internet address.\\"\\"\\"
+  """Contains or equal to the specified internet address."""
   containsOrEqualTo: InternetAddress
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: InternetAddress
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: InternetAddress
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: InternetAddress
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: InternetAddress
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [InternetAddress!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: InternetAddress
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: InternetAddress
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: InternetAddress
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: InternetAddress
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [InternetAddress!]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against InternetAddress List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input InternetAddressListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: InternetAddress
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: InternetAddress
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: InternetAddress
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: InternetAddress
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: InternetAddress
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: InternetAddress
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [InternetAddress]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [InternetAddress]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [InternetAddress]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [InternetAddress]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [InternetAddress]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [InternetAddress]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [InternetAddress]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [InternetAddress]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [InternetAddress]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [InternetAddress]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [InternetAddress]
 }
 
-\\"\\"\\"
+"""
 An interval of time that has passed where the smallest distinct unit is a second.
-\\"\\"\\"
+"""
 type Interval {
-  \\"\\"\\"A quantity of days.\\"\\"\\"
+  """A quantity of days."""
   days: Int
 
-  \\"\\"\\"A quantity of hours.\\"\\"\\"
+  """A quantity of hours."""
   hours: Int
 
-  \\"\\"\\"A quantity of minutes.\\"\\"\\"
+  """A quantity of minutes."""
   minutes: Int
 
-  \\"\\"\\"A quantity of months.\\"\\"\\"
+  """A quantity of months."""
   months: Int
 
-  \\"\\"\\"
+  """
   A quantity of seconds. This is the only non-integer field, as all the other
   fields will dump their overflow into a smaller unit of time. Intervals don’t
   have a smaller unit than seconds.
-  \\"\\"\\"
+  """
   seconds: Float
 
-  \\"\\"\\"A quantity of years.\\"\\"\\"
+  """A quantity of years."""
   years: Int
 }
 
-\\"\\"\\"
+"""
 A filter to be used against Interval fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input IntervalFilter {
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: IntervalInput
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: IntervalInput
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: IntervalInput
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: IntervalInput
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [IntervalInput!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: IntervalInput
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: IntervalInput
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: IntervalInput
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: IntervalInput
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [IntervalInput!]
 }
 
-\\"\\"\\"
+"""
 An interval of time that has passed where the smallest distinct unit is a second.
-\\"\\"\\"
+"""
 input IntervalInput {
-  \\"\\"\\"A quantity of days.\\"\\"\\"
+  """A quantity of days."""
   days: Int
 
-  \\"\\"\\"A quantity of hours.\\"\\"\\"
+  """A quantity of hours."""
   hours: Int
 
-  \\"\\"\\"A quantity of minutes.\\"\\"\\"
+  """A quantity of minutes."""
   minutes: Int
 
-  \\"\\"\\"A quantity of months.\\"\\"\\"
+  """A quantity of months."""
   months: Int
 
-  \\"\\"\\"
+  """
   A quantity of seconds. This is the only non-integer field, as all the other
   fields will dump their overflow into a smaller unit of time. Intervals don’t
   have a smaller unit than seconds.
-  \\"\\"\\"
+  """
   seconds: Float
 
-  \\"\\"\\"A quantity of years.\\"\\"\\"
+  """A quantity of years."""
   years: Int
 }
 
-\\"\\"\\"
+"""
 A filter to be used against Interval List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input IntervalListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: IntervalInput
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: IntervalInput
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: IntervalInput
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: IntervalInput
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: IntervalInput
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: IntervalInput
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [IntervalInput]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [IntervalInput]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [IntervalInput]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [IntervalInput]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [IntervalInput]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [IntervalInput]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [IntervalInput]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [IntervalInput]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [IntervalInput]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [IntervalInput]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [IntervalInput]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against Int fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input IntFilter {
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: Int
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: Int
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: Int
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: Int
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [Int!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: Int
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: Int
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: Int
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: Int
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [Int!]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against Int List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input IntListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: Int
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: Int
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: Int
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: Int
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: Int
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: Int
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [Int]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [Int]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [Int]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [Int]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [Int]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [Int]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [Int]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [Int]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [Int]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [Int]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [Int]
 }
 
-\\"\\"\\"A range of \`Int\`.\\"\\"\\"
+"""A range of \`Int\`."""
 type IntRange {
-  \\"\\"\\"The ending bound of our range.\\"\\"\\"
+  """The ending bound of our range."""
   end: IntRangeBound
 
-  \\"\\"\\"The starting bound of our range.\\"\\"\\"
+  """The starting bound of our range."""
   start: IntRangeBound
 }
 
-\\"\\"\\"
+"""
 The value at one end of a range. A range can either include this value, or not.
-\\"\\"\\"
+"""
 type IntRangeBound {
-  \\"\\"\\"Whether or not the value of this bound is included in the range.\\"\\"\\"
+  """Whether or not the value of this bound is included in the range."""
   inclusive: Boolean!
 
-  \\"\\"\\"The value at one end of our range.\\"\\"\\"
+  """The value at one end of our range."""
   value: Int!
 }
 
-\\"\\"\\"
+"""
 The value at one end of a range. A range can either include this value, or not.
-\\"\\"\\"
+"""
 input IntRangeBoundInput {
-  \\"\\"\\"Whether or not the value of this bound is included in the range.\\"\\"\\"
+  """Whether or not the value of this bound is included in the range."""
   inclusive: Boolean!
 
-  \\"\\"\\"The value at one end of our range.\\"\\"\\"
+  """The value at one end of our range."""
   value: Int!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against IntRange fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input IntRangeFilter {
-  \\"\\"\\"Adjacent to the specified range.\\"\\"\\"
+  """Adjacent to the specified range."""
   adjacentTo: IntRangeInput
 
-  \\"\\"\\"Contained by the specified range.\\"\\"\\"
+  """Contained by the specified range."""
   containedBy: IntRangeInput
 
-  \\"\\"\\"Contains the specified range.\\"\\"\\"
+  """Contains the specified range."""
   contains: IntRangeInput
 
-  \\"\\"\\"Contains the specified value.\\"\\"\\"
+  """Contains the specified value."""
   containsElement: Int
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: IntRangeInput
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: IntRangeInput
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: IntRangeInput
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: IntRangeInput
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [IntRangeInput!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: IntRangeInput
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: IntRangeInput
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: IntRangeInput
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: IntRangeInput
 
-  \\"\\"\\"Does not extend left of the specified range.\\"\\"\\"
+  """Does not extend left of the specified range."""
   notExtendsLeftOf: IntRangeInput
 
-  \\"\\"\\"Does not extend right of the specified range.\\"\\"\\"
+  """Does not extend right of the specified range."""
   notExtendsRightOf: IntRangeInput
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [IntRangeInput!]
 
-  \\"\\"\\"Overlaps the specified range.\\"\\"\\"
+  """Overlaps the specified range."""
   overlaps: IntRangeInput
 
-  \\"\\"\\"Strictly left of the specified range.\\"\\"\\"
+  """Strictly left of the specified range."""
   strictlyLeftOf: IntRangeInput
 
-  \\"\\"\\"Strictly right of the specified range.\\"\\"\\"
+  """Strictly right of the specified range."""
   strictlyRightOf: IntRangeInput
 }
 
-\\"\\"\\"A range of \`Int\`.\\"\\"\\"
+"""A range of \`Int\`."""
 input IntRangeInput {
-  \\"\\"\\"The ending bound of our range.\\"\\"\\"
+  """The ending bound of our range."""
   end: IntRangeBoundInput
 
-  \\"\\"\\"The starting bound of our range.\\"\\"\\"
+  """The starting bound of our range."""
   start: IntRangeBoundInput
 }
 
-\\"\\"\\"
+"""
 A filter to be used against IntRange List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input IntRangeListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: IntRangeInput
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: IntRangeInput
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: IntRangeInput
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: IntRangeInput
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: IntRangeInput
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: IntRangeInput
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [IntRangeInput]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [IntRangeInput]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [IntRangeInput]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [IntRangeInput]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [IntRangeInput]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [IntRangeInput]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [IntRangeInput]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [IntRangeInput]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [IntRangeInput]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [IntRangeInput]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [IntRangeInput]
 }
 
-\\"\\"\\"
+"""
 A JavaScript object encoded in the JSON format as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf).
-\\"\\"\\"
+"""
 scalar JSON
 
 type JsonbTest implements Node {
@@ -4089,62 +4089,62 @@ type JsonbTest implements Node {
   jsonbWithArray: JSON
   jsonbWithObject: JSON
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`JsonbTest\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input JsonbTestFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [JsonbTestFilter!]
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`jsonbWithArray\` field.\\"\\"\\"
+  """Filter by the object’s \`jsonbWithArray\` field."""
   jsonbWithArray: JSONFilter
 
-  \\"\\"\\"Filter by the object’s \`jsonbWithObject\` field.\\"\\"\\"
+  """Filter by the object’s \`jsonbWithObject\` field."""
   jsonbWithObject: JSONFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: JsonbTestFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [JsonbTestFilter!]
 }
 
-\\"\\"\\"A connection to a list of \`JsonbTest\` values.\\"\\"\\"
+"""A connection to a list of \`JsonbTest\` values."""
 type JsonbTestsConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`JsonbTest\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [JsonbTestsEdge!]!
 
-  \\"\\"\\"A list of \`JsonbTest\` objects.\\"\\"\\"
+  """A list of \`JsonbTest\` objects."""
   nodes: [JsonbTest]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`JsonbTest\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`JsonbTest\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`JsonbTest\` edge in the connection.\\"\\"\\"
+"""A \`JsonbTest\` edge in the connection."""
 type JsonbTestsEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`JsonbTest\` at the end of the edge.\\"\\"\\"
+  """The \`JsonbTest\` at the end of the edge."""
   node: JsonbTest
 }
 
-\\"\\"\\"Methods to use when ordering \`JsonbTest\`.\\"\\"\\"
+"""Methods to use when ordering \`JsonbTest\`."""
 enum JsonbTestsOrderBy {
   ID_ASC
   ID_DESC
@@ -4157,194 +4157,194 @@ enum JsonbTestsOrderBy {
   PRIMARY_KEY_DESC
 }
 
-\\"\\"\\"
+"""
 A filter to be used against JSON fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input JSONFilter {
-  \\"\\"\\"Contained by the specified JSON.\\"\\"\\"
+  """Contained by the specified JSON."""
   containedBy: JSON
 
-  \\"\\"\\"Contains the specified JSON.\\"\\"\\"
+  """Contains the specified JSON."""
   contains: JSON
 
-  \\"\\"\\"Contains all of the specified keys.\\"\\"\\"
+  """Contains all of the specified keys."""
   containsAllKeys: [String!]
 
-  \\"\\"\\"Contains any of the specified keys.\\"\\"\\"
+  """Contains any of the specified keys."""
   containsAnyKeys: [String!]
 
-  \\"\\"\\"Contains the specified key.\\"\\"\\"
+  """Contains the specified key."""
   containsKey: String
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: JSON
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: JSON
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: JSON
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: JSON
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [JSON!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: JSON
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: JSON
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: JSON
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: JSON
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [JSON!]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against JSON List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input JSONListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: JSON
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: JSON
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: JSON
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: JSON
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: JSON
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: JSON
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [JSON]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [JSON]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [JSON]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [JSON]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [JSON]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [JSON]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [JSON]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [JSON]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [JSON]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [JSON]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [JSON]
 }
 
 type Junction implements Node {
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 
-  \\"\\"\\"Reads a single \`SideA\` that is related to this \`Junction\`.\\"\\"\\"
+  """Reads a single \`SideA\` that is related to this \`Junction\`."""
   sideABySideAId: SideA
   sideAId: Int!
 
-  \\"\\"\\"Reads a single \`SideB\` that is related to this \`Junction\`.\\"\\"\\"
+  """Reads a single \`SideB\` that is related to this \`Junction\`."""
   sideBBySideBId: SideB
   sideBId: Int!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`Junction\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input JunctionFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [JunctionFilter!]
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: JunctionFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [JunctionFilter!]
 
-  \\"\\"\\"Filter by the object’s \`sideABySideAId\` relation.\\"\\"\\"
+  """Filter by the object’s \`sideABySideAId\` relation."""
   sideABySideAId: SideAFilter
 
-  \\"\\"\\"Filter by the object’s \`sideAId\` field.\\"\\"\\"
+  """Filter by the object’s \`sideAId\` field."""
   sideAId: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`sideBBySideBId\` relation.\\"\\"\\"
+  """Filter by the object’s \`sideBBySideBId\` relation."""
   sideBBySideBId: SideBFilter
 
-  \\"\\"\\"Filter by the object’s \`sideBId\` field.\\"\\"\\"
+  """Filter by the object’s \`sideBId\` field."""
   sideBId: IntFilter
 }
 
-\\"\\"\\"A connection to a list of \`Junction\` values.\\"\\"\\"
+"""A connection to a list of \`Junction\` values."""
 type JunctionsConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`Junction\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [JunctionsEdge!]!
 
-  \\"\\"\\"A list of \`Junction\` objects.\\"\\"\\"
+  """A list of \`Junction\` objects."""
   nodes: [Junction]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`Junction\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`Junction\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`Junction\` edge in the connection.\\"\\"\\"
+"""A \`Junction\` edge in the connection."""
 type JunctionsEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`Junction\` at the end of the edge.\\"\\"\\"
+  """The \`Junction\` at the end of the edge."""
   node: Junction
 }
 
-\\"\\"\\"Methods to use when ordering \`Junction\`.\\"\\"\\"
+"""Methods to use when ordering \`Junction\`."""
 enum JunctionsOrderBy {
   NATURAL
   PRIMARY_KEY_ASC
@@ -4355,116 +4355,116 @@ enum JunctionsOrderBy {
   SIDE_B_ID_DESC
 }
 
-\\"\\"\\"
+"""
 A set of key/value pairs, keys are strings, values may be a string or null. Exposed as a JSON object.
-\\"\\"\\"
+"""
 scalar KeyValueHash
 
-\\"\\"\\"
+"""
 A filter to be used against KeyValueHash fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input KeyValueHashFilter {
-  \\"\\"\\"Contained by the specified KeyValueHash.\\"\\"\\"
+  """Contained by the specified KeyValueHash."""
   containedBy: KeyValueHash
 
-  \\"\\"\\"Contains the specified KeyValueHash.\\"\\"\\"
+  """Contains the specified KeyValueHash."""
   contains: KeyValueHash
 
-  \\"\\"\\"Contains all of the specified keys.\\"\\"\\"
+  """Contains all of the specified keys."""
   containsAllKeys: [String!]
 
-  \\"\\"\\"Contains any of the specified keys.\\"\\"\\"
+  """Contains any of the specified keys."""
   containsAnyKeys: [String!]
 
-  \\"\\"\\"Contains the specified key.\\"\\"\\"
+  """Contains the specified key."""
   containsKey: String
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: KeyValueHash
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: KeyValueHash
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [KeyValueHash!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: KeyValueHash
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: KeyValueHash
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [KeyValueHash!]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against KeyValueHash List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input KeyValueHashListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: KeyValueHash
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: KeyValueHash
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: KeyValueHash
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: KeyValueHash
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: KeyValueHash
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: KeyValueHash
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [KeyValueHash]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [KeyValueHash]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [KeyValueHash]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [KeyValueHash]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [KeyValueHash]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [KeyValueHash]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [KeyValueHash]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [KeyValueHash]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [KeyValueHash]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [KeyValueHash]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [KeyValueHash]
 }
 
@@ -4474,225 +4474,225 @@ enum Mood {
   SAD
 }
 
-\\"\\"\\"
+"""
 A filter to be used against Mood fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input MoodFilter {
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: Mood
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: Mood
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: Mood
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: Mood
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [Mood!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: Mood
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: Mood
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: Mood
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: Mood
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [Mood!]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against Mood List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input MoodListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: Mood
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: Mood
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: Mood
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: Mood
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: Mood
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: Mood
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [Mood]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [Mood]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [Mood]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [Mood]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [Mood]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [Mood]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [Mood]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [Mood]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [Mood]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [Mood]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [Mood]
 }
 
-\\"\\"\\"An object with a globally unique \`ID\`.\\"\\"\\"
+"""An object with a globally unique \`ID\`."""
 interface Node {
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
-\\"\\"\\"Information about pagination in a connection.\\"\\"\\"
+"""Information about pagination in a connection."""
 type PageInfo {
-  \\"\\"\\"When paginating forwards, the cursor to continue.\\"\\"\\"
+  """When paginating forwards, the cursor to continue."""
   endCursor: Cursor
 
-  \\"\\"\\"When paginating forwards, are there more items?\\"\\"\\"
+  """When paginating forwards, are there more items?"""
   hasNextPage: Boolean!
 
-  \\"\\"\\"When paginating backwards, are there more items?\\"\\"\\"
+  """When paginating backwards, are there more items?"""
   hasPreviousPage: Boolean!
 
-  \\"\\"\\"When paginating backwards, the cursor to continue.\\"\\"\\"
+  """When paginating backwards, the cursor to continue."""
   startCursor: Cursor
 }
 
 type Parent implements Node {
-  \\"\\"\\"Reads and enables pagination through a set of \`Filterable\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Filterable\`."""
   filterablesByParentId(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: FilterableFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`Filterable\`.\\"\\"\\"
+    """The method to use when ordering \`Filterable\`."""
     orderBy: [FilterablesOrderBy!] = [PRIMARY_KEY_ASC]
   ): FilterablesConnection!
   id: Int!
   name: String!
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`Parent\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input ParentFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [ParentFilter!]
 
-  \\"\\"\\"Filter by the object’s \`filterablesByParentId\` relation.\\"\\"\\"
+  """Filter by the object’s \`filterablesByParentId\` relation."""
   filterablesByParentId: ParentToManyFilterableFilter
 
-  \\"\\"\\"Some related \`filterablesByParentId\` exist.\\"\\"\\"
+  """Some related \`filterablesByParentId\` exist."""
   filterablesByParentIdExist: Boolean
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`name\` field.\\"\\"\\"
+  """Filter by the object’s \`name\` field."""
   name: StringFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: ParentFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [ParentFilter!]
 }
 
-\\"\\"\\"A connection to a list of \`Parent\` values.\\"\\"\\"
+"""A connection to a list of \`Parent\` values."""
 type ParentsConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`Parent\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [ParentsEdge!]!
 
-  \\"\\"\\"A list of \`Parent\` objects.\\"\\"\\"
+  """A list of \`Parent\` objects."""
   nodes: [Parent]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`Parent\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`Parent\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`Parent\` edge in the connection.\\"\\"\\"
+"""A \`Parent\` edge in the connection."""
 type ParentsEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`Parent\` at the end of the edge.\\"\\"\\"
+  """The \`Parent\` at the end of the edge."""
   node: Parent
 }
 
-\\"\\"\\"Methods to use when ordering \`Parent\`.\\"\\"\\"
+"""Methods to use when ordering \`Parent\`."""
 enum ParentsOrderBy {
   ID_ASC
   ID_DESC
@@ -4703,23 +4703,23 @@ enum ParentsOrderBy {
   PRIMARY_KEY_DESC
 }
 
-\\"\\"\\"
+"""
 A filter to be used against many \`Filterable\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input ParentToManyFilterableFilter {
-  \\"\\"\\"
+  """
   Every related \`Filterable\` matches the filter criteria. All fields are combined with a logical ‘and.’
-  \\"\\"\\"
+  """
   every: FilterableFilter
 
-  \\"\\"\\"
+  """
   No related \`Filterable\` matches the filter criteria. All fields are combined with a logical ‘and.’
-  \\"\\"\\"
+  """
   none: FilterableFilter
 
-  \\"\\"\\"
+  """
   Some related \`Filterable\` matches the filter criteria. All fields are combined with a logical ‘and.’
-  \\"\\"\\"
+  """
   some: FilterableFilter
 }
 
@@ -4727,704 +4727,704 @@ type Protected implements Node {
   id: Int!
   name: String
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
   otherId: Int
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`Protected\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input ProtectedFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [ProtectedFilter!]
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`name\` field.\\"\\"\\"
+  """Filter by the object’s \`name\` field."""
   name: StringFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: ProtectedFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [ProtectedFilter!]
 
-  \\"\\"\\"Filter by the object’s \`otherId\` field.\\"\\"\\"
+  """Filter by the object’s \`otherId\` field."""
   otherId: IntFilter
 }
 
-\\"\\"\\"A connection to a list of \`Protected\` values.\\"\\"\\"
+"""A connection to a list of \`Protected\` values."""
 type ProtectedsConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`Protected\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [ProtectedsEdge!]!
 
-  \\"\\"\\"A list of \`Protected\` objects.\\"\\"\\"
+  """A list of \`Protected\` objects."""
   nodes: [Protected]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`Protected\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`Protected\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`Protected\` edge in the connection.\\"\\"\\"
+"""A \`Protected\` edge in the connection."""
 type ProtectedsEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`Protected\` at the end of the edge.\\"\\"\\"
+  """The \`Protected\` at the end of the edge."""
   node: Protected
 }
 
-\\"\\"\\"The root query type which gives access points into the data universe.\\"\\"\\"
+"""The root query type which gives access points into the data universe."""
 type Query implements Node {
-  \\"\\"\\"Reads and enables pagination through a set of \`ArrayType\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`ArrayType\`."""
   allArrayTypes(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: ArrayTypeFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`ArrayType\`.\\"\\"\\"
+    """The method to use when ordering \`ArrayType\`."""
     orderBy: [ArrayTypesOrderBy!] = [PRIMARY_KEY_ASC]
   ): ArrayTypesConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`BackwardCompound\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`BackwardCompound\`."""
   allBackwardCompounds(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: BackwardCompoundFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`BackwardCompound\`.\\"\\"\\"
+    """The method to use when ordering \`BackwardCompound\`."""
     orderBy: [BackwardCompoundsOrderBy!] = [PRIMARY_KEY_ASC]
   ): BackwardCompoundsConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Backward\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Backward\`."""
   allBackwards(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: BackwardFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`Backward\`.\\"\\"\\"
+    """The method to use when ordering \`Backward\`."""
     orderBy: [BackwardsOrderBy!] = [PRIMARY_KEY_ASC]
   ): BackwardsConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`ChildNoRelatedFilter\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`ChildNoRelatedFilter\`."""
   allChildNoRelatedFilters(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: ChildNoRelatedFilterFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`ChildNoRelatedFilter\`.\\"\\"\\"
+    """The method to use when ordering \`ChildNoRelatedFilter\`."""
     orderBy: [ChildNoRelatedFiltersOrderBy!] = [PRIMARY_KEY_ASC]
   ): ChildNoRelatedFiltersConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Child\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Child\`."""
   allChildren(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: ChildFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`Child\`.\\"\\"\\"
+    """The method to use when ordering \`Child\`."""
     orderBy: [ChildrenOrderBy!] = [PRIMARY_KEY_ASC]
   ): ChildrenConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`DomainType\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`DomainType\`."""
   allDomainTypes(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: DomainTypeFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`DomainType\`.\\"\\"\\"
+    """The method to use when ordering \`DomainType\`."""
     orderBy: [DomainTypesOrderBy!] = [PRIMARY_KEY_ASC]
   ): DomainTypesConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`EnumArrayType\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`EnumArrayType\`."""
   allEnumArrayTypes(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: EnumArrayTypeFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`EnumArrayType\`.\\"\\"\\"
+    """The method to use when ordering \`EnumArrayType\`."""
     orderBy: [EnumArrayTypesOrderBy!] = [PRIMARY_KEY_ASC]
   ): EnumArrayTypesConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`EnumType\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`EnumType\`."""
   allEnumTypes(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: EnumTypeFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`EnumType\`.\\"\\"\\"
+    """The method to use when ordering \`EnumType\`."""
     orderBy: [EnumTypesOrderBy!] = [PRIMARY_KEY_ASC]
   ): EnumTypesConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Filterable\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Filterable\`."""
   allFilterables(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: FilterableFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`Filterable\`.\\"\\"\\"
+    """The method to use when ordering \`Filterable\`."""
     orderBy: [FilterablesOrderBy!] = [PRIMARY_KEY_ASC]
   ): FilterablesConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`ForwardCompound\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`ForwardCompound\`."""
   allForwardCompounds(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: ForwardCompoundFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`ForwardCompound\`.\\"\\"\\"
+    """The method to use when ordering \`ForwardCompound\`."""
     orderBy: [ForwardCompoundsOrderBy!] = [PRIMARY_KEY_ASC]
   ): ForwardCompoundsConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Forward\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Forward\`."""
   allForwards(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: ForwardFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`Forward\`.\\"\\"\\"
+    """The method to use when ordering \`Forward\`."""
     orderBy: [ForwardsOrderBy!] = [PRIMARY_KEY_ASC]
   ): ForwardsConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`FullyOmitted\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`FullyOmitted\`."""
   allFullyOmitteds(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`FullyOmitted\`.\\"\\"\\"
+    """The method to use when ordering \`FullyOmitted\`."""
     orderBy: [FullyOmittedsOrderBy!] = [PRIMARY_KEY_ASC]
   ): FullyOmittedsConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`JsonbTest\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`JsonbTest\`."""
   allJsonbTests(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: JsonbTestFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`JsonbTest\`.\\"\\"\\"
+    """The method to use when ordering \`JsonbTest\`."""
     orderBy: [JsonbTestsOrderBy!] = [PRIMARY_KEY_ASC]
   ): JsonbTestsConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Junction\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Junction\`."""
   allJunctions(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: JunctionFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`Junction\`.\\"\\"\\"
+    """The method to use when ordering \`Junction\`."""
     orderBy: [JunctionsOrderBy!] = [PRIMARY_KEY_ASC]
   ): JunctionsConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Parent\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Parent\`."""
   allParents(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: ParentFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`Parent\`.\\"\\"\\"
+    """The method to use when ordering \`Parent\`."""
     orderBy: [ParentsOrderBy!] = [PRIMARY_KEY_ASC]
   ): ParentsConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`RangeArrayType\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`RangeArrayType\`."""
   allRangeArrayTypes(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: RangeArrayTypeFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`RangeArrayType\`.\\"\\"\\"
+    """The method to use when ordering \`RangeArrayType\`."""
     orderBy: [RangeArrayTypesOrderBy!] = [PRIMARY_KEY_ASC]
   ): RangeArrayTypesConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`RangeType\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`RangeType\`."""
   allRangeTypes(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: RangeTypeFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`RangeType\`.\\"\\"\\"
+    """The method to use when ordering \`RangeType\`."""
     orderBy: [RangeTypesOrderBy!] = [PRIMARY_KEY_ASC]
   ): RangeTypesConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`SideA\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`SideA\`."""
   allSideAs(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: SideAFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`SideA\`.\\"\\"\\"
+    """The method to use when ordering \`SideA\`."""
     orderBy: [SideAsOrderBy!] = [PRIMARY_KEY_ASC]
   ): SideAsConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`SideB\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`SideB\`."""
   allSideBs(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: SideBFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`SideB\`.\\"\\"\\"
+    """The method to use when ordering \`SideB\`."""
     orderBy: [SideBsOrderBy!] = [PRIMARY_KEY_ASC]
   ): SideBsConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Unfilterable\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Unfilterable\`."""
   allUnfilterables(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`Unfilterable\`.\\"\\"\\"
+    """The method to use when ordering \`Unfilterable\`."""
     orderBy: [UnfilterablesOrderBy!] = [PRIMARY_KEY_ASC]
   ): UnfilterablesConnection
 
-  \\"\\"\\"Reads a single \`ArrayType\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`ArrayType\` using its globally unique \`ID\`."""
   arrayType(
-    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`ArrayType\`.\\"\\"\\"
+    """The globally unique \`ID\` to be used in selecting a single \`ArrayType\`."""
     nodeId: ID!
   ): ArrayType
   arrayTypeById(id: Int!): ArrayType
 
-  \\"\\"\\"Reads a single \`Backward\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`Backward\` using its globally unique \`ID\`."""
   backward(
-    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`Backward\`.\\"\\"\\"
+    """The globally unique \`ID\` to be used in selecting a single \`Backward\`."""
     nodeId: ID!
   ): Backward
   backwardByFilterableId(filterableId: Int!): Backward
   backwardById(id: Int!): Backward
 
-  \\"\\"\\"Reads a single \`BackwardCompound\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`BackwardCompound\` using its globally unique \`ID\`."""
   backwardCompound(
-    \\"\\"\\"
+    """
     The globally unique \`ID\` to be used in selecting a single \`BackwardCompound\`.
-    \\"\\"\\"
+    """
     nodeId: ID!
   ): BackwardCompound
   backwardCompoundByBackwardCompound1AndBackwardCompound2(backwardCompound1: Int!, backwardCompound2: Int!): BackwardCompound
 
-  \\"\\"\\"Reads a single \`Child\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`Child\` using its globally unique \`ID\`."""
   child(
-    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`Child\`.\\"\\"\\"
+    """The globally unique \`ID\` to be used in selecting a single \`Child\`."""
     nodeId: ID!
   ): Child
   childById(id: Int!): Child
 
-  \\"\\"\\"Reads a single \`ChildNoRelatedFilter\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`ChildNoRelatedFilter\` using its globally unique \`ID\`."""
   childNoRelatedFilter(
-    \\"\\"\\"
+    """
     The globally unique \`ID\` to be used in selecting a single \`ChildNoRelatedFilter\`.
-    \\"\\"\\"
+    """
     nodeId: ID!
   ): ChildNoRelatedFilter
   childNoRelatedFilterById(id: Int!): ChildNoRelatedFilter
 
-  \\"\\"\\"Reads a single \`DomainType\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`DomainType\` using its globally unique \`ID\`."""
   domainType(
-    \\"\\"\\"
+    """
     The globally unique \`ID\` to be used in selecting a single \`DomainType\`.
-    \\"\\"\\"
+    """
     nodeId: ID!
   ): DomainType
   domainTypeById(id: Int!): DomainType
 
-  \\"\\"\\"Reads a single \`EnumArrayType\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`EnumArrayType\` using its globally unique \`ID\`."""
   enumArrayType(
-    \\"\\"\\"
+    """
     The globally unique \`ID\` to be used in selecting a single \`EnumArrayType\`.
-    \\"\\"\\"
+    """
     nodeId: ID!
   ): EnumArrayType
   enumArrayTypeById(id: Int!): EnumArrayType
 
-  \\"\\"\\"Reads a single \`EnumType\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`EnumType\` using its globally unique \`ID\`."""
   enumType(
-    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`EnumType\`.\\"\\"\\"
+    """The globally unique \`ID\` to be used in selecting a single \`EnumType\`."""
     nodeId: ID!
   ): EnumType
   enumTypeById(id: Int!): EnumType
 
-  \\"\\"\\"Reads a single \`Filterable\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`Filterable\` using its globally unique \`ID\`."""
   filterable(
-    \\"\\"\\"
+    """
     The globally unique \`ID\` to be used in selecting a single \`Filterable\`.
-    \\"\\"\\"
+    """
     nodeId: ID!
   ): Filterable
   filterableByBackwardCompound1AndBackwardCompound2(backwardCompound1: Int!, backwardCompound2: Int!): Filterable
@@ -5432,247 +5432,247 @@ type Query implements Node {
   filterableByForwardId(forwardId: Int!): Filterable
   filterableById(id: Int!): Filterable
 
-  \\"\\"\\"Reads a single \`FilterableClosure\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`FilterableClosure\` using its globally unique \`ID\`."""
   filterableClosure(
-    \\"\\"\\"
+    """
     The globally unique \`ID\` to be used in selecting a single \`FilterableClosure\`.
-    \\"\\"\\"
+    """
     nodeId: ID!
   ): FilterableClosure
   filterableClosureById(id: Int!): FilterableClosure
 
-  \\"\\"\\"Reads a single \`Forward\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`Forward\` using its globally unique \`ID\`."""
   forward(
-    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`Forward\`.\\"\\"\\"
+    """The globally unique \`ID\` to be used in selecting a single \`Forward\`."""
     nodeId: ID!
   ): Forward
   forwardById(id: Int!): Forward
 
-  \\"\\"\\"Reads a single \`ForwardCompound\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`ForwardCompound\` using its globally unique \`ID\`."""
   forwardCompound(
-    \\"\\"\\"
+    """
     The globally unique \`ID\` to be used in selecting a single \`ForwardCompound\`.
-    \\"\\"\\"
+    """
     nodeId: ID!
   ): ForwardCompound
   forwardCompoundByForwardCompound1AndForwardCompound2(forwardCompound1: Int!, forwardCompound2: Int!): ForwardCompound
 
-  \\"\\"\\"Reads a single \`FullyOmitted\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`FullyOmitted\` using its globally unique \`ID\`."""
   fullyOmitted(
-    \\"\\"\\"
+    """
     The globally unique \`ID\` to be used in selecting a single \`FullyOmitted\`.
-    \\"\\"\\"
+    """
     nodeId: ID!
   ): FullyOmitted
   fullyOmittedById(id: Int!): FullyOmitted
   funcReturnsTableMultiCol(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: FuncReturnsTableMultiColRecordFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
     i: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
   ): FuncReturnsTableMultiColConnection!
   funcReturnsTableOneCol(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: IntFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
     i: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
   ): FuncReturnsTableOneColConnection!
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Filterable\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Filterable\`."""
   funcTaggedFilterableReturnsSetofFilterable(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: FilterableFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
   ): FilterablesConnection!
   funcTaggedFilterableReturnsTableMultiCol(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: FuncTaggedFilterableReturnsTableMultiColRecordFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
   ): FuncTaggedFilterableReturnsTableMultiColConnection!
 
-  \\"\\"\\"Reads a single \`JsonbTest\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`JsonbTest\` using its globally unique \`ID\`."""
   jsonbTest(
-    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`JsonbTest\`.\\"\\"\\"
+    """The globally unique \`ID\` to be used in selecting a single \`JsonbTest\`."""
     nodeId: ID!
   ): JsonbTest
   jsonbTestById(id: Int!): JsonbTest
 
-  \\"\\"\\"Reads a single \`Junction\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`Junction\` using its globally unique \`ID\`."""
   junction(
-    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`Junction\`.\\"\\"\\"
+    """The globally unique \`ID\` to be used in selecting a single \`Junction\`."""
     nodeId: ID!
   ): Junction
   junctionBySideAIdAndSideBId(sideAId: Int!, sideBId: Int!): Junction
 
-  \\"\\"\\"Fetches an object given its globally unique \`ID\`.\\"\\"\\"
+  """Fetches an object given its globally unique \`ID\`."""
   node(
-    \\"\\"\\"The globally unique \`ID\`.\\"\\"\\"
+    """The globally unique \`ID\`."""
     nodeId: ID!
   ): Node
 
-  \\"\\"\\"
+  """
   The root query type must be a \`Node\` to work well with Relay 1 mutations. This just resolves to \`query\`.
-  \\"\\"\\"
+  """
   nodeId: ID!
 
-  \\"\\"\\"Reads a single \`Parent\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`Parent\` using its globally unique \`ID\`."""
   parent(
-    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`Parent\`.\\"\\"\\"
+    """The globally unique \`ID\` to be used in selecting a single \`Parent\`."""
     nodeId: ID!
   ): Parent
   parentById(id: Int!): Parent
 
-  \\"\\"\\"Reads a single \`Protected\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`Protected\` using its globally unique \`ID\`."""
   protected(
-    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`Protected\`.\\"\\"\\"
+    """The globally unique \`ID\` to be used in selecting a single \`Protected\`."""
     nodeId: ID!
   ): Protected
   protectedById(id: Int!): Protected
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Protected\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Protected\`."""
   protectedsByOtherId(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: ProtectedFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
     otherId: Int
   ): ProtectedsConnection!
 
-  \\"\\"\\"
+  """
   Exposes the root query type nested one level down. This is helpful for Relay 1
   which can only query top level fields if they are in a particular form.
-  \\"\\"\\"
+  """
   query: Query!
 
-  \\"\\"\\"Reads a single \`RangeArrayType\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`RangeArrayType\` using its globally unique \`ID\`."""
   rangeArrayType(
-    \\"\\"\\"
+    """
     The globally unique \`ID\` to be used in selecting a single \`RangeArrayType\`.
-    \\"\\"\\"
+    """
     nodeId: ID!
   ): RangeArrayType
   rangeArrayTypeById(id: Int!): RangeArrayType
 
-  \\"\\"\\"Reads a single \`RangeType\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`RangeType\` using its globally unique \`ID\`."""
   rangeType(
-    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`RangeType\`.\\"\\"\\"
+    """The globally unique \`ID\` to be used in selecting a single \`RangeType\`."""
     nodeId: ID!
   ): RangeType
   rangeTypeById(id: Int!): RangeType
 
-  \\"\\"\\"Reads a single \`SideA\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`SideA\` using its globally unique \`ID\`."""
   sideA(
-    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`SideA\`.\\"\\"\\"
+    """The globally unique \`ID\` to be used in selecting a single \`SideA\`."""
     nodeId: ID!
   ): SideA
   sideAByAId(aId: Int!): SideA
 
-  \\"\\"\\"Reads a single \`SideB\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`SideB\` using its globally unique \`ID\`."""
   sideB(
-    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`SideB\`.\\"\\"\\"
+    """The globally unique \`ID\` to be used in selecting a single \`SideB\`."""
     nodeId: ID!
   ): SideB
   sideBByBId(bId: Int!): SideB
 
-  \\"\\"\\"Reads a single \`Unfilterable\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`Unfilterable\` using its globally unique \`ID\`."""
   unfilterable(
-    \\"\\"\\"
+    """
     The globally unique \`ID\` to be used in selecting a single \`Unfilterable\`.
-    \\"\\"\\"
+    """
     nodeId: ID!
   ): Unfilterable
   unfilterableById(id: Int!): Unfilterable
@@ -5684,77 +5684,77 @@ type RangeArrayType implements Node {
   int4RangeArray: [IntRange]
   int8RangeArray: [BigIntRange]
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
   numericRangeArray: [BigFloatRange]
   timestampRangeArray: [DatetimeRange]
   timestamptzRangeArray: [DatetimeRange]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`RangeArrayType\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input RangeArrayTypeFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [RangeArrayTypeFilter!]
 
-  \\"\\"\\"Filter by the object’s \`dateRangeArray\` field.\\"\\"\\"
+  """Filter by the object’s \`dateRangeArray\` field."""
   dateRangeArray: DateRangeListFilter
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`int4RangeArray\` field.\\"\\"\\"
+  """Filter by the object’s \`int4RangeArray\` field."""
   int4RangeArray: IntRangeListFilter
 
-  \\"\\"\\"Filter by the object’s \`int8RangeArray\` field.\\"\\"\\"
+  """Filter by the object’s \`int8RangeArray\` field."""
   int8RangeArray: BigIntRangeListFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: RangeArrayTypeFilter
 
-  \\"\\"\\"Filter by the object’s \`numericRangeArray\` field.\\"\\"\\"
+  """Filter by the object’s \`numericRangeArray\` field."""
   numericRangeArray: BigFloatRangeListFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [RangeArrayTypeFilter!]
 
-  \\"\\"\\"Filter by the object’s \`timestampRangeArray\` field.\\"\\"\\"
+  """Filter by the object’s \`timestampRangeArray\` field."""
   timestampRangeArray: DatetimeRangeListFilter
 
-  \\"\\"\\"Filter by the object’s \`timestamptzRangeArray\` field.\\"\\"\\"
+  """Filter by the object’s \`timestamptzRangeArray\` field."""
   timestamptzRangeArray: DatetimeRangeListFilter
 }
 
-\\"\\"\\"A connection to a list of \`RangeArrayType\` values.\\"\\"\\"
+"""A connection to a list of \`RangeArrayType\` values."""
 type RangeArrayTypesConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`RangeArrayType\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [RangeArrayTypesEdge!]!
 
-  \\"\\"\\"A list of \`RangeArrayType\` objects.\\"\\"\\"
+  """A list of \`RangeArrayType\` objects."""
   nodes: [RangeArrayType]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`RangeArrayType\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`RangeArrayType\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`RangeArrayType\` edge in the connection.\\"\\"\\"
+"""A \`RangeArrayType\` edge in the connection."""
 type RangeArrayTypesEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`RangeArrayType\` at the end of the edge.\\"\\"\\"
+  """The \`RangeArrayType\` at the end of the edge."""
   node: RangeArrayType
 }
 
-\\"\\"\\"Methods to use when ordering \`RangeArrayType\`.\\"\\"\\"
+"""Methods to use when ordering \`RangeArrayType\`."""
 enum RangeArrayTypesOrderBy {
   DATE_RANGE_ARRAY_ASC
   DATE_RANGE_ARRAY_DESC
@@ -5781,77 +5781,77 @@ type RangeType implements Node {
   int4Range: IntRange
   int8Range: BigIntRange
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
   numericRange: BigFloatRange
   timestampRange: DatetimeRange
   timestamptzRange: DatetimeRange
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`RangeType\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input RangeTypeFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [RangeTypeFilter!]
 
-  \\"\\"\\"Filter by the object’s \`dateRange\` field.\\"\\"\\"
+  """Filter by the object’s \`dateRange\` field."""
   dateRange: DateRangeFilter
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`int4Range\` field.\\"\\"\\"
+  """Filter by the object’s \`int4Range\` field."""
   int4Range: IntRangeFilter
 
-  \\"\\"\\"Filter by the object’s \`int8Range\` field.\\"\\"\\"
+  """Filter by the object’s \`int8Range\` field."""
   int8Range: BigIntRangeFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: RangeTypeFilter
 
-  \\"\\"\\"Filter by the object’s \`numericRange\` field.\\"\\"\\"
+  """Filter by the object’s \`numericRange\` field."""
   numericRange: BigFloatRangeFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [RangeTypeFilter!]
 
-  \\"\\"\\"Filter by the object’s \`timestampRange\` field.\\"\\"\\"
+  """Filter by the object’s \`timestampRange\` field."""
   timestampRange: DatetimeRangeFilter
 
-  \\"\\"\\"Filter by the object’s \`timestamptzRange\` field.\\"\\"\\"
+  """Filter by the object’s \`timestamptzRange\` field."""
   timestamptzRange: DatetimeRangeFilter
 }
 
-\\"\\"\\"A connection to a list of \`RangeType\` values.\\"\\"\\"
+"""A connection to a list of \`RangeType\` values."""
 type RangeTypesConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`RangeType\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [RangeTypesEdge!]!
 
-  \\"\\"\\"A list of \`RangeType\` objects.\\"\\"\\"
+  """A list of \`RangeType\` objects."""
   nodes: [RangeType]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`RangeType\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`RangeType\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`RangeType\` edge in the connection.\\"\\"\\"
+"""A \`RangeType\` edge in the connection."""
 type RangeTypesEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`RangeType\` at the end of the edge.\\"\\"\\"
+  """The \`RangeType\` at the end of the edge."""
   node: RangeType
 }
 
-\\"\\"\\"Methods to use when ordering \`RangeType\`.\\"\\"\\"
+"""Methods to use when ordering \`RangeType\`."""
 enum RangeTypesOrderBy {
   DATE_RANGE_ASC
   DATE_RANGE_DESC
@@ -5875,95 +5875,95 @@ enum RangeTypesOrderBy {
 type SideA implements Node {
   aId: Int!
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Junction\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Junction\`."""
   junctionsBySideAId(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: JunctionFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`Junction\`.\\"\\"\\"
+    """The method to use when ordering \`Junction\`."""
     orderBy: [JunctionsOrderBy!] = [PRIMARY_KEY_ASC]
   ): JunctionsConnection!
   name: String!
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`SideA\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input SideAFilter {
-  \\"\\"\\"Filter by the object’s \`aId\` field.\\"\\"\\"
+  """Filter by the object’s \`aId\` field."""
   aId: IntFilter
 
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [SideAFilter!]
 
-  \\"\\"\\"Filter by the object’s \`junctionsBySideAId\` relation.\\"\\"\\"
+  """Filter by the object’s \`junctionsBySideAId\` relation."""
   junctionsBySideAId: SideAToManyJunctionFilter
 
-  \\"\\"\\"Some related \`junctionsBySideAId\` exist.\\"\\"\\"
+  """Some related \`junctionsBySideAId\` exist."""
   junctionsBySideAIdExist: Boolean
 
-  \\"\\"\\"Filter by the object’s \`name\` field.\\"\\"\\"
+  """Filter by the object’s \`name\` field."""
   name: StringFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: SideAFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [SideAFilter!]
 }
 
-\\"\\"\\"A connection to a list of \`SideA\` values.\\"\\"\\"
+"""A connection to a list of \`SideA\` values."""
 type SideAsConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`SideA\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [SideAsEdge!]!
 
-  \\"\\"\\"A list of \`SideA\` objects.\\"\\"\\"
+  """A list of \`SideA\` objects."""
   nodes: [SideA]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`SideA\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`SideA\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`SideA\` edge in the connection.\\"\\"\\"
+"""A \`SideA\` edge in the connection."""
 type SideAsEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`SideA\` at the end of the edge.\\"\\"\\"
+  """The \`SideA\` at the end of the edge."""
   node: SideA
 }
 
-\\"\\"\\"Methods to use when ordering \`SideA\`.\\"\\"\\"
+"""Methods to use when ordering \`SideA\`."""
 enum SideAsOrderBy {
   A_ID_ASC
   A_ID_DESC
@@ -5974,118 +5974,118 @@ enum SideAsOrderBy {
   PRIMARY_KEY_DESC
 }
 
-\\"\\"\\"
+"""
 A filter to be used against many \`Junction\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input SideAToManyJunctionFilter {
-  \\"\\"\\"
+  """
   Every related \`Junction\` matches the filter criteria. All fields are combined with a logical ‘and.’
-  \\"\\"\\"
+  """
   every: JunctionFilter
 
-  \\"\\"\\"
+  """
   No related \`Junction\` matches the filter criteria. All fields are combined with a logical ‘and.’
-  \\"\\"\\"
+  """
   none: JunctionFilter
 
-  \\"\\"\\"
+  """
   Some related \`Junction\` matches the filter criteria. All fields are combined with a logical ‘and.’
-  \\"\\"\\"
+  """
   some: JunctionFilter
 }
 
 type SideB implements Node {
   bId: Int!
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Junction\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Junction\`."""
   junctionsBySideBId(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: JunctionFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`Junction\`.\\"\\"\\"
+    """The method to use when ordering \`Junction\`."""
     orderBy: [JunctionsOrderBy!] = [PRIMARY_KEY_ASC]
   ): JunctionsConnection!
   name: String!
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`SideB\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input SideBFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [SideBFilter!]
 
-  \\"\\"\\"Filter by the object’s \`bId\` field.\\"\\"\\"
+  """Filter by the object’s \`bId\` field."""
   bId: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`junctionsBySideBId\` relation.\\"\\"\\"
+  """Filter by the object’s \`junctionsBySideBId\` relation."""
   junctionsBySideBId: SideBToManyJunctionFilter
 
-  \\"\\"\\"Some related \`junctionsBySideBId\` exist.\\"\\"\\"
+  """Some related \`junctionsBySideBId\` exist."""
   junctionsBySideBIdExist: Boolean
 
-  \\"\\"\\"Filter by the object’s \`name\` field.\\"\\"\\"
+  """Filter by the object’s \`name\` field."""
   name: StringFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: SideBFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [SideBFilter!]
 }
 
-\\"\\"\\"A connection to a list of \`SideB\` values.\\"\\"\\"
+"""A connection to a list of \`SideB\` values."""
 type SideBsConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`SideB\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [SideBsEdge!]!
 
-  \\"\\"\\"A list of \`SideB\` objects.\\"\\"\\"
+  """A list of \`SideB\` objects."""
   nodes: [SideB]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`SideB\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`SideB\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`SideB\` edge in the connection.\\"\\"\\"
+"""A \`SideB\` edge in the connection."""
 type SideBsEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`SideB\` at the end of the edge.\\"\\"\\"
+  """The \`SideB\` at the end of the edge."""
   node: SideB
 }
 
-\\"\\"\\"Methods to use when ordering \`SideB\`.\\"\\"\\"
+"""Methods to use when ordering \`SideB\`."""
 enum SideBsOrderBy {
   B_ID_ASC
   B_ID_DESC
@@ -6096,402 +6096,402 @@ enum SideBsOrderBy {
   PRIMARY_KEY_DESC
 }
 
-\\"\\"\\"
+"""
 A filter to be used against many \`Junction\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input SideBToManyJunctionFilter {
-  \\"\\"\\"
+  """
   Every related \`Junction\` matches the filter criteria. All fields are combined with a logical ‘and.’
-  \\"\\"\\"
+  """
   every: JunctionFilter
 
-  \\"\\"\\"
+  """
   No related \`Junction\` matches the filter criteria. All fields are combined with a logical ‘and.’
-  \\"\\"\\"
+  """
   none: JunctionFilter
 
-  \\"\\"\\"
+  """
   Some related \`Junction\` matches the filter criteria. All fields are combined with a logical ‘and.’
-  \\"\\"\\"
+  """
   some: JunctionFilter
 }
 
-\\"\\"\\"
+"""
 A filter to be used against String fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input StringFilter {
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: String
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value (case-insensitive).
-  \\"\\"\\"
+  """
   distinctFromInsensitive: String
 
-  \\"\\"\\"Ends with the specified string (case-sensitive).\\"\\"\\"
+  """Ends with the specified string (case-sensitive)."""
   endsWith: String
 
-  \\"\\"\\"Ends with the specified string (case-insensitive).\\"\\"\\"
+  """Ends with the specified string (case-insensitive)."""
   endsWithInsensitive: String
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: String
 
-  \\"\\"\\"Equal to the specified value (case-insensitive).\\"\\"\\"
+  """Equal to the specified value (case-insensitive)."""
   equalToInsensitive: String
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: String
 
-  \\"\\"\\"Greater than the specified value (case-insensitive).\\"\\"\\"
+  """Greater than the specified value (case-insensitive)."""
   greaterThanInsensitive: String
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: String
 
-  \\"\\"\\"Greater than or equal to the specified value (case-insensitive).\\"\\"\\"
+  """Greater than or equal to the specified value (case-insensitive)."""
   greaterThanOrEqualToInsensitive: String
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [String!]
 
-  \\"\\"\\"Included in the specified list (case-insensitive).\\"\\"\\"
-  inInsensitive: [String!]
-
-  \\"\\"\\"Contains the specified string (case-sensitive).\\"\\"\\"
+  """Contains the specified string (case-sensitive)."""
   includes: String
 
-  \\"\\"\\"Contains the specified string (case-insensitive).\\"\\"\\"
+  """Contains the specified string (case-insensitive)."""
   includesInsensitive: String
 
-  \\"\\"\\"
+  """Included in the specified list (case-insensitive)."""
+  inInsensitive: [String!]
+
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: String
 
-  \\"\\"\\"Less than the specified value (case-insensitive).\\"\\"\\"
+  """Less than the specified value (case-insensitive)."""
   lessThanInsensitive: String
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: String
 
-  \\"\\"\\"Less than or equal to the specified value (case-insensitive).\\"\\"\\"
+  """Less than or equal to the specified value (case-insensitive)."""
   lessThanOrEqualToInsensitive: String
 
-  \\"\\"\\"
+  """
   Matches the specified pattern (case-sensitive). An underscore (_) matches any
   single character; a percent sign (%) matches any sequence of zero or more characters.
-  \\"\\"\\"
+  """
   like: String
 
-  \\"\\"\\"
+  """
   Matches the specified pattern (case-insensitive). An underscore (_) matches
   any single character; a percent sign (%) matches any sequence of zero or more characters.
-  \\"\\"\\"
+  """
   likeInsensitive: String
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: String
 
-  \\"\\"\\"
+  """
   Equal to the specified value, treating null like an ordinary value (case-insensitive).
-  \\"\\"\\"
+  """
   notDistinctFromInsensitive: String
 
-  \\"\\"\\"Does not end with the specified string (case-sensitive).\\"\\"\\"
+  """Does not end with the specified string (case-sensitive)."""
   notEndsWith: String
 
-  \\"\\"\\"Does not end with the specified string (case-insensitive).\\"\\"\\"
+  """Does not end with the specified string (case-insensitive)."""
   notEndsWithInsensitive: String
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: String
 
-  \\"\\"\\"Not equal to the specified value (case-insensitive).\\"\\"\\"
+  """Not equal to the specified value (case-insensitive)."""
   notEqualToInsensitive: String
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [String!]
 
-  \\"\\"\\"Not included in the specified list (case-insensitive).\\"\\"\\"
-  notInInsensitive: [String!]
-
-  \\"\\"\\"Does not contain the specified string (case-sensitive).\\"\\"\\"
+  """Does not contain the specified string (case-sensitive)."""
   notIncludes: String
 
-  \\"\\"\\"Does not contain the specified string (case-insensitive).\\"\\"\\"
+  """Does not contain the specified string (case-insensitive)."""
   notIncludesInsensitive: String
 
-  \\"\\"\\"
+  """Not included in the specified list (case-insensitive)."""
+  notInInsensitive: [String!]
+
+  """
   Does not match the specified pattern (case-sensitive). An underscore (_)
   matches any single character; a percent sign (%) matches any sequence of zero
   or more characters.
-  \\"\\"\\"
+  """
   notLike: String
 
-  \\"\\"\\"
+  """
   Does not match the specified pattern (case-insensitive). An underscore (_)
   matches any single character; a percent sign (%) matches any sequence of zero
   or more characters.
-  \\"\\"\\"
+  """
   notLikeInsensitive: String
 
-  \\"\\"\\"Does not start with the specified string (case-sensitive).\\"\\"\\"
+  """Does not start with the specified string (case-sensitive)."""
   notStartsWith: String
 
-  \\"\\"\\"Does not start with the specified string (case-insensitive).\\"\\"\\"
+  """Does not start with the specified string (case-insensitive)."""
   notStartsWithInsensitive: String
 
-  \\"\\"\\"Starts with the specified string (case-sensitive).\\"\\"\\"
+  """Starts with the specified string (case-sensitive)."""
   startsWith: String
 
-  \\"\\"\\"Starts with the specified string (case-insensitive).\\"\\"\\"
+  """Starts with the specified string (case-insensitive)."""
   startsWithInsensitive: String
 }
 
-\\"\\"\\"
+"""
 A filter to be used against String List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input StringListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: String
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: String
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: String
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: String
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: String
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: String
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [String]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [String]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [String]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [String]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [String]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [String]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [String]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [String]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [String]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [String]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [String]
 }
 
-\\"\\"\\"
+"""
 The exact time of day, does not include the date. May or may not have a timezone offset.
-\\"\\"\\"
+"""
 scalar Time
 
-\\"\\"\\"
+"""
 A filter to be used against Time fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input TimeFilter {
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: Time
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: Time
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: Time
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: Time
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [Time!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: Time
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: Time
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: Time
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: Time
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [Time!]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against Time List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input TimeListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: Time
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: Time
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: Time
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: Time
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: Time
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: Time
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [Time]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [Time]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [Time]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [Time]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [Time]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [Time]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [Time]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [Time]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [Time]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [Time]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [Time]
 }
 
 type Unfilterable implements Node {
-  \\"\\"\\"Reads and enables pagination through a set of \`ChildNoRelatedFilter\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`ChildNoRelatedFilter\`."""
   childNoRelatedFiltersByUnfilterableId(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: ChildNoRelatedFilterFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`ChildNoRelatedFilter\`.\\"\\"\\"
+    """The method to use when ordering \`ChildNoRelatedFilter\`."""
     orderBy: [ChildNoRelatedFiltersOrderBy!] = [PRIMARY_KEY_ASC]
   ): ChildNoRelatedFiltersConnection!
   id: Int!
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
   text: String
 }
 
-\\"\\"\\"A connection to a list of \`Unfilterable\` values.\\"\\"\\"
+"""A connection to a list of \`Unfilterable\` values."""
 type UnfilterablesConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`Unfilterable\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [UnfilterablesEdge!]!
 
-  \\"\\"\\"A list of \`Unfilterable\` objects.\\"\\"\\"
+  """A list of \`Unfilterable\` objects."""
   nodes: [Unfilterable]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`Unfilterable\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`Unfilterable\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`Unfilterable\` edge in the connection.\\"\\"\\"
+"""A \`Unfilterable\` edge in the connection."""
 type UnfilterablesEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`Unfilterable\` at the end of the edge.\\"\\"\\"
+  """The \`Unfilterable\` at the end of the edge."""
   node: Unfilterable
 }
 
-\\"\\"\\"Methods to use when ordering \`Unfilterable\`.\\"\\"\\"
+"""Methods to use when ordering \`Unfilterable\`."""
 enum UnfilterablesOrderBy {
   ID_ASC
   ID_DESC
@@ -6502,114 +6502,114 @@ enum UnfilterablesOrderBy {
   TEXT_DESC
 }
 
-\\"\\"\\"
+"""
 A universally unique identifier as defined by [RFC 4122](https://tools.ietf.org/html/rfc4122).
-\\"\\"\\"
+"""
 scalar UUID
 
-\\"\\"\\"
+"""
 A filter to be used against UUID fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input UUIDFilter {
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: UUID
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: UUID
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: UUID
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: UUID
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [UUID!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: UUID
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: UUID
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: UUID
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: UUID
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [UUID!]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against UUID List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input UUIDListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: UUID
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: UUID
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: UUID
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: UUID
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: UUID
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: UUID
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [UUID]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [UUID]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [UUID]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [UUID]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [UUID]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [UUID]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [UUID]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [UUID]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [UUID]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [UUID]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [UUID]
 }
-"
+
 `;

--- a/__tests__/integration/schema/__snapshots__/relationsWithListInflectors.test.ts.snap
+++ b/__tests__/integration/schema/__snapshots__/relationsWithListInflectors.test.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`prints a schema with the filter plugin, the simplify plugin, and both \`connectionFilterRelations\` and \`connectionFilterUseListInflectors\` set to \`true\` 1`] = `
-"type ArrayType implements Node {
+type ArrayType implements Node {
   bit4Array: [BitString]
   boolArray: [Boolean]
   bpchar4Array: [String]
@@ -25,9 +25,9 @@ exports[`prints a schema with the filter plugin, the simplify plugin, and both \
   moneyArray: [Float]
   nameArray: [String]
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
   numericArray: [BigFloat]
   textArray: [String]
@@ -41,128 +41,128 @@ exports[`prints a schema with the filter plugin, the simplify plugin, and both \
   xmlArray: [String]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`ArrayType\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input ArrayTypeFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [ArrayTypeFilter!]
 
-  \\"\\"\\"Filter by the object’s \`bit4Array\` field.\\"\\"\\"
+  """Filter by the object’s \`bit4Array\` field."""
   bit4Array: BitStringListFilter
 
-  \\"\\"\\"Filter by the object’s \`boolArray\` field.\\"\\"\\"
+  """Filter by the object’s \`boolArray\` field."""
   boolArray: BooleanListFilter
 
-  \\"\\"\\"Filter by the object’s \`bpchar4Array\` field.\\"\\"\\"
+  """Filter by the object’s \`bpchar4Array\` field."""
   bpchar4Array: StringListFilter
 
-  \\"\\"\\"Filter by the object’s \`char4Array\` field.\\"\\"\\"
+  """Filter by the object’s \`char4Array\` field."""
   char4Array: StringListFilter
 
-  \\"\\"\\"Filter by the object’s \`citextArray\` field.\\"\\"\\"
+  """Filter by the object’s \`citextArray\` field."""
   citextArray: StringListFilter
 
-  \\"\\"\\"Filter by the object’s \`dateArray\` field.\\"\\"\\"
+  """Filter by the object’s \`dateArray\` field."""
   dateArray: DateListFilter
 
-  \\"\\"\\"Filter by the object’s \`float4Array\` field.\\"\\"\\"
+  """Filter by the object’s \`float4Array\` field."""
   float4Array: FloatListFilter
 
-  \\"\\"\\"Filter by the object’s \`float8Array\` field.\\"\\"\\"
+  """Filter by the object’s \`float8Array\` field."""
   float8Array: FloatListFilter
 
-  \\"\\"\\"Filter by the object’s \`hstoreArray\` field.\\"\\"\\"
+  """Filter by the object’s \`hstoreArray\` field."""
   hstoreArray: KeyValueHashListFilter
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`inetArray\` field.\\"\\"\\"
+  """Filter by the object’s \`inetArray\` field."""
   inetArray: InternetAddressListFilter
 
-  \\"\\"\\"Filter by the object’s \`int2Array\` field.\\"\\"\\"
+  """Filter by the object’s \`int2Array\` field."""
   int2Array: IntListFilter
 
-  \\"\\"\\"Filter by the object’s \`int4Array\` field.\\"\\"\\"
+  """Filter by the object’s \`int4Array\` field."""
   int4Array: IntListFilter
 
-  \\"\\"\\"Filter by the object’s \`int8Array\` field.\\"\\"\\"
+  """Filter by the object’s \`int8Array\` field."""
   int8Array: BigIntListFilter
 
-  \\"\\"\\"Filter by the object’s \`intervalArray\` field.\\"\\"\\"
+  """Filter by the object’s \`intervalArray\` field."""
   intervalArray: IntervalListFilter
 
-  \\"\\"\\"Filter by the object’s \`jsonbArray\` field.\\"\\"\\"
+  """Filter by the object’s \`jsonbArray\` field."""
   jsonbArray: JSONListFilter
 
-  \\"\\"\\"Filter by the object’s \`moneyArray\` field.\\"\\"\\"
+  """Filter by the object’s \`moneyArray\` field."""
   moneyArray: FloatListFilter
 
-  \\"\\"\\"Filter by the object’s \`nameArray\` field.\\"\\"\\"
+  """Filter by the object’s \`nameArray\` field."""
   nameArray: StringListFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: ArrayTypeFilter
 
-  \\"\\"\\"Filter by the object’s \`numericArray\` field.\\"\\"\\"
+  """Filter by the object’s \`numericArray\` field."""
   numericArray: BigFloatListFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [ArrayTypeFilter!]
 
-  \\"\\"\\"Filter by the object’s \`textArray\` field.\\"\\"\\"
+  """Filter by the object’s \`textArray\` field."""
   textArray: StringListFilter
 
-  \\"\\"\\"Filter by the object’s \`timeArray\` field.\\"\\"\\"
+  """Filter by the object’s \`timeArray\` field."""
   timeArray: TimeListFilter
 
-  \\"\\"\\"Filter by the object’s \`timestampArray\` field.\\"\\"\\"
+  """Filter by the object’s \`timestampArray\` field."""
   timestampArray: DatetimeListFilter
 
-  \\"\\"\\"Filter by the object’s \`timestamptzArray\` field.\\"\\"\\"
+  """Filter by the object’s \`timestamptzArray\` field."""
   timestamptzArray: DatetimeListFilter
 
-  \\"\\"\\"Filter by the object’s \`timetzArray\` field.\\"\\"\\"
+  """Filter by the object’s \`timetzArray\` field."""
   timetzArray: TimeListFilter
 
-  \\"\\"\\"Filter by the object’s \`uuidArray\` field.\\"\\"\\"
+  """Filter by the object’s \`uuidArray\` field."""
   uuidArray: UUIDListFilter
 
-  \\"\\"\\"Filter by the object’s \`varbitArray\` field.\\"\\"\\"
+  """Filter by the object’s \`varbitArray\` field."""
   varbitArray: BitStringListFilter
 
-  \\"\\"\\"Filter by the object’s \`varcharArray\` field.\\"\\"\\"
+  """Filter by the object’s \`varcharArray\` field."""
   varcharArray: StringListFilter
 }
 
-\\"\\"\\"A connection to a list of \`ArrayType\` values.\\"\\"\\"
+"""A connection to a list of \`ArrayType\` values."""
 type ArrayTypesConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`ArrayType\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [ArrayTypesEdge!]!
 
-  \\"\\"\\"A list of \`ArrayType\` objects.\\"\\"\\"
+  """A list of \`ArrayType\` objects."""
   nodes: [ArrayType]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`ArrayType\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`ArrayType\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`ArrayType\` edge in the connection.\\"\\"\\"
+"""A \`ArrayType\` edge in the connection."""
 type ArrayTypesEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`ArrayType\` at the end of the edge.\\"\\"\\"
+  """The \`ArrayType\` at the end of the edge."""
   node: ArrayType
 }
 
-\\"\\"\\"Methods to use when ordering \`ArrayType\`.\\"\\"\\"
+"""Methods to use when ordering \`ArrayType\`."""
 enum ArrayTypesOrderBy {
   BIT4_ARRAY_ASC
   BIT4_ARRAY_DESC
@@ -234,15 +234,15 @@ enum ArrayTypesOrderBy {
 }
 
 type Backward implements Node {
-  \\"\\"\\"Reads a single \`Filterable\` that is related to this \`Backward\`.\\"\\"\\"
+  """Reads a single \`Filterable\` that is related to this \`Backward\`."""
   filterable: Filterable
   filterableId: Int
   id: Int!
   name: String!
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
@@ -250,75 +250,75 @@ type BackwardCompound implements Node {
   backwardCompound1: Int!
   backwardCompound2: Int!
 
-  \\"\\"\\"
+  """
   Reads a single \`Filterable\` that is related to this \`BackwardCompound\`.
-  \\"\\"\\"
+  """
   filterableByBackwardCompound1AndBackwardCompound2: Filterable
   name: String
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`BackwardCompound\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input BackwardCompoundFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [BackwardCompoundFilter!]
 
-  \\"\\"\\"Filter by the object’s \`backwardCompound1\` field.\\"\\"\\"
+  """Filter by the object’s \`backwardCompound1\` field."""
   backwardCompound1: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`backwardCompound2\` field.\\"\\"\\"
+  """Filter by the object’s \`backwardCompound2\` field."""
   backwardCompound2: IntFilter
 
-  \\"\\"\\"
+  """
   Filter by the object’s \`filterableByBackwardCompound1AndBackwardCompound2\` relation.
-  \\"\\"\\"
+  """
   filterableByBackwardCompound1AndBackwardCompound2: FilterableFilter
 
-  \\"\\"\\"Filter by the object’s \`name\` field.\\"\\"\\"
+  """Filter by the object’s \`name\` field."""
   name: StringFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: BackwardCompoundFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [BackwardCompoundFilter!]
 }
 
-\\"\\"\\"A connection to a list of \`BackwardCompound\` values.\\"\\"\\"
+"""A connection to a list of \`BackwardCompound\` values."""
 type BackwardCompoundsConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`BackwardCompound\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [BackwardCompoundsEdge!]!
 
-  \\"\\"\\"A list of \`BackwardCompound\` objects.\\"\\"\\"
+  """A list of \`BackwardCompound\` objects."""
   nodes: [BackwardCompound]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"
+  """
   The count of *all* \`BackwardCompound\` you could get from the connection.
-  \\"\\"\\"
+  """
   totalCount: Int!
 }
 
-\\"\\"\\"A \`BackwardCompound\` edge in the connection.\\"\\"\\"
+"""A \`BackwardCompound\` edge in the connection."""
 type BackwardCompoundsEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`BackwardCompound\` at the end of the edge.\\"\\"\\"
+  """The \`BackwardCompound\` at the end of the edge."""
   node: BackwardCompound
 }
 
-\\"\\"\\"Methods to use when ordering \`BackwardCompound\`.\\"\\"\\"
+"""Methods to use when ordering \`BackwardCompound\`."""
 enum BackwardCompoundsOrderBy {
   BACKWARD_COMPOUND_1_ASC
   BACKWARD_COMPOUND_1_DESC
@@ -331,62 +331,62 @@ enum BackwardCompoundsOrderBy {
   PRIMARY_KEY_DESC
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`Backward\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input BackwardFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [BackwardFilter!]
 
-  \\"\\"\\"Filter by the object’s \`filterable\` relation.\\"\\"\\"
+  """Filter by the object’s \`filterable\` relation."""
   filterable: FilterableFilter
 
-  \\"\\"\\"A related \`filterable\` exists.\\"\\"\\"
+  """A related \`filterable\` exists."""
   filterableExists: Boolean
 
-  \\"\\"\\"Filter by the object’s \`filterableId\` field.\\"\\"\\"
+  """Filter by the object’s \`filterableId\` field."""
   filterableId: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`name\` field.\\"\\"\\"
+  """Filter by the object’s \`name\` field."""
   name: StringFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: BackwardFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [BackwardFilter!]
 }
 
-\\"\\"\\"A connection to a list of \`Backward\` values.\\"\\"\\"
+"""A connection to a list of \`Backward\` values."""
 type BackwardsConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`Backward\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [BackwardsEdge!]!
 
-  \\"\\"\\"A list of \`Backward\` objects.\\"\\"\\"
+  """A list of \`Backward\` objects."""
   nodes: [Backward]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`Backward\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`Backward\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`Backward\` edge in the connection.\\"\\"\\"
+"""A \`Backward\` edge in the connection."""
 type BackwardsEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`Backward\` at the end of the edge.\\"\\"\\"
+  """The \`Backward\` at the end of the edge."""
   node: Backward
 }
 
-\\"\\"\\"Methods to use when ordering \`Backward\`.\\"\\"\\"
+"""Methods to use when ordering \`Backward\`."""
 enum BackwardsOrderBy {
   FILTERABLE_ID_ASC
   FILTERABLE_ID_DESC
@@ -399,1043 +399,1043 @@ enum BackwardsOrderBy {
   PRIMARY_KEY_DESC
 }
 
-\\"\\"\\"
+"""
 A floating point number that requires more precision than IEEE 754 binary 64
-\\"\\"\\"
+"""
 scalar BigFloat
 
-\\"\\"\\"
+"""
 A filter to be used against BigFloat fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input BigFloatFilter {
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: BigFloat
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: BigFloat
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: BigFloat
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: BigFloat
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [BigFloat!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: BigFloat
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: BigFloat
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: BigFloat
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: BigFloat
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [BigFloat!]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against BigFloat List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input BigFloatListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: BigFloat
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: BigFloat
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: BigFloat
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: BigFloat
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: BigFloat
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: BigFloat
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [BigFloat]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [BigFloat]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [BigFloat]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [BigFloat]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [BigFloat]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [BigFloat]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [BigFloat]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [BigFloat]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [BigFloat]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [BigFloat]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [BigFloat]
 }
 
-\\"\\"\\"A range of \`BigFloat\`.\\"\\"\\"
+"""A range of \`BigFloat\`."""
 type BigFloatRange {
-  \\"\\"\\"The ending bound of our range.\\"\\"\\"
+  """The ending bound of our range."""
   end: BigFloatRangeBound
 
-  \\"\\"\\"The starting bound of our range.\\"\\"\\"
+  """The starting bound of our range."""
   start: BigFloatRangeBound
 }
 
-\\"\\"\\"
+"""
 The value at one end of a range. A range can either include this value, or not.
-\\"\\"\\"
+"""
 type BigFloatRangeBound {
-  \\"\\"\\"Whether or not the value of this bound is included in the range.\\"\\"\\"
+  """Whether or not the value of this bound is included in the range."""
   inclusive: Boolean!
 
-  \\"\\"\\"The value at one end of our range.\\"\\"\\"
+  """The value at one end of our range."""
   value: BigFloat!
 }
 
-\\"\\"\\"
+"""
 The value at one end of a range. A range can either include this value, or not.
-\\"\\"\\"
+"""
 input BigFloatRangeBoundInput {
-  \\"\\"\\"Whether or not the value of this bound is included in the range.\\"\\"\\"
+  """Whether or not the value of this bound is included in the range."""
   inclusive: Boolean!
 
-  \\"\\"\\"The value at one end of our range.\\"\\"\\"
+  """The value at one end of our range."""
   value: BigFloat!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against BigFloatRange fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input BigFloatRangeFilter {
-  \\"\\"\\"Adjacent to the specified range.\\"\\"\\"
+  """Adjacent to the specified range."""
   adjacentTo: BigFloatRangeInput
 
-  \\"\\"\\"Contained by the specified range.\\"\\"\\"
+  """Contained by the specified range."""
   containedBy: BigFloatRangeInput
 
-  \\"\\"\\"Contains the specified range.\\"\\"\\"
+  """Contains the specified range."""
   contains: BigFloatRangeInput
 
-  \\"\\"\\"Contains the specified value.\\"\\"\\"
+  """Contains the specified value."""
   containsElement: BigFloat
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: BigFloatRangeInput
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: BigFloatRangeInput
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: BigFloatRangeInput
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: BigFloatRangeInput
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [BigFloatRangeInput!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: BigFloatRangeInput
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: BigFloatRangeInput
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: BigFloatRangeInput
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: BigFloatRangeInput
 
-  \\"\\"\\"Does not extend left of the specified range.\\"\\"\\"
+  """Does not extend left of the specified range."""
   notExtendsLeftOf: BigFloatRangeInput
 
-  \\"\\"\\"Does not extend right of the specified range.\\"\\"\\"
+  """Does not extend right of the specified range."""
   notExtendsRightOf: BigFloatRangeInput
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [BigFloatRangeInput!]
 
-  \\"\\"\\"Overlaps the specified range.\\"\\"\\"
+  """Overlaps the specified range."""
   overlaps: BigFloatRangeInput
 
-  \\"\\"\\"Strictly left of the specified range.\\"\\"\\"
+  """Strictly left of the specified range."""
   strictlyLeftOf: BigFloatRangeInput
 
-  \\"\\"\\"Strictly right of the specified range.\\"\\"\\"
+  """Strictly right of the specified range."""
   strictlyRightOf: BigFloatRangeInput
 }
 
-\\"\\"\\"A range of \`BigFloat\`.\\"\\"\\"
+"""A range of \`BigFloat\`."""
 input BigFloatRangeInput {
-  \\"\\"\\"The ending bound of our range.\\"\\"\\"
+  """The ending bound of our range."""
   end: BigFloatRangeBoundInput
 
-  \\"\\"\\"The starting bound of our range.\\"\\"\\"
+  """The starting bound of our range."""
   start: BigFloatRangeBoundInput
 }
 
-\\"\\"\\"
+"""
 A filter to be used against BigFloatRange List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input BigFloatRangeListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: BigFloatRangeInput
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: BigFloatRangeInput
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: BigFloatRangeInput
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: BigFloatRangeInput
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: BigFloatRangeInput
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: BigFloatRangeInput
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [BigFloatRangeInput]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [BigFloatRangeInput]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [BigFloatRangeInput]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [BigFloatRangeInput]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [BigFloatRangeInput]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [BigFloatRangeInput]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [BigFloatRangeInput]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [BigFloatRangeInput]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [BigFloatRangeInput]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [BigFloatRangeInput]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [BigFloatRangeInput]
 }
 
-\\"\\"\\"
+"""
 A signed eight-byte integer. The upper big integer values are greater than the
 max value for a JavaScript number. Therefore all big integers will be output as
 strings and not numbers.
-\\"\\"\\"
+"""
 scalar BigInt
 
-\\"\\"\\"
+"""
 A filter to be used against BigInt fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input BigIntFilter {
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: BigInt
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: BigInt
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: BigInt
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: BigInt
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [BigInt!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: BigInt
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: BigInt
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: BigInt
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: BigInt
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [BigInt!]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against BigInt List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input BigIntListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: BigInt
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: BigInt
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: BigInt
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: BigInt
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: BigInt
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: BigInt
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [BigInt]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [BigInt]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [BigInt]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [BigInt]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [BigInt]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [BigInt]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [BigInt]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [BigInt]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [BigInt]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [BigInt]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [BigInt]
 }
 
-\\"\\"\\"A range of \`BigInt\`.\\"\\"\\"
+"""A range of \`BigInt\`."""
 type BigIntRange {
-  \\"\\"\\"The ending bound of our range.\\"\\"\\"
+  """The ending bound of our range."""
   end: BigIntRangeBound
 
-  \\"\\"\\"The starting bound of our range.\\"\\"\\"
+  """The starting bound of our range."""
   start: BigIntRangeBound
 }
 
-\\"\\"\\"
+"""
 The value at one end of a range. A range can either include this value, or not.
-\\"\\"\\"
+"""
 type BigIntRangeBound {
-  \\"\\"\\"Whether or not the value of this bound is included in the range.\\"\\"\\"
+  """Whether or not the value of this bound is included in the range."""
   inclusive: Boolean!
 
-  \\"\\"\\"The value at one end of our range.\\"\\"\\"
+  """The value at one end of our range."""
   value: BigInt!
 }
 
-\\"\\"\\"
+"""
 The value at one end of a range. A range can either include this value, or not.
-\\"\\"\\"
+"""
 input BigIntRangeBoundInput {
-  \\"\\"\\"Whether or not the value of this bound is included in the range.\\"\\"\\"
+  """Whether or not the value of this bound is included in the range."""
   inclusive: Boolean!
 
-  \\"\\"\\"The value at one end of our range.\\"\\"\\"
+  """The value at one end of our range."""
   value: BigInt!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against BigIntRange fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input BigIntRangeFilter {
-  \\"\\"\\"Adjacent to the specified range.\\"\\"\\"
+  """Adjacent to the specified range."""
   adjacentTo: BigIntRangeInput
 
-  \\"\\"\\"Contained by the specified range.\\"\\"\\"
+  """Contained by the specified range."""
   containedBy: BigIntRangeInput
 
-  \\"\\"\\"Contains the specified range.\\"\\"\\"
+  """Contains the specified range."""
   contains: BigIntRangeInput
 
-  \\"\\"\\"Contains the specified value.\\"\\"\\"
+  """Contains the specified value."""
   containsElement: BigInt
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: BigIntRangeInput
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: BigIntRangeInput
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: BigIntRangeInput
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: BigIntRangeInput
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [BigIntRangeInput!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: BigIntRangeInput
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: BigIntRangeInput
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: BigIntRangeInput
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: BigIntRangeInput
 
-  \\"\\"\\"Does not extend left of the specified range.\\"\\"\\"
+  """Does not extend left of the specified range."""
   notExtendsLeftOf: BigIntRangeInput
 
-  \\"\\"\\"Does not extend right of the specified range.\\"\\"\\"
+  """Does not extend right of the specified range."""
   notExtendsRightOf: BigIntRangeInput
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [BigIntRangeInput!]
 
-  \\"\\"\\"Overlaps the specified range.\\"\\"\\"
+  """Overlaps the specified range."""
   overlaps: BigIntRangeInput
 
-  \\"\\"\\"Strictly left of the specified range.\\"\\"\\"
+  """Strictly left of the specified range."""
   strictlyLeftOf: BigIntRangeInput
 
-  \\"\\"\\"Strictly right of the specified range.\\"\\"\\"
+  """Strictly right of the specified range."""
   strictlyRightOf: BigIntRangeInput
 }
 
-\\"\\"\\"A range of \`BigInt\`.\\"\\"\\"
+"""A range of \`BigInt\`."""
 input BigIntRangeInput {
-  \\"\\"\\"The ending bound of our range.\\"\\"\\"
+  """The ending bound of our range."""
   end: BigIntRangeBoundInput
 
-  \\"\\"\\"The starting bound of our range.\\"\\"\\"
+  """The starting bound of our range."""
   start: BigIntRangeBoundInput
 }
 
-\\"\\"\\"
+"""
 A filter to be used against BigIntRange List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input BigIntRangeListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: BigIntRangeInput
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: BigIntRangeInput
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: BigIntRangeInput
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: BigIntRangeInput
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: BigIntRangeInput
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: BigIntRangeInput
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [BigIntRangeInput]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [BigIntRangeInput]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [BigIntRangeInput]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [BigIntRangeInput]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [BigIntRangeInput]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [BigIntRangeInput]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [BigIntRangeInput]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [BigIntRangeInput]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [BigIntRangeInput]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [BigIntRangeInput]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [BigIntRangeInput]
 }
 
-\\"\\"\\"A string representing a series of binary bits\\"\\"\\"
+"""A string representing a series of binary bits"""
 scalar BitString
 
-\\"\\"\\"
+"""
 A filter to be used against BitString fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input BitStringFilter {
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: BitString
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: BitString
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: BitString
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: BitString
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [BitString!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: BitString
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: BitString
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: BitString
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: BitString
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [BitString!]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against BitString List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input BitStringListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: BitString
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: BitString
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: BitString
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: BitString
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: BitString
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: BitString
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [BitString]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [BitString]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [BitString]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [BitString]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [BitString]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [BitString]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [BitString]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [BitString]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [BitString]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [BitString]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [BitString]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against Boolean fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input BooleanFilter {
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: Boolean
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: Boolean
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: Boolean
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: Boolean
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [Boolean!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: Boolean
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: Boolean
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: Boolean
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: Boolean
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [Boolean!]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against Boolean List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input BooleanListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: Boolean
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: Boolean
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: Boolean
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: Boolean
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: Boolean
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: Boolean
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [Boolean]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [Boolean]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [Boolean]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [Boolean]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [Boolean]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [Boolean]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [Boolean]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [Boolean]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [Boolean]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [Boolean]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [Boolean]
 }
 
 scalar Char4Domain
 
-\\"\\"\\"
+"""
 A filter to be used against Char4Domain fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input Char4DomainFilter {
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: Char4Domain
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value (case-insensitive).
-  \\"\\"\\"
+  """
   distinctFromInsensitive: Char4Domain
 
-  \\"\\"\\"Ends with the specified string (case-sensitive).\\"\\"\\"
+  """Ends with the specified string (case-sensitive)."""
   endsWith: Char4Domain
 
-  \\"\\"\\"Ends with the specified string (case-insensitive).\\"\\"\\"
+  """Ends with the specified string (case-insensitive)."""
   endsWithInsensitive: Char4Domain
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: Char4Domain
 
-  \\"\\"\\"Equal to the specified value (case-insensitive).\\"\\"\\"
+  """Equal to the specified value (case-insensitive)."""
   equalToInsensitive: Char4Domain
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: Char4Domain
 
-  \\"\\"\\"Greater than the specified value (case-insensitive).\\"\\"\\"
+  """Greater than the specified value (case-insensitive)."""
   greaterThanInsensitive: Char4Domain
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: Char4Domain
 
-  \\"\\"\\"Greater than or equal to the specified value (case-insensitive).\\"\\"\\"
+  """Greater than or equal to the specified value (case-insensitive)."""
   greaterThanOrEqualToInsensitive: Char4Domain
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [Char4Domain!]
 
-  \\"\\"\\"Included in the specified list (case-insensitive).\\"\\"\\"
-  inInsensitive: [Char4Domain!]
-
-  \\"\\"\\"Contains the specified string (case-sensitive).\\"\\"\\"
+  """Contains the specified string (case-sensitive)."""
   includes: Char4Domain
 
-  \\"\\"\\"Contains the specified string (case-insensitive).\\"\\"\\"
+  """Contains the specified string (case-insensitive)."""
   includesInsensitive: Char4Domain
 
-  \\"\\"\\"
+  """Included in the specified list (case-insensitive)."""
+  inInsensitive: [Char4Domain!]
+
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: Char4Domain
 
-  \\"\\"\\"Less than the specified value (case-insensitive).\\"\\"\\"
+  """Less than the specified value (case-insensitive)."""
   lessThanInsensitive: Char4Domain
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: Char4Domain
 
-  \\"\\"\\"Less than or equal to the specified value (case-insensitive).\\"\\"\\"
+  """Less than or equal to the specified value (case-insensitive)."""
   lessThanOrEqualToInsensitive: Char4Domain
 
-  \\"\\"\\"
+  """
   Matches the specified pattern (case-sensitive). An underscore (_) matches any
   single character; a percent sign (%) matches any sequence of zero or more characters.
-  \\"\\"\\"
+  """
   like: Char4Domain
 
-  \\"\\"\\"
+  """
   Matches the specified pattern (case-insensitive). An underscore (_) matches
   any single character; a percent sign (%) matches any sequence of zero or more characters.
-  \\"\\"\\"
+  """
   likeInsensitive: Char4Domain
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: Char4Domain
 
-  \\"\\"\\"
+  """
   Equal to the specified value, treating null like an ordinary value (case-insensitive).
-  \\"\\"\\"
+  """
   notDistinctFromInsensitive: Char4Domain
 
-  \\"\\"\\"Does not end with the specified string (case-sensitive).\\"\\"\\"
+  """Does not end with the specified string (case-sensitive)."""
   notEndsWith: Char4Domain
 
-  \\"\\"\\"Does not end with the specified string (case-insensitive).\\"\\"\\"
+  """Does not end with the specified string (case-insensitive)."""
   notEndsWithInsensitive: Char4Domain
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: Char4Domain
 
-  \\"\\"\\"Not equal to the specified value (case-insensitive).\\"\\"\\"
+  """Not equal to the specified value (case-insensitive)."""
   notEqualToInsensitive: Char4Domain
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [Char4Domain!]
 
-  \\"\\"\\"Not included in the specified list (case-insensitive).\\"\\"\\"
-  notInInsensitive: [Char4Domain!]
-
-  \\"\\"\\"Does not contain the specified string (case-sensitive).\\"\\"\\"
+  """Does not contain the specified string (case-sensitive)."""
   notIncludes: Char4Domain
 
-  \\"\\"\\"Does not contain the specified string (case-insensitive).\\"\\"\\"
+  """Does not contain the specified string (case-insensitive)."""
   notIncludesInsensitive: Char4Domain
 
-  \\"\\"\\"
+  """Not included in the specified list (case-insensitive)."""
+  notInInsensitive: [Char4Domain!]
+
+  """
   Does not match the specified pattern (case-sensitive). An underscore (_)
   matches any single character; a percent sign (%) matches any sequence of zero
   or more characters.
-  \\"\\"\\"
+  """
   notLike: Char4Domain
 
-  \\"\\"\\"
+  """
   Does not match the specified pattern (case-insensitive). An underscore (_)
   matches any single character; a percent sign (%) matches any sequence of zero
   or more characters.
-  \\"\\"\\"
+  """
   notLikeInsensitive: Char4Domain
 
-  \\"\\"\\"Does not start with the specified string (case-sensitive).\\"\\"\\"
+  """Does not start with the specified string (case-sensitive)."""
   notStartsWith: Char4Domain
 
-  \\"\\"\\"Does not start with the specified string (case-insensitive).\\"\\"\\"
+  """Does not start with the specified string (case-insensitive)."""
   notStartsWithInsensitive: Char4Domain
 
-  \\"\\"\\"Starts with the specified string (case-sensitive).\\"\\"\\"
+  """Starts with the specified string (case-sensitive)."""
   startsWith: Char4Domain
 
-  \\"\\"\\"Starts with the specified string (case-insensitive).\\"\\"\\"
+  """Starts with the specified string (case-insensitive)."""
   startsWithInsensitive: Char4Domain
 }
 
 type Child implements Node {
-  \\"\\"\\"Reads a single \`Filterable\` that is related to this \`Child\`.\\"\\"\\"
+  """Reads a single \`Filterable\` that is related to this \`Child\`."""
   filterable: Filterable
   filterableId: Int
   id: Int!
   name: String!
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`Child\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input ChildFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [ChildFilter!]
 
-  \\"\\"\\"Filter by the object’s \`filterable\` relation.\\"\\"\\"
+  """Filter by the object’s \`filterable\` relation."""
   filterable: FilterableFilter
 
-  \\"\\"\\"A related \`filterable\` exists.\\"\\"\\"
+  """A related \`filterable\` exists."""
   filterableExists: Boolean
 
-  \\"\\"\\"Filter by the object’s \`filterableId\` field.\\"\\"\\"
+  """Filter by the object’s \`filterableId\` field."""
   filterableId: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`name\` field.\\"\\"\\"
+  """Filter by the object’s \`name\` field."""
   name: StringFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: ChildFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [ChildFilter!]
 }
 
 type ChildNoRelatedFilter implements Node {
-  \\"\\"\\"
+  """
   Reads a single \`Filterable\` that is related to this \`ChildNoRelatedFilter\`.
-  \\"\\"\\"
+  """
   filterable: Filterable
   filterableId: Int
   id: Int!
   name: String!
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 
-  \\"\\"\\"
+  """
   Reads a single \`Unfilterable\` that is related to this \`ChildNoRelatedFilter\`.
-  \\"\\"\\"
+  """
   unfilterable: Unfilterable
   unfilterableId: Int
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`ChildNoRelatedFilter\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input ChildNoRelatedFilterFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [ChildNoRelatedFilterFilter!]
 
-  \\"\\"\\"Filter by the object’s \`filterableId\` field.\\"\\"\\"
+  """Filter by the object’s \`filterableId\` field."""
   filterableId: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`name\` field.\\"\\"\\"
+  """Filter by the object’s \`name\` field."""
   name: StringFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: ChildNoRelatedFilterFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [ChildNoRelatedFilterFilter!]
 
-  \\"\\"\\"Filter by the object’s \`unfilterableId\` field.\\"\\"\\"
+  """Filter by the object’s \`unfilterableId\` field."""
   unfilterableId: IntFilter
 }
 
-\\"\\"\\"A connection to a list of \`ChildNoRelatedFilter\` values.\\"\\"\\"
+"""A connection to a list of \`ChildNoRelatedFilter\` values."""
 type ChildNoRelatedFiltersConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`ChildNoRelatedFilter\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [ChildNoRelatedFiltersEdge!]!
 
-  \\"\\"\\"A list of \`ChildNoRelatedFilter\` objects.\\"\\"\\"
+  """A list of \`ChildNoRelatedFilter\` objects."""
   nodes: [ChildNoRelatedFilter]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"
+  """
   The count of *all* \`ChildNoRelatedFilter\` you could get from the connection.
-  \\"\\"\\"
+  """
   totalCount: Int!
 }
 
-\\"\\"\\"A \`ChildNoRelatedFilter\` edge in the connection.\\"\\"\\"
+"""A \`ChildNoRelatedFilter\` edge in the connection."""
 type ChildNoRelatedFiltersEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`ChildNoRelatedFilter\` at the end of the edge.\\"\\"\\"
+  """The \`ChildNoRelatedFilter\` at the end of the edge."""
   node: ChildNoRelatedFilter
 }
 
-\\"\\"\\"Methods to use when ordering \`ChildNoRelatedFilter\`.\\"\\"\\"
+"""Methods to use when ordering \`ChildNoRelatedFilter\`."""
 enum ChildNoRelatedFiltersOrderBy {
   FILTERABLE_ID_ASC
   FILTERABLE_ID_DESC
@@ -1450,33 +1450,33 @@ enum ChildNoRelatedFiltersOrderBy {
   UNFILTERABLE_ID_DESC
 }
 
-\\"\\"\\"A connection to a list of \`Child\` values.\\"\\"\\"
+"""A connection to a list of \`Child\` values."""
 type ChildrenConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`Child\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [ChildrenEdge!]!
 
-  \\"\\"\\"A list of \`Child\` objects.\\"\\"\\"
+  """A list of \`Child\` objects."""
   nodes: [Child]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`Child\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`Child\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`Child\` edge in the connection.\\"\\"\\"
+"""A \`Child\` edge in the connection."""
 type ChildrenEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`Child\` at the end of the edge.\\"\\"\\"
+  """The \`Child\` at the end of the edge."""
   node: Child
 }
 
-\\"\\"\\"Methods to use when ordering \`Child\`.\\"\\"\\"
+"""Methods to use when ordering \`Child\`."""
 enum ChildrenOrderBy {
   FILTERABLE_ID_ASC
   FILTERABLE_ID_DESC
@@ -1494,633 +1494,633 @@ type Composite {
   b: String
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`Composite\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input CompositeFilter {
-  \\"\\"\\"Filter by the object’s \`a\` field.\\"\\"\\"
+  """Filter by the object’s \`a\` field."""
   a: IntFilter
 
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [CompositeFilter!]
 
-  \\"\\"\\"Filter by the object’s \`b\` field.\\"\\"\\"
+  """Filter by the object’s \`b\` field."""
   b: StringFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: CompositeFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [CompositeFilter!]
 }
 
-\\"\\"\\"A location in a connection that can be used for resuming pagination.\\"\\"\\"
+"""A location in a connection that can be used for resuming pagination."""
 scalar Cursor
 
-\\"\\"\\"The day, does not include a time.\\"\\"\\"
+"""The day, does not include a time."""
 scalar Date
 
 scalar DateDomain
 
-\\"\\"\\"
+"""
 A filter to be used against DateDomain fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input DateDomainFilter {
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: DateDomain
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: DateDomain
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: DateDomain
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: DateDomain
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [DateDomain!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: DateDomain
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: DateDomain
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: DateDomain
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: DateDomain
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [DateDomain!]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against Date fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input DateFilter {
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: Date
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: Date
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: Date
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: Date
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [Date!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: Date
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: Date
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: Date
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: Date
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [Date!]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against Date List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input DateListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: Date
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: Date
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: Date
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: Date
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: Date
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: Date
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [Date]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [Date]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [Date]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [Date]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [Date]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [Date]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [Date]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [Date]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [Date]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [Date]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [Date]
 }
 
-\\"\\"\\"A range of \`Date\`.\\"\\"\\"
+"""A range of \`Date\`."""
 type DateRange {
-  \\"\\"\\"The ending bound of our range.\\"\\"\\"
+  """The ending bound of our range."""
   end: DateRangeBound
 
-  \\"\\"\\"The starting bound of our range.\\"\\"\\"
+  """The starting bound of our range."""
   start: DateRangeBound
 }
 
-\\"\\"\\"
+"""
 The value at one end of a range. A range can either include this value, or not.
-\\"\\"\\"
+"""
 type DateRangeBound {
-  \\"\\"\\"Whether or not the value of this bound is included in the range.\\"\\"\\"
+  """Whether or not the value of this bound is included in the range."""
   inclusive: Boolean!
 
-  \\"\\"\\"The value at one end of our range.\\"\\"\\"
+  """The value at one end of our range."""
   value: Date!
 }
 
-\\"\\"\\"
+"""
 The value at one end of a range. A range can either include this value, or not.
-\\"\\"\\"
+"""
 input DateRangeBoundInput {
-  \\"\\"\\"Whether or not the value of this bound is included in the range.\\"\\"\\"
+  """Whether or not the value of this bound is included in the range."""
   inclusive: Boolean!
 
-  \\"\\"\\"The value at one end of our range.\\"\\"\\"
+  """The value at one end of our range."""
   value: Date!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against DateRange fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input DateRangeFilter {
-  \\"\\"\\"Adjacent to the specified range.\\"\\"\\"
+  """Adjacent to the specified range."""
   adjacentTo: DateRangeInput
 
-  \\"\\"\\"Contained by the specified range.\\"\\"\\"
+  """Contained by the specified range."""
   containedBy: DateRangeInput
 
-  \\"\\"\\"Contains the specified range.\\"\\"\\"
+  """Contains the specified range."""
   contains: DateRangeInput
 
-  \\"\\"\\"Contains the specified value.\\"\\"\\"
+  """Contains the specified value."""
   containsElement: Date
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: DateRangeInput
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: DateRangeInput
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: DateRangeInput
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: DateRangeInput
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [DateRangeInput!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: DateRangeInput
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: DateRangeInput
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: DateRangeInput
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: DateRangeInput
 
-  \\"\\"\\"Does not extend left of the specified range.\\"\\"\\"
+  """Does not extend left of the specified range."""
   notExtendsLeftOf: DateRangeInput
 
-  \\"\\"\\"Does not extend right of the specified range.\\"\\"\\"
+  """Does not extend right of the specified range."""
   notExtendsRightOf: DateRangeInput
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [DateRangeInput!]
 
-  \\"\\"\\"Overlaps the specified range.\\"\\"\\"
+  """Overlaps the specified range."""
   overlaps: DateRangeInput
 
-  \\"\\"\\"Strictly left of the specified range.\\"\\"\\"
+  """Strictly left of the specified range."""
   strictlyLeftOf: DateRangeInput
 
-  \\"\\"\\"Strictly right of the specified range.\\"\\"\\"
+  """Strictly right of the specified range."""
   strictlyRightOf: DateRangeInput
 }
 
-\\"\\"\\"A range of \`Date\`.\\"\\"\\"
+"""A range of \`Date\`."""
 input DateRangeInput {
-  \\"\\"\\"The ending bound of our range.\\"\\"\\"
+  """The ending bound of our range."""
   end: DateRangeBoundInput
 
-  \\"\\"\\"The starting bound of our range.\\"\\"\\"
+  """The starting bound of our range."""
   start: DateRangeBoundInput
 }
 
-\\"\\"\\"
+"""
 A filter to be used against DateRange List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input DateRangeListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: DateRangeInput
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: DateRangeInput
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: DateRangeInput
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: DateRangeInput
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: DateRangeInput
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: DateRangeInput
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [DateRangeInput]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [DateRangeInput]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [DateRangeInput]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [DateRangeInput]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [DateRangeInput]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [DateRangeInput]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [DateRangeInput]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [DateRangeInput]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [DateRangeInput]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [DateRangeInput]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [DateRangeInput]
 }
 
-\\"\\"\\"
+"""
 A point in time as described by the [ISO
 8601](https://en.wikipedia.org/wiki/ISO_8601) standard. May or may not include a timezone.
-\\"\\"\\"
+"""
 scalar Datetime
 
-\\"\\"\\"
+"""
 A filter to be used against Datetime fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input DatetimeFilter {
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: Datetime
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: Datetime
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: Datetime
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: Datetime
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [Datetime!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: Datetime
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: Datetime
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: Datetime
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: Datetime
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [Datetime!]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against Datetime List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input DatetimeListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: Datetime
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: Datetime
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: Datetime
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: Datetime
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: Datetime
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: Datetime
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [Datetime]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [Datetime]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [Datetime]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [Datetime]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [Datetime]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [Datetime]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [Datetime]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [Datetime]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [Datetime]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [Datetime]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [Datetime]
 }
 
-\\"\\"\\"A range of \`Datetime\`.\\"\\"\\"
+"""A range of \`Datetime\`."""
 type DatetimeRange {
-  \\"\\"\\"The ending bound of our range.\\"\\"\\"
+  """The ending bound of our range."""
   end: DatetimeRangeBound
 
-  \\"\\"\\"The starting bound of our range.\\"\\"\\"
+  """The starting bound of our range."""
   start: DatetimeRangeBound
 }
 
-\\"\\"\\"
+"""
 The value at one end of a range. A range can either include this value, or not.
-\\"\\"\\"
+"""
 type DatetimeRangeBound {
-  \\"\\"\\"Whether or not the value of this bound is included in the range.\\"\\"\\"
+  """Whether or not the value of this bound is included in the range."""
   inclusive: Boolean!
 
-  \\"\\"\\"The value at one end of our range.\\"\\"\\"
+  """The value at one end of our range."""
   value: Datetime!
 }
 
-\\"\\"\\"
+"""
 The value at one end of a range. A range can either include this value, or not.
-\\"\\"\\"
+"""
 input DatetimeRangeBoundInput {
-  \\"\\"\\"Whether or not the value of this bound is included in the range.\\"\\"\\"
+  """Whether or not the value of this bound is included in the range."""
   inclusive: Boolean!
 
-  \\"\\"\\"The value at one end of our range.\\"\\"\\"
+  """The value at one end of our range."""
   value: Datetime!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against DatetimeRange fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input DatetimeRangeFilter {
-  \\"\\"\\"Adjacent to the specified range.\\"\\"\\"
+  """Adjacent to the specified range."""
   adjacentTo: DatetimeRangeInput
 
-  \\"\\"\\"Contained by the specified range.\\"\\"\\"
+  """Contained by the specified range."""
   containedBy: DatetimeRangeInput
 
-  \\"\\"\\"Contains the specified range.\\"\\"\\"
+  """Contains the specified range."""
   contains: DatetimeRangeInput
 
-  \\"\\"\\"Contains the specified value.\\"\\"\\"
+  """Contains the specified value."""
   containsElement: Datetime
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: DatetimeRangeInput
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: DatetimeRangeInput
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: DatetimeRangeInput
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: DatetimeRangeInput
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [DatetimeRangeInput!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: DatetimeRangeInput
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: DatetimeRangeInput
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: DatetimeRangeInput
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: DatetimeRangeInput
 
-  \\"\\"\\"Does not extend left of the specified range.\\"\\"\\"
+  """Does not extend left of the specified range."""
   notExtendsLeftOf: DatetimeRangeInput
 
-  \\"\\"\\"Does not extend right of the specified range.\\"\\"\\"
+  """Does not extend right of the specified range."""
   notExtendsRightOf: DatetimeRangeInput
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [DatetimeRangeInput!]
 
-  \\"\\"\\"Overlaps the specified range.\\"\\"\\"
+  """Overlaps the specified range."""
   overlaps: DatetimeRangeInput
 
-  \\"\\"\\"Strictly left of the specified range.\\"\\"\\"
+  """Strictly left of the specified range."""
   strictlyLeftOf: DatetimeRangeInput
 
-  \\"\\"\\"Strictly right of the specified range.\\"\\"\\"
+  """Strictly right of the specified range."""
   strictlyRightOf: DatetimeRangeInput
 }
 
-\\"\\"\\"A range of \`Datetime\`.\\"\\"\\"
+"""A range of \`Datetime\`."""
 input DatetimeRangeInput {
-  \\"\\"\\"The ending bound of our range.\\"\\"\\"
+  """The ending bound of our range."""
   end: DatetimeRangeBoundInput
 
-  \\"\\"\\"The starting bound of our range.\\"\\"\\"
+  """The starting bound of our range."""
   start: DatetimeRangeBoundInput
 }
 
-\\"\\"\\"
+"""
 A filter to be used against DatetimeRange List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input DatetimeRangeListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: DatetimeRangeInput
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: DatetimeRangeInput
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: DatetimeRangeInput
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: DatetimeRangeInput
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: DatetimeRangeInput
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: DatetimeRangeInput
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [DatetimeRangeInput]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [DatetimeRangeInput]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [DatetimeRangeInput]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [DatetimeRangeInput]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [DatetimeRangeInput]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [DatetimeRangeInput]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [DatetimeRangeInput]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [DatetimeRangeInput]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [DatetimeRangeInput]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [DatetimeRangeInput]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [DatetimeRangeInput]
 }
 
@@ -2130,65 +2130,65 @@ type DomainType implements Node {
   id: Int!
   int4Domain: Int4Domain
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`DomainType\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input DomainTypeFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [DomainTypeFilter!]
 
-  \\"\\"\\"Filter by the object’s \`char4Domain\` field.\\"\\"\\"
+  """Filter by the object’s \`char4Domain\` field."""
   char4Domain: Char4DomainFilter
 
-  \\"\\"\\"Filter by the object’s \`dateDomain\` field.\\"\\"\\"
+  """Filter by the object’s \`dateDomain\` field."""
   dateDomain: DateDomainFilter
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`int4Domain\` field.\\"\\"\\"
+  """Filter by the object’s \`int4Domain\` field."""
   int4Domain: Int4DomainFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: DomainTypeFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [DomainTypeFilter!]
 }
 
-\\"\\"\\"A connection to a list of \`DomainType\` values.\\"\\"\\"
+"""A connection to a list of \`DomainType\` values."""
 type DomainTypesConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`DomainType\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [DomainTypesEdge!]!
 
-  \\"\\"\\"A list of \`DomainType\` objects.\\"\\"\\"
+  """A list of \`DomainType\` objects."""
   nodes: [DomainType]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`DomainType\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`DomainType\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`DomainType\` edge in the connection.\\"\\"\\"
+"""A \`DomainType\` edge in the connection."""
 type DomainTypesEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`DomainType\` at the end of the edge.\\"\\"\\"
+  """The \`DomainType\` at the end of the edge."""
   node: DomainType
 }
 
-\\"\\"\\"Methods to use when ordering \`DomainType\`.\\"\\"\\"
+"""Methods to use when ordering \`DomainType\`."""
 enum DomainTypesOrderBy {
   CHAR4_DOMAIN_ASC
   CHAR4_DOMAIN_DESC
@@ -2207,59 +2207,59 @@ type EnumArrayType implements Node {
   enumArray: [Mood]
   id: Int!
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`EnumArrayType\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input EnumArrayTypeFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [EnumArrayTypeFilter!]
 
-  \\"\\"\\"Filter by the object’s \`enumArray\` field.\\"\\"\\"
+  """Filter by the object’s \`enumArray\` field."""
   enumArray: MoodListFilter
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: EnumArrayTypeFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [EnumArrayTypeFilter!]
 }
 
-\\"\\"\\"A connection to a list of \`EnumArrayType\` values.\\"\\"\\"
+"""A connection to a list of \`EnumArrayType\` values."""
 type EnumArrayTypesConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`EnumArrayType\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [EnumArrayTypesEdge!]!
 
-  \\"\\"\\"A list of \`EnumArrayType\` objects.\\"\\"\\"
+  """A list of \`EnumArrayType\` objects."""
   nodes: [EnumArrayType]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`EnumArrayType\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`EnumArrayType\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`EnumArrayType\` edge in the connection.\\"\\"\\"
+"""A \`EnumArrayType\` edge in the connection."""
 type EnumArrayTypesEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`EnumArrayType\` at the end of the edge.\\"\\"\\"
+  """The \`EnumArrayType\` at the end of the edge."""
   node: EnumArrayType
 }
 
-\\"\\"\\"Methods to use when ordering \`EnumArrayType\`.\\"\\"\\"
+"""Methods to use when ordering \`EnumArrayType\`."""
 enum EnumArrayTypesOrderBy {
   ENUM_ARRAY_ASC
   ENUM_ARRAY_DESC
@@ -2274,59 +2274,59 @@ type EnumType implements Node {
   enum: Mood
   id: Int!
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`EnumType\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input EnumTypeFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [EnumTypeFilter!]
 
-  \\"\\"\\"Filter by the object’s \`enum\` field.\\"\\"\\"
+  """Filter by the object’s \`enum\` field."""
   enum: MoodFilter
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: EnumTypeFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [EnumTypeFilter!]
 }
 
-\\"\\"\\"A connection to a list of \`EnumType\` values.\\"\\"\\"
+"""A connection to a list of \`EnumType\` values."""
 type EnumTypesConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`EnumType\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [EnumTypesEdge!]!
 
-  \\"\\"\\"A list of \`EnumType\` objects.\\"\\"\\"
+  """A list of \`EnumType\` objects."""
   nodes: [EnumType]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`EnumType\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`EnumType\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`EnumType\` edge in the connection.\\"\\"\\"
+"""A \`EnumType\` edge in the connection."""
 type EnumTypesEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`EnumType\` at the end of the edge.\\"\\"\\"
+  """The \`EnumType\` at the end of the edge."""
   node: EnumType
 }
 
-\\"\\"\\"Methods to use when ordering \`EnumType\`.\\"\\"\\"
+"""Methods to use when ordering \`EnumType\`."""
 enum EnumTypesOrderBy {
   ENUM_ASC
   ENUM_DESC
@@ -2338,14 +2338,14 @@ enum EnumTypesOrderBy {
 }
 
 type Filterable implements Node {
-  \\"\\"\\"Reads a single \`Backward\` that is related to this \`Filterable\`.\\"\\"\\"
+  """Reads a single \`Backward\` that is related to this \`Filterable\`."""
   backward: Backward
   backwardCompound1: Int
   backwardCompound2: Int
 
-  \\"\\"\\"
+  """
   Reads a single \`BackwardCompound\` that is related to this \`Filterable\`.
-  \\"\\"\\"
+  """
   backwardCompoundByBackwardCompound1AndBackwardCompound2: BackwardCompound
   bit4: BitString
   bool: Boolean
@@ -2353,95 +2353,95 @@ type Filterable implements Node {
   bytea: String
   char4: String
 
-  \\"\\"\\"Reads and enables pagination through a set of \`ChildNoRelatedFilter\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`ChildNoRelatedFilter\`."""
   childNoRelatedFilters(
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: ChildNoRelatedFilterFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Skip the first \`n\` values.\\"\\"\\"
+    """Skip the first \`n\` values."""
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`ChildNoRelatedFilter\`.\\"\\"\\"
+    """The method to use when ordering \`ChildNoRelatedFilter\`."""
     orderBy: [ChildNoRelatedFiltersOrderBy!]
   ): [ChildNoRelatedFilter!]!
 
-  \\"\\"\\"Reads and enables pagination through a set of \`ChildNoRelatedFilter\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`ChildNoRelatedFilter\`."""
   childNoRelatedFiltersConnection(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: ChildNoRelatedFilterFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`ChildNoRelatedFilter\`.\\"\\"\\"
+    """The method to use when ordering \`ChildNoRelatedFilter\`."""
     orderBy: [ChildNoRelatedFiltersOrderBy!] = [PRIMARY_KEY_ASC]
   ): ChildNoRelatedFiltersConnection!
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Child\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Child\`."""
   children(
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: ChildFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Skip the first \`n\` values.\\"\\"\\"
+    """Skip the first \`n\` values."""
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`Child\`.\\"\\"\\"
+    """The method to use when ordering \`Child\`."""
     orderBy: [ChildrenOrderBy!]
   ): [Child!]!
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Child\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Child\`."""
   childrenConnection(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: ChildFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`Child\`.\\"\\"\\"
+    """The method to use when ordering \`Child\`."""
     orderBy: [ChildrenOrderBy!] = [PRIMARY_KEY_ASC]
   ): ChildrenConnection!
   cidr: String
@@ -2452,186 +2452,186 @@ type Filterable implements Node {
   computedChild: Child
   computedIntArray: [Int]
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Child\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Child\`."""
   computedSetofChild(
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: ChildFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Skip the first \`n\` values.\\"\\"\\"
+    """Skip the first \`n\` values."""
     offset: Int
   ): [Child]
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Child\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Child\`."""
   computedSetofChildConnection(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: ChildFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
   ): ChildrenConnection!
   computedSetofInt(
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: IntFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Skip the first \`n\` values.\\"\\"\\"
+    """Skip the first \`n\` values."""
     offset: Int
   ): [Int]
   computedSetofIntConnection(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: IntFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
   ): FilterableComputedSetofIntConnection!
   computedTaggedFilterable: Int
   computedWithRequiredArg(i: Int!): Int
   date: Date
 
-  \\"\\"\\"Reads and enables pagination through a set of \`FilterableClosure\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`FilterableClosure\`."""
   filterableClosuresByAncestorId(
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: FilterableClosureFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Skip the first \`n\` values.\\"\\"\\"
+    """Skip the first \`n\` values."""
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`FilterableClosure\`.\\"\\"\\"
+    """The method to use when ordering \`FilterableClosure\`."""
     orderBy: [FilterableClosuresOrderBy!]
   ): [FilterableClosure!]!
 
-  \\"\\"\\"Reads and enables pagination through a set of \`FilterableClosure\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`FilterableClosure\`."""
   filterableClosuresByAncestorIdConnection(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: FilterableClosureFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`FilterableClosure\`.\\"\\"\\"
+    """The method to use when ordering \`FilterableClosure\`."""
     orderBy: [FilterableClosuresOrderBy!] = [PRIMARY_KEY_ASC]
   ): FilterableClosuresConnection!
 
-  \\"\\"\\"Reads and enables pagination through a set of \`FilterableClosure\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`FilterableClosure\`."""
   filterableClosuresByDescendantId(
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: FilterableClosureFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Skip the first \`n\` values.\\"\\"\\"
+    """Skip the first \`n\` values."""
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`FilterableClosure\`.\\"\\"\\"
+    """The method to use when ordering \`FilterableClosure\`."""
     orderBy: [FilterableClosuresOrderBy!]
   ): [FilterableClosure!]!
 
-  \\"\\"\\"Reads and enables pagination through a set of \`FilterableClosure\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`FilterableClosure\`."""
   filterableClosuresByDescendantIdConnection(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: FilterableClosureFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`FilterableClosure\`.\\"\\"\\"
+    """The method to use when ordering \`FilterableClosure\`."""
     orderBy: [FilterableClosuresOrderBy!] = [PRIMARY_KEY_ASC]
   ): FilterableClosuresConnection!
   float4: Float
   float8: Float
 
-  \\"\\"\\"Reads a single \`Forward\` that is related to this \`Filterable\`.\\"\\"\\"
+  """Reads a single \`Forward\` that is related to this \`Filterable\`."""
   forward: Forward
   forwardColumn: Forward
   forwardCompound1: Int
   forwardCompound2: Int
 
-  \\"\\"\\"Reads a single \`ForwardCompound\` that is related to this \`Filterable\`.\\"\\"\\"
+  """Reads a single \`ForwardCompound\` that is related to this \`Filterable\`."""
   forwardCompoundByForwardCompound1AndForwardCompound2: ForwardCompound
   forwardId: Int
   hstore: KeyValueHash
@@ -2647,13 +2647,13 @@ type Filterable implements Node {
   money: Float
   name: String
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
   numeric: BigFloat
 
-  \\"\\"\\"Reads a single \`Parent\` that is related to this \`Filterable\`.\\"\\"\\"
+  """Reads a single \`Parent\` that is related to this \`Filterable\`."""
   parent: Parent
   parentId: Int
   text: String
@@ -2669,87 +2669,87 @@ type Filterable implements Node {
 }
 
 type FilterableClosure implements Node {
-  \\"\\"\\"
+  """
   Reads a single \`Filterable\` that is related to this \`FilterableClosure\`.
-  \\"\\"\\"
+  """
   ancestor: Filterable
   ancestorId: Int!
   depth: Int!
 
-  \\"\\"\\"
+  """
   Reads a single \`Filterable\` that is related to this \`FilterableClosure\`.
-  \\"\\"\\"
+  """
   descendant: Filterable
   descendantId: Int!
   id: Int!
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`FilterableClosure\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input FilterableClosureFilter {
-  \\"\\"\\"Filter by the object’s \`ancestor\` relation.\\"\\"\\"
+  """Filter by the object’s \`ancestor\` relation."""
   ancestor: FilterableFilter
 
-  \\"\\"\\"Filter by the object’s \`ancestorId\` field.\\"\\"\\"
+  """Filter by the object’s \`ancestorId\` field."""
   ancestorId: IntFilter
 
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [FilterableClosureFilter!]
 
-  \\"\\"\\"Filter by the object’s \`depth\` field.\\"\\"\\"
+  """Filter by the object’s \`depth\` field."""
   depth: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`descendant\` relation.\\"\\"\\"
+  """Filter by the object’s \`descendant\` relation."""
   descendant: FilterableFilter
 
-  \\"\\"\\"Filter by the object’s \`descendantId\` field.\\"\\"\\"
+  """Filter by the object’s \`descendantId\` field."""
   descendantId: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: FilterableClosureFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [FilterableClosureFilter!]
 }
 
-\\"\\"\\"A connection to a list of \`FilterableClosure\` values.\\"\\"\\"
+"""A connection to a list of \`FilterableClosure\` values."""
 type FilterableClosuresConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`FilterableClosure\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [FilterableClosuresEdge!]!
 
-  \\"\\"\\"A list of \`FilterableClosure\` objects.\\"\\"\\"
+  """A list of \`FilterableClosure\` objects."""
   nodes: [FilterableClosure]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"
+  """
   The count of *all* \`FilterableClosure\` you could get from the connection.
-  \\"\\"\\"
+  """
   totalCount: Int!
 }
 
-\\"\\"\\"A \`FilterableClosure\` edge in the connection.\\"\\"\\"
+"""A \`FilterableClosure\` edge in the connection."""
 type FilterableClosuresEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`FilterableClosure\` at the end of the edge.\\"\\"\\"
+  """The \`FilterableClosure\` at the end of the edge."""
   node: FilterableClosure
 }
 
-\\"\\"\\"Methods to use when ordering \`FilterableClosure\`.\\"\\"\\"
+"""Methods to use when ordering \`FilterableClosure\`."""
 enum FilterableClosuresOrderBy {
   ANCESTOR_ID_ASC
   ANCESTOR_ID_DESC
@@ -2764,237 +2764,237 @@ enum FilterableClosuresOrderBy {
   PRIMARY_KEY_DESC
 }
 
-\\"\\"\\"A connection to a list of \`Int\` values.\\"\\"\\"
+"""A connection to a list of \`Int\` values."""
 type FilterableComputedSetofIntConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`Int\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [FilterableComputedSetofIntEdge!]!
 
-  \\"\\"\\"A list of \`Int\` objects.\\"\\"\\"
+  """A list of \`Int\` objects."""
   nodes: [Int]!
 
-  \\"\\"\\"The count of *all* \`Int\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`Int\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`Int\` edge in the connection.\\"\\"\\"
+"""A \`Int\` edge in the connection."""
 type FilterableComputedSetofIntEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`Int\` at the end of the edge.\\"\\"\\"
+  """The \`Int\` at the end of the edge."""
   node: Int
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`Filterable\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input FilterableFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [FilterableFilter!]
 
-  \\"\\"\\"Filter by the object’s \`backward\` relation.\\"\\"\\"
+  """Filter by the object’s \`backward\` relation."""
   backward: BackwardFilter
 
-  \\"\\"\\"Filter by the object’s \`backwardCompound1\` field.\\"\\"\\"
+  """Filter by the object’s \`backwardCompound1\` field."""
   backwardCompound1: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`backwardCompound2\` field.\\"\\"\\"
+  """Filter by the object’s \`backwardCompound2\` field."""
   backwardCompound2: IntFilter
 
-  \\"\\"\\"
+  """
   Filter by the object’s \`backwardCompoundByBackwardCompound1AndBackwardCompound2\` relation.
-  \\"\\"\\"
+  """
   backwardCompoundByBackwardCompound1AndBackwardCompound2: BackwardCompoundFilter
 
-  \\"\\"\\"
+  """
   A related \`backwardCompoundByBackwardCompound1AndBackwardCompound2\` exists.
-  \\"\\"\\"
+  """
   backwardCompoundByBackwardCompound1AndBackwardCompound2Exists: Boolean
 
-  \\"\\"\\"A related \`backward\` exists.\\"\\"\\"
+  """A related \`backward\` exists."""
   backwardExists: Boolean
 
-  \\"\\"\\"Filter by the object’s \`bit4\` field.\\"\\"\\"
+  """Filter by the object’s \`bit4\` field."""
   bit4: BitStringFilter
 
-  \\"\\"\\"Filter by the object’s \`bool\` field.\\"\\"\\"
+  """Filter by the object’s \`bool\` field."""
   bool: BooleanFilter
 
-  \\"\\"\\"Filter by the object’s \`bpchar4\` field.\\"\\"\\"
+  """Filter by the object’s \`bpchar4\` field."""
   bpchar4: StringFilter
 
-  \\"\\"\\"Filter by the object’s \`char4\` field.\\"\\"\\"
+  """Filter by the object’s \`char4\` field."""
   char4: StringFilter
 
-  \\"\\"\\"Filter by the object’s \`children\` relation.\\"\\"\\"
+  """Filter by the object’s \`children\` relation."""
   children: FilterableToManyChildFilter
 
-  \\"\\"\\"Some related \`children\` exist.\\"\\"\\"
+  """Some related \`children\` exist."""
   childrenExist: Boolean
 
-  \\"\\"\\"Filter by the object’s \`citext\` field.\\"\\"\\"
+  """Filter by the object’s \`citext\` field."""
   citext: StringFilter
 
-  \\"\\"\\"Filter by the object’s \`compositeColumn\` field.\\"\\"\\"
+  """Filter by the object’s \`compositeColumn\` field."""
   compositeColumn: CompositeFilter
 
-  \\"\\"\\"Filter by the object’s \`computed\` field.\\"\\"\\"
+  """Filter by the object’s \`computed\` field."""
   computed: StringFilter
 
-  \\"\\"\\"Filter by the object’s \`computedIntArray\` field.\\"\\"\\"
+  """Filter by the object’s \`computedIntArray\` field."""
   computedIntArray: IntListFilter
 
-  \\"\\"\\"Filter by the object’s \`computedTaggedFilterable\` field.\\"\\"\\"
+  """Filter by the object’s \`computedTaggedFilterable\` field."""
   computedTaggedFilterable: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`date\` field.\\"\\"\\"
+  """Filter by the object’s \`date\` field."""
   date: DateFilter
 
-  \\"\\"\\"Filter by the object’s \`filterableClosuresByAncestorId\` relation.\\"\\"\\"
+  """Filter by the object’s \`filterableClosuresByAncestorId\` relation."""
   filterableClosuresByAncestorId: FilterableToManyFilterableClosureFilter
 
-  \\"\\"\\"Some related \`filterableClosuresByAncestorId\` exist.\\"\\"\\"
+  """Some related \`filterableClosuresByAncestorId\` exist."""
   filterableClosuresByAncestorIdExist: Boolean
 
-  \\"\\"\\"Filter by the object’s \`filterableClosuresByDescendantId\` relation.\\"\\"\\"
+  """Filter by the object’s \`filterableClosuresByDescendantId\` relation."""
   filterableClosuresByDescendantId: FilterableToManyFilterableClosureFilter
 
-  \\"\\"\\"Some related \`filterableClosuresByDescendantId\` exist.\\"\\"\\"
+  """Some related \`filterableClosuresByDescendantId\` exist."""
   filterableClosuresByDescendantIdExist: Boolean
 
-  \\"\\"\\"Filter by the object’s \`float4\` field.\\"\\"\\"
+  """Filter by the object’s \`float4\` field."""
   float4: FloatFilter
 
-  \\"\\"\\"Filter by the object’s \`float8\` field.\\"\\"\\"
+  """Filter by the object’s \`float8\` field."""
   float8: FloatFilter
 
-  \\"\\"\\"Filter by the object’s \`forward\` relation.\\"\\"\\"
+  """Filter by the object’s \`forward\` relation."""
   forward: ForwardFilter
 
-  \\"\\"\\"Filter by the object’s \`forwardCompound1\` field.\\"\\"\\"
+  """Filter by the object’s \`forwardCompound1\` field."""
   forwardCompound1: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`forwardCompound2\` field.\\"\\"\\"
+  """Filter by the object’s \`forwardCompound2\` field."""
   forwardCompound2: IntFilter
 
-  \\"\\"\\"
+  """
   Filter by the object’s \`forwardCompoundByForwardCompound1AndForwardCompound2\` relation.
-  \\"\\"\\"
+  """
   forwardCompoundByForwardCompound1AndForwardCompound2: ForwardCompoundFilter
 
-  \\"\\"\\"
+  """
   A related \`forwardCompoundByForwardCompound1AndForwardCompound2\` exists.
-  \\"\\"\\"
+  """
   forwardCompoundByForwardCompound1AndForwardCompound2Exists: Boolean
 
-  \\"\\"\\"A related \`forward\` exists.\\"\\"\\"
+  """A related \`forward\` exists."""
   forwardExists: Boolean
 
-  \\"\\"\\"Filter by the object’s \`forwardId\` field.\\"\\"\\"
+  """Filter by the object’s \`forwardId\` field."""
   forwardId: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`hstore\` field.\\"\\"\\"
+  """Filter by the object’s \`hstore\` field."""
   hstore: KeyValueHashFilter
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`inet\` field.\\"\\"\\"
+  """Filter by the object’s \`inet\` field."""
   inet: InternetAddressFilter
 
-  \\"\\"\\"Filter by the object’s \`int2\` field.\\"\\"\\"
+  """Filter by the object’s \`int2\` field."""
   int2: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`int4\` field.\\"\\"\\"
+  """Filter by the object’s \`int4\` field."""
   int4: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`int8\` field.\\"\\"\\"
+  """Filter by the object’s \`int8\` field."""
   int8: BigIntFilter
 
-  \\"\\"\\"Filter by the object’s \`interval\` field.\\"\\"\\"
+  """Filter by the object’s \`interval\` field."""
   interval: IntervalFilter
 
-  \\"\\"\\"Filter by the object’s \`jsonb\` field.\\"\\"\\"
+  """Filter by the object’s \`jsonb\` field."""
   jsonb: JSONFilter
 
-  \\"\\"\\"Filter by the object’s \`money\` field.\\"\\"\\"
+  """Filter by the object’s \`money\` field."""
   money: FloatFilter
 
-  \\"\\"\\"Filter by the object’s \`name\` field.\\"\\"\\"
+  """Filter by the object’s \`name\` field."""
   name: StringFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: FilterableFilter
 
-  \\"\\"\\"Filter by the object’s \`numeric\` field.\\"\\"\\"
+  """Filter by the object’s \`numeric\` field."""
   numeric: BigFloatFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [FilterableFilter!]
 
-  \\"\\"\\"Filter by the object’s \`parent\` relation.\\"\\"\\"
+  """Filter by the object’s \`parent\` relation."""
   parent: ParentFilter
 
-  \\"\\"\\"A related \`parent\` exists.\\"\\"\\"
+  """A related \`parent\` exists."""
   parentExists: Boolean
 
-  \\"\\"\\"Filter by the object’s \`parentId\` field.\\"\\"\\"
+  """Filter by the object’s \`parentId\` field."""
   parentId: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`text\` field.\\"\\"\\"
+  """Filter by the object’s \`text\` field."""
   text: StringFilter
 
-  \\"\\"\\"Filter by the object’s \`time\` field.\\"\\"\\"
+  """Filter by the object’s \`time\` field."""
   time: TimeFilter
 
-  \\"\\"\\"Filter by the object’s \`timestamp\` field.\\"\\"\\"
+  """Filter by the object’s \`timestamp\` field."""
   timestamp: DatetimeFilter
 
-  \\"\\"\\"Filter by the object’s \`timestamptz\` field.\\"\\"\\"
+  """Filter by the object’s \`timestamptz\` field."""
   timestamptz: DatetimeFilter
 
-  \\"\\"\\"Filter by the object’s \`timetz\` field.\\"\\"\\"
+  """Filter by the object’s \`timetz\` field."""
   timetz: TimeFilter
 
-  \\"\\"\\"Filter by the object’s \`uuid\` field.\\"\\"\\"
+  """Filter by the object’s \`uuid\` field."""
   uuid: UUIDFilter
 
-  \\"\\"\\"Filter by the object’s \`varbit\` field.\\"\\"\\"
+  """Filter by the object’s \`varbit\` field."""
   varbit: BitStringFilter
 
-  \\"\\"\\"Filter by the object’s \`varchar\` field.\\"\\"\\"
+  """Filter by the object’s \`varchar\` field."""
   varchar: StringFilter
 }
 
-\\"\\"\\"A connection to a list of \`Filterable\` values.\\"\\"\\"
+"""A connection to a list of \`Filterable\` values."""
 type FilterablesConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`Filterable\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [FilterablesEdge!]!
 
-  \\"\\"\\"A list of \`Filterable\` objects.\\"\\"\\"
+  """A list of \`Filterable\` objects."""
   nodes: [Filterable]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`Filterable\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`Filterable\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`Filterable\` edge in the connection.\\"\\"\\"
+"""A \`Filterable\` edge in the connection."""
 type FilterablesEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`Filterable\` at the end of the edge.\\"\\"\\"
+  """The \`Filterable\` at the end of the edge."""
   node: Filterable
 }
 
-\\"\\"\\"Methods to use when ordering \`Filterable\`.\\"\\"\\"
+"""Methods to use when ordering \`Filterable\`."""
 enum FilterablesOrderBy {
   BACKWARD_COMPOUND_1_ASC
   BACKWARD_COMPOUND_1_DESC
@@ -3083,236 +3083,236 @@ enum FilterablesOrderBy {
   XML_DESC
 }
 
-\\"\\"\\"
+"""
 A filter to be used against many \`Child\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input FilterableToManyChildFilter {
-  \\"\\"\\"
+  """
   Every related \`Child\` matches the filter criteria. All fields are combined with a logical ‘and.’
-  \\"\\"\\"
+  """
   every: ChildFilter
 
-  \\"\\"\\"
+  """
   No related \`Child\` matches the filter criteria. All fields are combined with a logical ‘and.’
-  \\"\\"\\"
+  """
   none: ChildFilter
 
-  \\"\\"\\"
+  """
   Some related \`Child\` matches the filter criteria. All fields are combined with a logical ‘and.’
-  \\"\\"\\"
+  """
   some: ChildFilter
 }
 
-\\"\\"\\"
+"""
 A filter to be used against many \`FilterableClosure\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input FilterableToManyFilterableClosureFilter {
-  \\"\\"\\"
+  """
   Every related \`FilterableClosure\` matches the filter criteria. All fields are combined with a logical ‘and.’
-  \\"\\"\\"
+  """
   every: FilterableClosureFilter
 
-  \\"\\"\\"
+  """
   No related \`FilterableClosure\` matches the filter criteria. All fields are combined with a logical ‘and.’
-  \\"\\"\\"
+  """
   none: FilterableClosureFilter
 
-  \\"\\"\\"
+  """
   Some related \`FilterableClosure\` matches the filter criteria. All fields are combined with a logical ‘and.’
-  \\"\\"\\"
+  """
   some: FilterableClosureFilter
 }
 
-\\"\\"\\"
+"""
 A filter to be used against Float fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input FloatFilter {
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: Float
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: Float
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: Float
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: Float
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [Float!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: Float
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: Float
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: Float
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: Float
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [Float!]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against Float List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input FloatListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: Float
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: Float
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: Float
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: Float
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: Float
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: Float
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [Float]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [Float]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [Float]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [Float]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [Float]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [Float]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [Float]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [Float]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [Float]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [Float]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [Float]
 }
 
 type Forward implements Node {
-  \\"\\"\\"Reads a single \`Filterable\` that is related to this \`Forward\`.\\"\\"\\"
+  """Reads a single \`Filterable\` that is related to this \`Forward\`."""
   filterable: Filterable
   id: Int!
   name: String!
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
 type ForwardCompound implements Node {
-  \\"\\"\\"Reads a single \`Filterable\` that is related to this \`ForwardCompound\`.\\"\\"\\"
+  """Reads a single \`Filterable\` that is related to this \`ForwardCompound\`."""
   filterableByForwardCompound1AndForwardCompound2: Filterable
   forwardCompound1: Int!
   forwardCompound2: Int!
   name: String
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`ForwardCompound\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input ForwardCompoundFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [ForwardCompoundFilter!]
 
-  \\"\\"\\"
+  """
   Filter by the object’s \`filterableByForwardCompound1AndForwardCompound2\` relation.
-  \\"\\"\\"
+  """
   filterableByForwardCompound1AndForwardCompound2: FilterableFilter
 
-  \\"\\"\\"A related \`filterableByForwardCompound1AndForwardCompound2\` exists.\\"\\"\\"
+  """A related \`filterableByForwardCompound1AndForwardCompound2\` exists."""
   filterableByForwardCompound1AndForwardCompound2Exists: Boolean
 
-  \\"\\"\\"Filter by the object’s \`forwardCompound1\` field.\\"\\"\\"
+  """Filter by the object’s \`forwardCompound1\` field."""
   forwardCompound1: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`forwardCompound2\` field.\\"\\"\\"
+  """Filter by the object’s \`forwardCompound2\` field."""
   forwardCompound2: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`name\` field.\\"\\"\\"
+  """Filter by the object’s \`name\` field."""
   name: StringFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: ForwardCompoundFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [ForwardCompoundFilter!]
 }
 
-\\"\\"\\"A connection to a list of \`ForwardCompound\` values.\\"\\"\\"
+"""A connection to a list of \`ForwardCompound\` values."""
 type ForwardCompoundsConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`ForwardCompound\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [ForwardCompoundsEdge!]!
 
-  \\"\\"\\"A list of \`ForwardCompound\` objects.\\"\\"\\"
+  """A list of \`ForwardCompound\` objects."""
   nodes: [ForwardCompound]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"
+  """
   The count of *all* \`ForwardCompound\` you could get from the connection.
-  \\"\\"\\"
+  """
   totalCount: Int!
 }
 
-\\"\\"\\"A \`ForwardCompound\` edge in the connection.\\"\\"\\"
+"""A \`ForwardCompound\` edge in the connection."""
 type ForwardCompoundsEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`ForwardCompound\` at the end of the edge.\\"\\"\\"
+  """The \`ForwardCompound\` at the end of the edge."""
   node: ForwardCompound
 }
 
-\\"\\"\\"Methods to use when ordering \`ForwardCompound\`.\\"\\"\\"
+"""Methods to use when ordering \`ForwardCompound\`."""
 enum ForwardCompoundsOrderBy {
   FORWARD_COMPOUND_1_ASC
   FORWARD_COMPOUND_1_DESC
@@ -3325,59 +3325,59 @@ enum ForwardCompoundsOrderBy {
   PRIMARY_KEY_DESC
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`Forward\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input ForwardFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [ForwardFilter!]
 
-  \\"\\"\\"Filter by the object’s \`filterable\` relation.\\"\\"\\"
+  """Filter by the object’s \`filterable\` relation."""
   filterable: FilterableFilter
 
-  \\"\\"\\"A related \`filterable\` exists.\\"\\"\\"
+  """A related \`filterable\` exists."""
   filterableExists: Boolean
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`name\` field.\\"\\"\\"
+  """Filter by the object’s \`name\` field."""
   name: StringFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: ForwardFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [ForwardFilter!]
 }
 
-\\"\\"\\"A connection to a list of \`Forward\` values.\\"\\"\\"
+"""A connection to a list of \`Forward\` values."""
 type ForwardsConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`Forward\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [ForwardsEdge!]!
 
-  \\"\\"\\"A list of \`Forward\` objects.\\"\\"\\"
+  """A list of \`Forward\` objects."""
   nodes: [Forward]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`Forward\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`Forward\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`Forward\` edge in the connection.\\"\\"\\"
+"""A \`Forward\` edge in the connection."""
 type ForwardsEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`Forward\` at the end of the edge.\\"\\"\\"
+  """The \`Forward\` at the end of the edge."""
   node: Forward
 }
 
-\\"\\"\\"Methods to use when ordering \`Forward\`.\\"\\"\\"
+"""Methods to use when ordering \`Forward\`."""
 enum ForwardsOrderBy {
   ID_ASC
   ID_DESC
@@ -3391,40 +3391,40 @@ enum ForwardsOrderBy {
 type FullyOmitted implements Node {
   id: Int!
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
   text: String
 }
 
-\\"\\"\\"A connection to a list of \`FullyOmitted\` values.\\"\\"\\"
+"""A connection to a list of \`FullyOmitted\` values."""
 type FullyOmittedsConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`FullyOmitted\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [FullyOmittedsEdge!]!
 
-  \\"\\"\\"A list of \`FullyOmitted\` objects.\\"\\"\\"
+  """A list of \`FullyOmitted\` objects."""
   nodes: [FullyOmitted]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`FullyOmitted\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`FullyOmitted\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`FullyOmitted\` edge in the connection.\\"\\"\\"
+"""A \`FullyOmitted\` edge in the connection."""
 type FullyOmittedsEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`FullyOmitted\` at the end of the edge.\\"\\"\\"
+  """The \`FullyOmitted\` at the end of the edge."""
   node: FullyOmitted
 }
 
-\\"\\"\\"Methods to use when ordering \`FullyOmitted\`.\\"\\"\\"
+"""Methods to use when ordering \`FullyOmitted\`."""
 enum FullyOmittedsOrderBy {
   ID_ASC
   ID_DESC
@@ -3435,746 +3435,746 @@ enum FullyOmittedsOrderBy {
   TEXT_DESC
 }
 
-\\"\\"\\"A connection to a list of \`FuncReturnsTableMultiColRecord\` values.\\"\\"\\"
+"""A connection to a list of \`FuncReturnsTableMultiColRecord\` values."""
 type FuncReturnsTableMultiColConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`FuncReturnsTableMultiColRecord\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [FuncReturnsTableMultiColEdge!]!
 
-  \\"\\"\\"A list of \`FuncReturnsTableMultiColRecord\` objects.\\"\\"\\"
+  """A list of \`FuncReturnsTableMultiColRecord\` objects."""
   nodes: [FuncReturnsTableMultiColRecord]!
 
-  \\"\\"\\"
+  """
   The count of *all* \`FuncReturnsTableMultiColRecord\` you could get from the connection.
-  \\"\\"\\"
+  """
   totalCount: Int!
 }
 
-\\"\\"\\"A \`FuncReturnsTableMultiColRecord\` edge in the connection.\\"\\"\\"
+"""A \`FuncReturnsTableMultiColRecord\` edge in the connection."""
 type FuncReturnsTableMultiColEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`FuncReturnsTableMultiColRecord\` at the end of the edge.\\"\\"\\"
+  """The \`FuncReturnsTableMultiColRecord\` at the end of the edge."""
   node: FuncReturnsTableMultiColRecord
 }
 
-\\"\\"\\"The return type of our \`funcReturnsTableMultiColConnection\` query.\\"\\"\\"
+"""The return type of our \`funcReturnsTableMultiColConnection\` query."""
 type FuncReturnsTableMultiColRecord {
   col1: Int
   col2: String
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`FuncReturnsTableMultiColRecord\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input FuncReturnsTableMultiColRecordFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [FuncReturnsTableMultiColRecordFilter!]
 
-  \\"\\"\\"Filter by the object’s \`col1\` field.\\"\\"\\"
+  """Filter by the object’s \`col1\` field."""
   col1: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`col2\` field.\\"\\"\\"
+  """Filter by the object’s \`col2\` field."""
   col2: StringFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: FuncReturnsTableMultiColRecordFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [FuncReturnsTableMultiColRecordFilter!]
 }
 
-\\"\\"\\"A connection to a list of \`Int\` values.\\"\\"\\"
+"""A connection to a list of \`Int\` values."""
 type FuncReturnsTableOneColConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`Int\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [FuncReturnsTableOneColEdge!]!
 
-  \\"\\"\\"A list of \`Int\` objects.\\"\\"\\"
+  """A list of \`Int\` objects."""
   nodes: [Int]!
 
-  \\"\\"\\"The count of *all* \`Int\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`Int\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`Int\` edge in the connection.\\"\\"\\"
+"""A \`Int\` edge in the connection."""
 type FuncReturnsTableOneColEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`Int\` at the end of the edge.\\"\\"\\"
+  """The \`Int\` at the end of the edge."""
   node: Int
 }
 
-\\"\\"\\"
+"""
 A connection to a list of \`FuncTaggedFilterableReturnsTableMultiColRecord\` values.
-\\"\\"\\"
+"""
 type FuncTaggedFilterableReturnsTableMultiColConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`FuncTaggedFilterableReturnsTableMultiColRecord\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [FuncTaggedFilterableReturnsTableMultiColEdge!]!
 
-  \\"\\"\\"A list of \`FuncTaggedFilterableReturnsTableMultiColRecord\` objects.\\"\\"\\"
+  """A list of \`FuncTaggedFilterableReturnsTableMultiColRecord\` objects."""
   nodes: [FuncTaggedFilterableReturnsTableMultiColRecord]!
 
-  \\"\\"\\"
+  """
   The count of *all* \`FuncTaggedFilterableReturnsTableMultiColRecord\` you could get from the connection.
-  \\"\\"\\"
+  """
   totalCount: Int!
 }
 
-\\"\\"\\"
+"""
 A \`FuncTaggedFilterableReturnsTableMultiColRecord\` edge in the connection.
-\\"\\"\\"
+"""
 type FuncTaggedFilterableReturnsTableMultiColEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"
+  """
   The \`FuncTaggedFilterableReturnsTableMultiColRecord\` at the end of the edge.
-  \\"\\"\\"
+  """
   node: FuncTaggedFilterableReturnsTableMultiColRecord
 }
 
-\\"\\"\\"
+"""
 The return type of our \`funcTaggedFilterableReturnsTableMultiColConnection\` query.
-\\"\\"\\"
+"""
 type FuncTaggedFilterableReturnsTableMultiColRecord {
   col1: Int
   col2: String
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`FuncTaggedFilterableReturnsTableMultiColRecord\`
 object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input FuncTaggedFilterableReturnsTableMultiColRecordFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [FuncTaggedFilterableReturnsTableMultiColRecordFilter!]
 
-  \\"\\"\\"Filter by the object’s \`col1\` field.\\"\\"\\"
+  """Filter by the object’s \`col1\` field."""
   col1: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`col2\` field.\\"\\"\\"
+  """Filter by the object’s \`col2\` field."""
   col2: StringFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: FuncTaggedFilterableReturnsTableMultiColRecordFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [FuncTaggedFilterableReturnsTableMultiColRecordFilter!]
 }
 
 scalar Int4Domain
 
-\\"\\"\\"
+"""
 A filter to be used against Int4Domain fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input Int4DomainFilter {
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: Int4Domain
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: Int4Domain
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: Int4Domain
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: Int4Domain
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [Int4Domain!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: Int4Domain
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: Int4Domain
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: Int4Domain
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: Int4Domain
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [Int4Domain!]
 }
 
-\\"\\"\\"An IPv4 or IPv6 host address, and optionally its subnet.\\"\\"\\"
+"""An IPv4 or IPv6 host address, and optionally its subnet."""
 scalar InternetAddress
 
-\\"\\"\\"
+"""
 A filter to be used against InternetAddress fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input InternetAddressFilter {
-  \\"\\"\\"Contained by the specified internet address.\\"\\"\\"
+  """Contained by the specified internet address."""
   containedBy: InternetAddress
 
-  \\"\\"\\"Contained by or equal to the specified internet address.\\"\\"\\"
+  """Contained by or equal to the specified internet address."""
   containedByOrEqualTo: InternetAddress
 
-  \\"\\"\\"Contains the specified internet address.\\"\\"\\"
+  """Contains the specified internet address."""
   contains: InternetAddress
 
-  \\"\\"\\"Contains or contained by the specified internet address.\\"\\"\\"
+  """Contains or contained by the specified internet address."""
   containsOrContainedBy: InternetAddress
 
-  \\"\\"\\"Contains or equal to the specified internet address.\\"\\"\\"
+  """Contains or equal to the specified internet address."""
   containsOrEqualTo: InternetAddress
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: InternetAddress
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: InternetAddress
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: InternetAddress
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: InternetAddress
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [InternetAddress!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: InternetAddress
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: InternetAddress
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: InternetAddress
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: InternetAddress
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [InternetAddress!]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against InternetAddress List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input InternetAddressListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: InternetAddress
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: InternetAddress
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: InternetAddress
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: InternetAddress
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: InternetAddress
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: InternetAddress
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [InternetAddress]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [InternetAddress]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [InternetAddress]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [InternetAddress]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [InternetAddress]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [InternetAddress]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [InternetAddress]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [InternetAddress]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [InternetAddress]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [InternetAddress]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [InternetAddress]
 }
 
-\\"\\"\\"
+"""
 An interval of time that has passed where the smallest distinct unit is a second.
-\\"\\"\\"
+"""
 type Interval {
-  \\"\\"\\"A quantity of days.\\"\\"\\"
+  """A quantity of days."""
   days: Int
 
-  \\"\\"\\"A quantity of hours.\\"\\"\\"
+  """A quantity of hours."""
   hours: Int
 
-  \\"\\"\\"A quantity of minutes.\\"\\"\\"
+  """A quantity of minutes."""
   minutes: Int
 
-  \\"\\"\\"A quantity of months.\\"\\"\\"
+  """A quantity of months."""
   months: Int
 
-  \\"\\"\\"
+  """
   A quantity of seconds. This is the only non-integer field, as all the other
   fields will dump their overflow into a smaller unit of time. Intervals don’t
   have a smaller unit than seconds.
-  \\"\\"\\"
+  """
   seconds: Float
 
-  \\"\\"\\"A quantity of years.\\"\\"\\"
+  """A quantity of years."""
   years: Int
 }
 
-\\"\\"\\"
+"""
 A filter to be used against Interval fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input IntervalFilter {
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: IntervalInput
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: IntervalInput
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: IntervalInput
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: IntervalInput
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [IntervalInput!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: IntervalInput
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: IntervalInput
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: IntervalInput
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: IntervalInput
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [IntervalInput!]
 }
 
-\\"\\"\\"
+"""
 An interval of time that has passed where the smallest distinct unit is a second.
-\\"\\"\\"
+"""
 input IntervalInput {
-  \\"\\"\\"A quantity of days.\\"\\"\\"
+  """A quantity of days."""
   days: Int
 
-  \\"\\"\\"A quantity of hours.\\"\\"\\"
+  """A quantity of hours."""
   hours: Int
 
-  \\"\\"\\"A quantity of minutes.\\"\\"\\"
+  """A quantity of minutes."""
   minutes: Int
 
-  \\"\\"\\"A quantity of months.\\"\\"\\"
+  """A quantity of months."""
   months: Int
 
-  \\"\\"\\"
+  """
   A quantity of seconds. This is the only non-integer field, as all the other
   fields will dump their overflow into a smaller unit of time. Intervals don’t
   have a smaller unit than seconds.
-  \\"\\"\\"
+  """
   seconds: Float
 
-  \\"\\"\\"A quantity of years.\\"\\"\\"
+  """A quantity of years."""
   years: Int
 }
 
-\\"\\"\\"
+"""
 A filter to be used against Interval List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input IntervalListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: IntervalInput
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: IntervalInput
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: IntervalInput
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: IntervalInput
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: IntervalInput
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: IntervalInput
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [IntervalInput]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [IntervalInput]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [IntervalInput]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [IntervalInput]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [IntervalInput]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [IntervalInput]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [IntervalInput]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [IntervalInput]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [IntervalInput]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [IntervalInput]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [IntervalInput]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against Int fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input IntFilter {
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: Int
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: Int
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: Int
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: Int
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [Int!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: Int
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: Int
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: Int
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: Int
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [Int!]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against Int List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input IntListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: Int
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: Int
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: Int
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: Int
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: Int
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: Int
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [Int]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [Int]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [Int]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [Int]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [Int]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [Int]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [Int]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [Int]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [Int]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [Int]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [Int]
 }
 
-\\"\\"\\"A range of \`Int\`.\\"\\"\\"
+"""A range of \`Int\`."""
 type IntRange {
-  \\"\\"\\"The ending bound of our range.\\"\\"\\"
+  """The ending bound of our range."""
   end: IntRangeBound
 
-  \\"\\"\\"The starting bound of our range.\\"\\"\\"
+  """The starting bound of our range."""
   start: IntRangeBound
 }
 
-\\"\\"\\"
+"""
 The value at one end of a range. A range can either include this value, or not.
-\\"\\"\\"
+"""
 type IntRangeBound {
-  \\"\\"\\"Whether or not the value of this bound is included in the range.\\"\\"\\"
+  """Whether or not the value of this bound is included in the range."""
   inclusive: Boolean!
 
-  \\"\\"\\"The value at one end of our range.\\"\\"\\"
+  """The value at one end of our range."""
   value: Int!
 }
 
-\\"\\"\\"
+"""
 The value at one end of a range. A range can either include this value, or not.
-\\"\\"\\"
+"""
 input IntRangeBoundInput {
-  \\"\\"\\"Whether or not the value of this bound is included in the range.\\"\\"\\"
+  """Whether or not the value of this bound is included in the range."""
   inclusive: Boolean!
 
-  \\"\\"\\"The value at one end of our range.\\"\\"\\"
+  """The value at one end of our range."""
   value: Int!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against IntRange fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input IntRangeFilter {
-  \\"\\"\\"Adjacent to the specified range.\\"\\"\\"
+  """Adjacent to the specified range."""
   adjacentTo: IntRangeInput
 
-  \\"\\"\\"Contained by the specified range.\\"\\"\\"
+  """Contained by the specified range."""
   containedBy: IntRangeInput
 
-  \\"\\"\\"Contains the specified range.\\"\\"\\"
+  """Contains the specified range."""
   contains: IntRangeInput
 
-  \\"\\"\\"Contains the specified value.\\"\\"\\"
+  """Contains the specified value."""
   containsElement: Int
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: IntRangeInput
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: IntRangeInput
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: IntRangeInput
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: IntRangeInput
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [IntRangeInput!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: IntRangeInput
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: IntRangeInput
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: IntRangeInput
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: IntRangeInput
 
-  \\"\\"\\"Does not extend left of the specified range.\\"\\"\\"
+  """Does not extend left of the specified range."""
   notExtendsLeftOf: IntRangeInput
 
-  \\"\\"\\"Does not extend right of the specified range.\\"\\"\\"
+  """Does not extend right of the specified range."""
   notExtendsRightOf: IntRangeInput
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [IntRangeInput!]
 
-  \\"\\"\\"Overlaps the specified range.\\"\\"\\"
+  """Overlaps the specified range."""
   overlaps: IntRangeInput
 
-  \\"\\"\\"Strictly left of the specified range.\\"\\"\\"
+  """Strictly left of the specified range."""
   strictlyLeftOf: IntRangeInput
 
-  \\"\\"\\"Strictly right of the specified range.\\"\\"\\"
+  """Strictly right of the specified range."""
   strictlyRightOf: IntRangeInput
 }
 
-\\"\\"\\"A range of \`Int\`.\\"\\"\\"
+"""A range of \`Int\`."""
 input IntRangeInput {
-  \\"\\"\\"The ending bound of our range.\\"\\"\\"
+  """The ending bound of our range."""
   end: IntRangeBoundInput
 
-  \\"\\"\\"The starting bound of our range.\\"\\"\\"
+  """The starting bound of our range."""
   start: IntRangeBoundInput
 }
 
-\\"\\"\\"
+"""
 A filter to be used against IntRange List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input IntRangeListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: IntRangeInput
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: IntRangeInput
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: IntRangeInput
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: IntRangeInput
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: IntRangeInput
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: IntRangeInput
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [IntRangeInput]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [IntRangeInput]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [IntRangeInput]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [IntRangeInput]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [IntRangeInput]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [IntRangeInput]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [IntRangeInput]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [IntRangeInput]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [IntRangeInput]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [IntRangeInput]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [IntRangeInput]
 }
 
-\\"\\"\\"
+"""
 A JavaScript object encoded in the JSON format as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf).
-\\"\\"\\"
+"""
 scalar JSON
 
 type JsonbTest implements Node {
@@ -4182,62 +4182,62 @@ type JsonbTest implements Node {
   jsonbWithArray: JSON
   jsonbWithObject: JSON
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`JsonbTest\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input JsonbTestFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [JsonbTestFilter!]
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`jsonbWithArray\` field.\\"\\"\\"
+  """Filter by the object’s \`jsonbWithArray\` field."""
   jsonbWithArray: JSONFilter
 
-  \\"\\"\\"Filter by the object’s \`jsonbWithObject\` field.\\"\\"\\"
+  """Filter by the object’s \`jsonbWithObject\` field."""
   jsonbWithObject: JSONFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: JsonbTestFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [JsonbTestFilter!]
 }
 
-\\"\\"\\"A connection to a list of \`JsonbTest\` values.\\"\\"\\"
+"""A connection to a list of \`JsonbTest\` values."""
 type JsonbTestsConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`JsonbTest\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [JsonbTestsEdge!]!
 
-  \\"\\"\\"A list of \`JsonbTest\` objects.\\"\\"\\"
+  """A list of \`JsonbTest\` objects."""
   nodes: [JsonbTest]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`JsonbTest\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`JsonbTest\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`JsonbTest\` edge in the connection.\\"\\"\\"
+"""A \`JsonbTest\` edge in the connection."""
 type JsonbTestsEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`JsonbTest\` at the end of the edge.\\"\\"\\"
+  """The \`JsonbTest\` at the end of the edge."""
   node: JsonbTest
 }
 
-\\"\\"\\"Methods to use when ordering \`JsonbTest\`.\\"\\"\\"
+"""Methods to use when ordering \`JsonbTest\`."""
 enum JsonbTestsOrderBy {
   ID_ASC
   ID_DESC
@@ -4250,194 +4250,194 @@ enum JsonbTestsOrderBy {
   PRIMARY_KEY_DESC
 }
 
-\\"\\"\\"
+"""
 A filter to be used against JSON fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input JSONFilter {
-  \\"\\"\\"Contained by the specified JSON.\\"\\"\\"
+  """Contained by the specified JSON."""
   containedBy: JSON
 
-  \\"\\"\\"Contains the specified JSON.\\"\\"\\"
+  """Contains the specified JSON."""
   contains: JSON
 
-  \\"\\"\\"Contains all of the specified keys.\\"\\"\\"
+  """Contains all of the specified keys."""
   containsAllKeys: [String!]
 
-  \\"\\"\\"Contains any of the specified keys.\\"\\"\\"
+  """Contains any of the specified keys."""
   containsAnyKeys: [String!]
 
-  \\"\\"\\"Contains the specified key.\\"\\"\\"
+  """Contains the specified key."""
   containsKey: String
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: JSON
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: JSON
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: JSON
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: JSON
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [JSON!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: JSON
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: JSON
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: JSON
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: JSON
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [JSON!]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against JSON List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input JSONListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: JSON
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: JSON
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: JSON
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: JSON
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: JSON
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: JSON
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [JSON]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [JSON]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [JSON]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [JSON]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [JSON]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [JSON]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [JSON]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [JSON]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [JSON]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [JSON]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [JSON]
 }
 
 type Junction implements Node {
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 
-  \\"\\"\\"Reads a single \`SideA\` that is related to this \`Junction\`.\\"\\"\\"
+  """Reads a single \`SideA\` that is related to this \`Junction\`."""
   sideA: SideA
   sideAId: Int!
 
-  \\"\\"\\"Reads a single \`SideB\` that is related to this \`Junction\`.\\"\\"\\"
+  """Reads a single \`SideB\` that is related to this \`Junction\`."""
   sideB: SideB
   sideBId: Int!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`Junction\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input JunctionFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [JunctionFilter!]
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: JunctionFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [JunctionFilter!]
 
-  \\"\\"\\"Filter by the object’s \`sideA\` relation.\\"\\"\\"
+  """Filter by the object’s \`sideA\` relation."""
   sideA: SideAFilter
 
-  \\"\\"\\"Filter by the object’s \`sideAId\` field.\\"\\"\\"
+  """Filter by the object’s \`sideAId\` field."""
   sideAId: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`sideB\` relation.\\"\\"\\"
+  """Filter by the object’s \`sideB\` relation."""
   sideB: SideBFilter
 
-  \\"\\"\\"Filter by the object’s \`sideBId\` field.\\"\\"\\"
+  """Filter by the object’s \`sideBId\` field."""
   sideBId: IntFilter
 }
 
-\\"\\"\\"A connection to a list of \`Junction\` values.\\"\\"\\"
+"""A connection to a list of \`Junction\` values."""
 type JunctionsConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`Junction\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [JunctionsEdge!]!
 
-  \\"\\"\\"A list of \`Junction\` objects.\\"\\"\\"
+  """A list of \`Junction\` objects."""
   nodes: [Junction]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`Junction\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`Junction\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`Junction\` edge in the connection.\\"\\"\\"
+"""A \`Junction\` edge in the connection."""
 type JunctionsEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`Junction\` at the end of the edge.\\"\\"\\"
+  """The \`Junction\` at the end of the edge."""
   node: Junction
 }
 
-\\"\\"\\"Methods to use when ordering \`Junction\`.\\"\\"\\"
+"""Methods to use when ordering \`Junction\`."""
 enum JunctionsOrderBy {
   NATURAL
   PRIMARY_KEY_ASC
@@ -4448,116 +4448,116 @@ enum JunctionsOrderBy {
   SIDE_B_ID_DESC
 }
 
-\\"\\"\\"
+"""
 A set of key/value pairs, keys are strings, values may be a string or null. Exposed as a JSON object.
-\\"\\"\\"
+"""
 scalar KeyValueHash
 
-\\"\\"\\"
+"""
 A filter to be used against KeyValueHash fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input KeyValueHashFilter {
-  \\"\\"\\"Contained by the specified KeyValueHash.\\"\\"\\"
+  """Contained by the specified KeyValueHash."""
   containedBy: KeyValueHash
 
-  \\"\\"\\"Contains the specified KeyValueHash.\\"\\"\\"
+  """Contains the specified KeyValueHash."""
   contains: KeyValueHash
 
-  \\"\\"\\"Contains all of the specified keys.\\"\\"\\"
+  """Contains all of the specified keys."""
   containsAllKeys: [String!]
 
-  \\"\\"\\"Contains any of the specified keys.\\"\\"\\"
+  """Contains any of the specified keys."""
   containsAnyKeys: [String!]
 
-  \\"\\"\\"Contains the specified key.\\"\\"\\"
+  """Contains the specified key."""
   containsKey: String
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: KeyValueHash
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: KeyValueHash
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [KeyValueHash!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: KeyValueHash
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: KeyValueHash
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [KeyValueHash!]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against KeyValueHash List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input KeyValueHashListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: KeyValueHash
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: KeyValueHash
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: KeyValueHash
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: KeyValueHash
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: KeyValueHash
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: KeyValueHash
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [KeyValueHash]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [KeyValueHash]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [KeyValueHash]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [KeyValueHash]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [KeyValueHash]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [KeyValueHash]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [KeyValueHash]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [KeyValueHash]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [KeyValueHash]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [KeyValueHash]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [KeyValueHash]
 }
 
@@ -4567,242 +4567,242 @@ enum Mood {
   SAD
 }
 
-\\"\\"\\"
+"""
 A filter to be used against Mood fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input MoodFilter {
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: Mood
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: Mood
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: Mood
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: Mood
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [Mood!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: Mood
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: Mood
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: Mood
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: Mood
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [Mood!]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against Mood List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input MoodListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: Mood
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: Mood
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: Mood
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: Mood
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: Mood
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: Mood
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [Mood]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [Mood]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [Mood]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [Mood]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [Mood]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [Mood]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [Mood]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [Mood]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [Mood]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [Mood]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [Mood]
 }
 
-\\"\\"\\"An object with a globally unique \`ID\`.\\"\\"\\"
+"""An object with a globally unique \`ID\`."""
 interface Node {
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
-\\"\\"\\"Information about pagination in a connection.\\"\\"\\"
+"""Information about pagination in a connection."""
 type PageInfo {
-  \\"\\"\\"When paginating forwards, the cursor to continue.\\"\\"\\"
+  """When paginating forwards, the cursor to continue."""
   endCursor: Cursor
 
-  \\"\\"\\"When paginating forwards, are there more items?\\"\\"\\"
+  """When paginating forwards, are there more items?"""
   hasNextPage: Boolean!
 
-  \\"\\"\\"When paginating backwards, are there more items?\\"\\"\\"
+  """When paginating backwards, are there more items?"""
   hasPreviousPage: Boolean!
 
-  \\"\\"\\"When paginating backwards, the cursor to continue.\\"\\"\\"
+  """When paginating backwards, the cursor to continue."""
   startCursor: Cursor
 }
 
 type Parent implements Node {
-  \\"\\"\\"Reads and enables pagination through a set of \`Filterable\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Filterable\`."""
   childFilterables(
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: FilterableFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Skip the first \`n\` values.\\"\\"\\"
+    """Skip the first \`n\` values."""
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`Filterable\`.\\"\\"\\"
+    """The method to use when ordering \`Filterable\`."""
     orderBy: [FilterablesOrderBy!]
   ): [Filterable!]!
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Filterable\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Filterable\`."""
   childFilterablesConnection(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: FilterableFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`Filterable\`.\\"\\"\\"
+    """The method to use when ordering \`Filterable\`."""
     orderBy: [FilterablesOrderBy!] = [PRIMARY_KEY_ASC]
   ): FilterablesConnection!
   id: Int!
   name: String!
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`Parent\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input ParentFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [ParentFilter!]
 
-  \\"\\"\\"Filter by the object’s \`childFilterables\` relation.\\"\\"\\"
+  """Filter by the object’s \`childFilterables\` relation."""
   childFilterables: ParentToManyFilterableFilter
 
-  \\"\\"\\"Some related \`childFilterables\` exist.\\"\\"\\"
+  """Some related \`childFilterables\` exist."""
   childFilterablesExist: Boolean
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`name\` field.\\"\\"\\"
+  """Filter by the object’s \`name\` field."""
   name: StringFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: ParentFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [ParentFilter!]
 }
 
-\\"\\"\\"A connection to a list of \`Parent\` values.\\"\\"\\"
+"""A connection to a list of \`Parent\` values."""
 type ParentsConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`Parent\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [ParentsEdge!]!
 
-  \\"\\"\\"A list of \`Parent\` objects.\\"\\"\\"
+  """A list of \`Parent\` objects."""
   nodes: [Parent]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`Parent\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`Parent\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`Parent\` edge in the connection.\\"\\"\\"
+"""A \`Parent\` edge in the connection."""
 type ParentsEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`Parent\` at the end of the edge.\\"\\"\\"
+  """The \`Parent\` at the end of the edge."""
   node: Parent
 }
 
-\\"\\"\\"Methods to use when ordering \`Parent\`.\\"\\"\\"
+"""Methods to use when ordering \`Parent\`."""
 enum ParentsOrderBy {
   ID_ASC
   ID_DESC
@@ -4813,23 +4813,23 @@ enum ParentsOrderBy {
   PRIMARY_KEY_DESC
 }
 
-\\"\\"\\"
+"""
 A filter to be used against many \`Filterable\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input ParentToManyFilterableFilter {
-  \\"\\"\\"
+  """
   Every related \`Filterable\` matches the filter criteria. All fields are combined with a logical ‘and.’
-  \\"\\"\\"
+  """
   every: FilterableFilter
 
-  \\"\\"\\"
+  """
   No related \`Filterable\` matches the filter criteria. All fields are combined with a logical ‘and.’
-  \\"\\"\\"
+  """
   none: FilterableFilter
 
-  \\"\\"\\"
+  """
   Some related \`Filterable\` matches the filter criteria. All fields are combined with a logical ‘and.’
-  \\"\\"\\"
+  """
   some: FilterableFilter
 }
 
@@ -4837,495 +4837,495 @@ type Protected implements Node {
   id: Int!
   name: String
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
   otherId: Int
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`Protected\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input ProtectedFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [ProtectedFilter!]
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`name\` field.\\"\\"\\"
+  """Filter by the object’s \`name\` field."""
   name: StringFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: ProtectedFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [ProtectedFilter!]
 
-  \\"\\"\\"Filter by the object’s \`otherId\` field.\\"\\"\\"
+  """Filter by the object’s \`otherId\` field."""
   otherId: IntFilter
 }
 
-\\"\\"\\"A connection to a list of \`Protected\` values.\\"\\"\\"
+"""A connection to a list of \`Protected\` values."""
 type ProtectedsConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`Protected\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [ProtectedsEdge!]!
 
-  \\"\\"\\"A list of \`Protected\` objects.\\"\\"\\"
+  """A list of \`Protected\` objects."""
   nodes: [Protected]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`Protected\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`Protected\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`Protected\` edge in the connection.\\"\\"\\"
+"""A \`Protected\` edge in the connection."""
 type ProtectedsEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`Protected\` at the end of the edge.\\"\\"\\"
+  """The \`Protected\` at the end of the edge."""
   node: Protected
 }
 
-\\"\\"\\"The root query type which gives access points into the data universe.\\"\\"\\"
+"""The root query type which gives access points into the data universe."""
 type Query implements Node {
   arrayType(id: Int!): ArrayType
 
-  \\"\\"\\"Reads a single \`ArrayType\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`ArrayType\` using its globally unique \`ID\`."""
   arrayTypeByNodeId(
-    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`ArrayType\`.\\"\\"\\"
+    """The globally unique \`ID\` to be used in selecting a single \`ArrayType\`."""
     nodeId: ID!
   ): ArrayType
 
-  \\"\\"\\"Reads a set of \`ArrayType\`.\\"\\"\\"
+  """Reads a set of \`ArrayType\`."""
   arrayTypes(
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: ArrayTypeFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Skip the first \`n\` values.\\"\\"\\"
+    """Skip the first \`n\` values."""
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`ArrayType\`.\\"\\"\\"
+    """The method to use when ordering \`ArrayType\`."""
     orderBy: [ArrayTypesOrderBy!]
   ): [ArrayType!]
 
-  \\"\\"\\"Reads and enables pagination through a set of \`ArrayType\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`ArrayType\`."""
   arrayTypesConnection(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: ArrayTypeFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`ArrayType\`.\\"\\"\\"
+    """The method to use when ordering \`ArrayType\`."""
     orderBy: [ArrayTypesOrderBy!] = [PRIMARY_KEY_ASC]
   ): ArrayTypesConnection
   backward(id: Int!): Backward
   backwardByFilterableId(filterableId: Int!): Backward
 
-  \\"\\"\\"Reads a single \`Backward\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`Backward\` using its globally unique \`ID\`."""
   backwardByNodeId(
-    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`Backward\`.\\"\\"\\"
+    """The globally unique \`ID\` to be used in selecting a single \`Backward\`."""
     nodeId: ID!
   ): Backward
   backwardCompound(backwardCompound1: Int!, backwardCompound2: Int!): BackwardCompound
 
-  \\"\\"\\"Reads a single \`BackwardCompound\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`BackwardCompound\` using its globally unique \`ID\`."""
   backwardCompoundByNodeId(
-    \\"\\"\\"
+    """
     The globally unique \`ID\` to be used in selecting a single \`BackwardCompound\`.
-    \\"\\"\\"
+    """
     nodeId: ID!
   ): BackwardCompound
 
-  \\"\\"\\"Reads a set of \`BackwardCompound\`.\\"\\"\\"
+  """Reads a set of \`BackwardCompound\`."""
   backwardCompounds(
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: BackwardCompoundFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Skip the first \`n\` values.\\"\\"\\"
+    """Skip the first \`n\` values."""
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`BackwardCompound\`.\\"\\"\\"
+    """The method to use when ordering \`BackwardCompound\`."""
     orderBy: [BackwardCompoundsOrderBy!]
   ): [BackwardCompound!]
 
-  \\"\\"\\"Reads and enables pagination through a set of \`BackwardCompound\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`BackwardCompound\`."""
   backwardCompoundsConnection(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: BackwardCompoundFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`BackwardCompound\`.\\"\\"\\"
+    """The method to use when ordering \`BackwardCompound\`."""
     orderBy: [BackwardCompoundsOrderBy!] = [PRIMARY_KEY_ASC]
   ): BackwardCompoundsConnection
 
-  \\"\\"\\"Reads a set of \`Backward\`.\\"\\"\\"
+  """Reads a set of \`Backward\`."""
   backwards(
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: BackwardFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Skip the first \`n\` values.\\"\\"\\"
+    """Skip the first \`n\` values."""
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`Backward\`.\\"\\"\\"
+    """The method to use when ordering \`Backward\`."""
     orderBy: [BackwardsOrderBy!]
   ): [Backward!]
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Backward\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Backward\`."""
   backwardsConnection(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: BackwardFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`Backward\`.\\"\\"\\"
+    """The method to use when ordering \`Backward\`."""
     orderBy: [BackwardsOrderBy!] = [PRIMARY_KEY_ASC]
   ): BackwardsConnection
   child(id: Int!): Child
 
-  \\"\\"\\"Reads a single \`Child\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`Child\` using its globally unique \`ID\`."""
   childByNodeId(
-    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`Child\`.\\"\\"\\"
+    """The globally unique \`ID\` to be used in selecting a single \`Child\`."""
     nodeId: ID!
   ): Child
   childNoRelatedFilter(id: Int!): ChildNoRelatedFilter
 
-  \\"\\"\\"Reads a single \`ChildNoRelatedFilter\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`ChildNoRelatedFilter\` using its globally unique \`ID\`."""
   childNoRelatedFilterByNodeId(
-    \\"\\"\\"
+    """
     The globally unique \`ID\` to be used in selecting a single \`ChildNoRelatedFilter\`.
-    \\"\\"\\"
+    """
     nodeId: ID!
   ): ChildNoRelatedFilter
 
-  \\"\\"\\"Reads a set of \`ChildNoRelatedFilter\`.\\"\\"\\"
+  """Reads a set of \`ChildNoRelatedFilter\`."""
   childNoRelatedFilters(
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: ChildNoRelatedFilterFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Skip the first \`n\` values.\\"\\"\\"
+    """Skip the first \`n\` values."""
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`ChildNoRelatedFilter\`.\\"\\"\\"
+    """The method to use when ordering \`ChildNoRelatedFilter\`."""
     orderBy: [ChildNoRelatedFiltersOrderBy!]
   ): [ChildNoRelatedFilter!]
 
-  \\"\\"\\"Reads and enables pagination through a set of \`ChildNoRelatedFilter\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`ChildNoRelatedFilter\`."""
   childNoRelatedFiltersConnection(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: ChildNoRelatedFilterFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`ChildNoRelatedFilter\`.\\"\\"\\"
+    """The method to use when ordering \`ChildNoRelatedFilter\`."""
     orderBy: [ChildNoRelatedFiltersOrderBy!] = [PRIMARY_KEY_ASC]
   ): ChildNoRelatedFiltersConnection
 
-  \\"\\"\\"Reads a set of \`Child\`.\\"\\"\\"
+  """Reads a set of \`Child\`."""
   children(
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: ChildFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Skip the first \`n\` values.\\"\\"\\"
+    """Skip the first \`n\` values."""
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`Child\`.\\"\\"\\"
+    """The method to use when ordering \`Child\`."""
     orderBy: [ChildrenOrderBy!]
   ): [Child!]
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Child\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Child\`."""
   childrenConnection(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: ChildFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`Child\`.\\"\\"\\"
+    """The method to use when ordering \`Child\`."""
     orderBy: [ChildrenOrderBy!] = [PRIMARY_KEY_ASC]
   ): ChildrenConnection
   domainType(id: Int!): DomainType
 
-  \\"\\"\\"Reads a single \`DomainType\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`DomainType\` using its globally unique \`ID\`."""
   domainTypeByNodeId(
-    \\"\\"\\"
+    """
     The globally unique \`ID\` to be used in selecting a single \`DomainType\`.
-    \\"\\"\\"
+    """
     nodeId: ID!
   ): DomainType
 
-  \\"\\"\\"Reads a set of \`DomainType\`.\\"\\"\\"
+  """Reads a set of \`DomainType\`."""
   domainTypes(
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: DomainTypeFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Skip the first \`n\` values.\\"\\"\\"
+    """Skip the first \`n\` values."""
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`DomainType\`.\\"\\"\\"
+    """The method to use when ordering \`DomainType\`."""
     orderBy: [DomainTypesOrderBy!]
   ): [DomainType!]
 
-  \\"\\"\\"Reads and enables pagination through a set of \`DomainType\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`DomainType\`."""
   domainTypesConnection(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: DomainTypeFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`DomainType\`.\\"\\"\\"
+    """The method to use when ordering \`DomainType\`."""
     orderBy: [DomainTypesOrderBy!] = [PRIMARY_KEY_ASC]
   ): DomainTypesConnection
   enumArrayType(id: Int!): EnumArrayType
 
-  \\"\\"\\"Reads a single \`EnumArrayType\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`EnumArrayType\` using its globally unique \`ID\`."""
   enumArrayTypeByNodeId(
-    \\"\\"\\"
+    """
     The globally unique \`ID\` to be used in selecting a single \`EnumArrayType\`.
-    \\"\\"\\"
+    """
     nodeId: ID!
   ): EnumArrayType
 
-  \\"\\"\\"Reads a set of \`EnumArrayType\`.\\"\\"\\"
+  """Reads a set of \`EnumArrayType\`."""
   enumArrayTypes(
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: EnumArrayTypeFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Skip the first \`n\` values.\\"\\"\\"
+    """Skip the first \`n\` values."""
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`EnumArrayType\`.\\"\\"\\"
+    """The method to use when ordering \`EnumArrayType\`."""
     orderBy: [EnumArrayTypesOrderBy!]
   ): [EnumArrayType!]
 
-  \\"\\"\\"Reads and enables pagination through a set of \`EnumArrayType\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`EnumArrayType\`."""
   enumArrayTypesConnection(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: EnumArrayTypeFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`EnumArrayType\`.\\"\\"\\"
+    """The method to use when ordering \`EnumArrayType\`."""
     orderBy: [EnumArrayTypesOrderBy!] = [PRIMARY_KEY_ASC]
   ): EnumArrayTypesConnection
   enumType(id: Int!): EnumType
 
-  \\"\\"\\"Reads a single \`EnumType\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`EnumType\` using its globally unique \`ID\`."""
   enumTypeByNodeId(
-    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`EnumType\`.\\"\\"\\"
+    """The globally unique \`ID\` to be used in selecting a single \`EnumType\`."""
     nodeId: ID!
   ): EnumType
 
-  \\"\\"\\"Reads a set of \`EnumType\`.\\"\\"\\"
+  """Reads a set of \`EnumType\`."""
   enumTypes(
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: EnumTypeFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Skip the first \`n\` values.\\"\\"\\"
+    """Skip the first \`n\` values."""
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`EnumType\`.\\"\\"\\"
+    """The method to use when ordering \`EnumType\`."""
     orderBy: [EnumTypesOrderBy!]
   ): [EnumType!]
 
-  \\"\\"\\"Reads and enables pagination through a set of \`EnumType\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`EnumType\`."""
   enumTypesConnection(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: EnumTypeFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`EnumType\`.\\"\\"\\"
+    """The method to use when ordering \`EnumType\`."""
     orderBy: [EnumTypesOrderBy!] = [PRIMARY_KEY_ASC]
   ): EnumTypesConnection
   filterable(id: Int!): Filterable
@@ -5333,855 +5333,855 @@ type Query implements Node {
   filterableByForwardCompound1AndForwardCompound2(forwardCompound1: Int!, forwardCompound2: Int!): Filterable
   filterableByForwardId(forwardId: Int!): Filterable
 
-  \\"\\"\\"Reads a single \`Filterable\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`Filterable\` using its globally unique \`ID\`."""
   filterableByNodeId(
-    \\"\\"\\"
+    """
     The globally unique \`ID\` to be used in selecting a single \`Filterable\`.
-    \\"\\"\\"
+    """
     nodeId: ID!
   ): Filterable
   filterableClosure(id: Int!): FilterableClosure
 
-  \\"\\"\\"Reads a single \`FilterableClosure\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`FilterableClosure\` using its globally unique \`ID\`."""
   filterableClosureByNodeId(
-    \\"\\"\\"
+    """
     The globally unique \`ID\` to be used in selecting a single \`FilterableClosure\`.
-    \\"\\"\\"
+    """
     nodeId: ID!
   ): FilterableClosure
 
-  \\"\\"\\"Reads a set of \`Filterable\`.\\"\\"\\"
+  """Reads a set of \`Filterable\`."""
   filterables(
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: FilterableFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Skip the first \`n\` values.\\"\\"\\"
+    """Skip the first \`n\` values."""
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`Filterable\`.\\"\\"\\"
+    """The method to use when ordering \`Filterable\`."""
     orderBy: [FilterablesOrderBy!]
   ): [Filterable!]
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Filterable\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Filterable\`."""
   filterablesConnection(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: FilterableFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`Filterable\`.\\"\\"\\"
+    """The method to use when ordering \`Filterable\`."""
     orderBy: [FilterablesOrderBy!] = [PRIMARY_KEY_ASC]
   ): FilterablesConnection
   forward(id: Int!): Forward
 
-  \\"\\"\\"Reads a single \`Forward\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`Forward\` using its globally unique \`ID\`."""
   forwardByNodeId(
-    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`Forward\`.\\"\\"\\"
+    """The globally unique \`ID\` to be used in selecting a single \`Forward\`."""
     nodeId: ID!
   ): Forward
   forwardCompound(forwardCompound1: Int!, forwardCompound2: Int!): ForwardCompound
 
-  \\"\\"\\"Reads a single \`ForwardCompound\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`ForwardCompound\` using its globally unique \`ID\`."""
   forwardCompoundByNodeId(
-    \\"\\"\\"
+    """
     The globally unique \`ID\` to be used in selecting a single \`ForwardCompound\`.
-    \\"\\"\\"
+    """
     nodeId: ID!
   ): ForwardCompound
 
-  \\"\\"\\"Reads a set of \`ForwardCompound\`.\\"\\"\\"
+  """Reads a set of \`ForwardCompound\`."""
   forwardCompounds(
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: ForwardCompoundFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Skip the first \`n\` values.\\"\\"\\"
+    """Skip the first \`n\` values."""
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`ForwardCompound\`.\\"\\"\\"
+    """The method to use when ordering \`ForwardCompound\`."""
     orderBy: [ForwardCompoundsOrderBy!]
   ): [ForwardCompound!]
 
-  \\"\\"\\"Reads and enables pagination through a set of \`ForwardCompound\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`ForwardCompound\`."""
   forwardCompoundsConnection(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: ForwardCompoundFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`ForwardCompound\`.\\"\\"\\"
+    """The method to use when ordering \`ForwardCompound\`."""
     orderBy: [ForwardCompoundsOrderBy!] = [PRIMARY_KEY_ASC]
   ): ForwardCompoundsConnection
 
-  \\"\\"\\"Reads a set of \`Forward\`.\\"\\"\\"
+  """Reads a set of \`Forward\`."""
   forwards(
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: ForwardFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Skip the first \`n\` values.\\"\\"\\"
+    """Skip the first \`n\` values."""
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`Forward\`.\\"\\"\\"
+    """The method to use when ordering \`Forward\`."""
     orderBy: [ForwardsOrderBy!]
   ): [Forward!]
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Forward\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Forward\`."""
   forwardsConnection(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: ForwardFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`Forward\`.\\"\\"\\"
+    """The method to use when ordering \`Forward\`."""
     orderBy: [ForwardsOrderBy!] = [PRIMARY_KEY_ASC]
   ): ForwardsConnection
   fullyOmitted(id: Int!): FullyOmitted
 
-  \\"\\"\\"Reads a single \`FullyOmitted\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`FullyOmitted\` using its globally unique \`ID\`."""
   fullyOmittedByNodeId(
-    \\"\\"\\"
+    """
     The globally unique \`ID\` to be used in selecting a single \`FullyOmitted\`.
-    \\"\\"\\"
+    """
     nodeId: ID!
   ): FullyOmitted
 
-  \\"\\"\\"Reads a set of \`FullyOmitted\`.\\"\\"\\"
+  """Reads a set of \`FullyOmitted\`."""
   fullyOmitteds(
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Skip the first \`n\` values.\\"\\"\\"
+    """Skip the first \`n\` values."""
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`FullyOmitted\`.\\"\\"\\"
+    """The method to use when ordering \`FullyOmitted\`."""
     orderBy: [FullyOmittedsOrderBy!]
   ): [FullyOmitted!]
 
-  \\"\\"\\"Reads and enables pagination through a set of \`FullyOmitted\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`FullyOmitted\`."""
   fullyOmittedsConnection(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`FullyOmitted\`.\\"\\"\\"
+    """The method to use when ordering \`FullyOmitted\`."""
     orderBy: [FullyOmittedsOrderBy!] = [PRIMARY_KEY_ASC]
   ): FullyOmittedsConnection
   funcReturnsTableMultiCol(
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: FuncReturnsTableMultiColRecordFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
     i: Int
 
-    \\"\\"\\"Skip the first \`n\` values.\\"\\"\\"
+    """Skip the first \`n\` values."""
     offset: Int
   ): [FuncReturnsTableMultiColRecord]
   funcReturnsTableMultiColConnection(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: FuncReturnsTableMultiColRecordFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
     i: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
   ): FuncReturnsTableMultiColConnection!
   funcReturnsTableOneCol(
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: IntFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
     i: Int
 
-    \\"\\"\\"Skip the first \`n\` values.\\"\\"\\"
+    """Skip the first \`n\` values."""
     offset: Int
   ): [Int]
   funcReturnsTableOneColConnection(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: IntFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
     i: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
   ): FuncReturnsTableOneColConnection!
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Filterable\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Filterable\`."""
   funcTaggedFilterableReturnsSetofFilterable(
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: FilterableFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Skip the first \`n\` values.\\"\\"\\"
+    """Skip the first \`n\` values."""
     offset: Int
   ): [Filterable]
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Filterable\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Filterable\`."""
   funcTaggedFilterableReturnsSetofFilterableConnection(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: FilterableFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
   ): FilterablesConnection!
   funcTaggedFilterableReturnsTableMultiCol(
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: FuncTaggedFilterableReturnsTableMultiColRecordFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Skip the first \`n\` values.\\"\\"\\"
+    """Skip the first \`n\` values."""
     offset: Int
   ): [FuncTaggedFilterableReturnsTableMultiColRecord]
   funcTaggedFilterableReturnsTableMultiColConnection(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: FuncTaggedFilterableReturnsTableMultiColRecordFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
   ): FuncTaggedFilterableReturnsTableMultiColConnection!
   jsonbTest(id: Int!): JsonbTest
 
-  \\"\\"\\"Reads a single \`JsonbTest\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`JsonbTest\` using its globally unique \`ID\`."""
   jsonbTestByNodeId(
-    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`JsonbTest\`.\\"\\"\\"
+    """The globally unique \`ID\` to be used in selecting a single \`JsonbTest\`."""
     nodeId: ID!
   ): JsonbTest
 
-  \\"\\"\\"Reads a set of \`JsonbTest\`.\\"\\"\\"
+  """Reads a set of \`JsonbTest\`."""
   jsonbTests(
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: JsonbTestFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Skip the first \`n\` values.\\"\\"\\"
+    """Skip the first \`n\` values."""
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`JsonbTest\`.\\"\\"\\"
+    """The method to use when ordering \`JsonbTest\`."""
     orderBy: [JsonbTestsOrderBy!]
   ): [JsonbTest!]
 
-  \\"\\"\\"Reads and enables pagination through a set of \`JsonbTest\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`JsonbTest\`."""
   jsonbTestsConnection(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: JsonbTestFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`JsonbTest\`.\\"\\"\\"
+    """The method to use when ordering \`JsonbTest\`."""
     orderBy: [JsonbTestsOrderBy!] = [PRIMARY_KEY_ASC]
   ): JsonbTestsConnection
   junction(sideAId: Int!, sideBId: Int!): Junction
 
-  \\"\\"\\"Reads a single \`Junction\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`Junction\` using its globally unique \`ID\`."""
   junctionByNodeId(
-    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`Junction\`.\\"\\"\\"
+    """The globally unique \`ID\` to be used in selecting a single \`Junction\`."""
     nodeId: ID!
   ): Junction
 
-  \\"\\"\\"Reads a set of \`Junction\`.\\"\\"\\"
+  """Reads a set of \`Junction\`."""
   junctions(
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: JunctionFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Skip the first \`n\` values.\\"\\"\\"
+    """Skip the first \`n\` values."""
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`Junction\`.\\"\\"\\"
+    """The method to use when ordering \`Junction\`."""
     orderBy: [JunctionsOrderBy!]
   ): [Junction!]
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Junction\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Junction\`."""
   junctionsConnection(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: JunctionFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`Junction\`.\\"\\"\\"
+    """The method to use when ordering \`Junction\`."""
     orderBy: [JunctionsOrderBy!] = [PRIMARY_KEY_ASC]
   ): JunctionsConnection
 
-  \\"\\"\\"Fetches an object given its globally unique \`ID\`.\\"\\"\\"
+  """Fetches an object given its globally unique \`ID\`."""
   node(
-    \\"\\"\\"The globally unique \`ID\`.\\"\\"\\"
+    """The globally unique \`ID\`."""
     nodeId: ID!
   ): Node
 
-  \\"\\"\\"
+  """
   The root query type must be a \`Node\` to work well with Relay 1 mutations. This just resolves to \`query\`.
-  \\"\\"\\"
+  """
   nodeId: ID!
   parent(id: Int!): Parent
 
-  \\"\\"\\"Reads a single \`Parent\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`Parent\` using its globally unique \`ID\`."""
   parentByNodeId(
-    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`Parent\`.\\"\\"\\"
+    """The globally unique \`ID\` to be used in selecting a single \`Parent\`."""
     nodeId: ID!
   ): Parent
 
-  \\"\\"\\"Reads a set of \`Parent\`.\\"\\"\\"
+  """Reads a set of \`Parent\`."""
   parents(
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: ParentFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Skip the first \`n\` values.\\"\\"\\"
+    """Skip the first \`n\` values."""
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`Parent\`.\\"\\"\\"
+    """The method to use when ordering \`Parent\`."""
     orderBy: [ParentsOrderBy!]
   ): [Parent!]
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Parent\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Parent\`."""
   parentsConnection(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: ParentFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`Parent\`.\\"\\"\\"
+    """The method to use when ordering \`Parent\`."""
     orderBy: [ParentsOrderBy!] = [PRIMARY_KEY_ASC]
   ): ParentsConnection
   protected(id: Int!): Protected
 
-  \\"\\"\\"Reads a single \`Protected\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`Protected\` using its globally unique \`ID\`."""
   protectedByNodeId(
-    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`Protected\`.\\"\\"\\"
+    """The globally unique \`ID\` to be used in selecting a single \`Protected\`."""
     nodeId: ID!
   ): Protected
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Protected\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Protected\`."""
   protectedsByOtherId(
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: ProtectedFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Skip the first \`n\` values.\\"\\"\\"
+    """Skip the first \`n\` values."""
     offset: Int
     otherId: Int
   ): [Protected]
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Protected\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Protected\`."""
   protectedsByOtherIdConnection(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: ProtectedFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
     otherId: Int
   ): ProtectedsConnection!
 
-  \\"\\"\\"
+  """
   Exposes the root query type nested one level down. This is helpful for Relay 1
   which can only query top level fields if they are in a particular form.
-  \\"\\"\\"
+  """
   query: Query!
   rangeArrayType(id: Int!): RangeArrayType
 
-  \\"\\"\\"Reads a single \`RangeArrayType\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`RangeArrayType\` using its globally unique \`ID\`."""
   rangeArrayTypeByNodeId(
-    \\"\\"\\"
+    """
     The globally unique \`ID\` to be used in selecting a single \`RangeArrayType\`.
-    \\"\\"\\"
+    """
     nodeId: ID!
   ): RangeArrayType
 
-  \\"\\"\\"Reads a set of \`RangeArrayType\`.\\"\\"\\"
+  """Reads a set of \`RangeArrayType\`."""
   rangeArrayTypes(
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: RangeArrayTypeFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Skip the first \`n\` values.\\"\\"\\"
+    """Skip the first \`n\` values."""
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`RangeArrayType\`.\\"\\"\\"
+    """The method to use when ordering \`RangeArrayType\`."""
     orderBy: [RangeArrayTypesOrderBy!]
   ): [RangeArrayType!]
 
-  \\"\\"\\"Reads and enables pagination through a set of \`RangeArrayType\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`RangeArrayType\`."""
   rangeArrayTypesConnection(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: RangeArrayTypeFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`RangeArrayType\`.\\"\\"\\"
+    """The method to use when ordering \`RangeArrayType\`."""
     orderBy: [RangeArrayTypesOrderBy!] = [PRIMARY_KEY_ASC]
   ): RangeArrayTypesConnection
   rangeType(id: Int!): RangeType
 
-  \\"\\"\\"Reads a single \`RangeType\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`RangeType\` using its globally unique \`ID\`."""
   rangeTypeByNodeId(
-    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`RangeType\`.\\"\\"\\"
+    """The globally unique \`ID\` to be used in selecting a single \`RangeType\`."""
     nodeId: ID!
   ): RangeType
 
-  \\"\\"\\"Reads a set of \`RangeType\`.\\"\\"\\"
+  """Reads a set of \`RangeType\`."""
   rangeTypes(
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: RangeTypeFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Skip the first \`n\` values.\\"\\"\\"
+    """Skip the first \`n\` values."""
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`RangeType\`.\\"\\"\\"
+    """The method to use when ordering \`RangeType\`."""
     orderBy: [RangeTypesOrderBy!]
   ): [RangeType!]
 
-  \\"\\"\\"Reads and enables pagination through a set of \`RangeType\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`RangeType\`."""
   rangeTypesConnection(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: RangeTypeFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`RangeType\`.\\"\\"\\"
+    """The method to use when ordering \`RangeType\`."""
     orderBy: [RangeTypesOrderBy!] = [PRIMARY_KEY_ASC]
   ): RangeTypesConnection
   sideA(aId: Int!): SideA
 
-  \\"\\"\\"Reads a single \`SideA\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`SideA\` using its globally unique \`ID\`."""
   sideAByNodeId(
-    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`SideA\`.\\"\\"\\"
+    """The globally unique \`ID\` to be used in selecting a single \`SideA\`."""
     nodeId: ID!
   ): SideA
 
-  \\"\\"\\"Reads a set of \`SideA\`.\\"\\"\\"
+  """Reads a set of \`SideA\`."""
   sideAs(
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: SideAFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Skip the first \`n\` values.\\"\\"\\"
+    """Skip the first \`n\` values."""
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`SideA\`.\\"\\"\\"
+    """The method to use when ordering \`SideA\`."""
     orderBy: [SideAsOrderBy!]
   ): [SideA!]
 
-  \\"\\"\\"Reads and enables pagination through a set of \`SideA\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`SideA\`."""
   sideAsConnection(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: SideAFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`SideA\`.\\"\\"\\"
+    """The method to use when ordering \`SideA\`."""
     orderBy: [SideAsOrderBy!] = [PRIMARY_KEY_ASC]
   ): SideAsConnection
   sideB(bId: Int!): SideB
 
-  \\"\\"\\"Reads a single \`SideB\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`SideB\` using its globally unique \`ID\`."""
   sideBByNodeId(
-    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`SideB\`.\\"\\"\\"
+    """The globally unique \`ID\` to be used in selecting a single \`SideB\`."""
     nodeId: ID!
   ): SideB
 
-  \\"\\"\\"Reads a set of \`SideB\`.\\"\\"\\"
+  """Reads a set of \`SideB\`."""
   sideBs(
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: SideBFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Skip the first \`n\` values.\\"\\"\\"
+    """Skip the first \`n\` values."""
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`SideB\`.\\"\\"\\"
+    """The method to use when ordering \`SideB\`."""
     orderBy: [SideBsOrderBy!]
   ): [SideB!]
 
-  \\"\\"\\"Reads and enables pagination through a set of \`SideB\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`SideB\`."""
   sideBsConnection(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: SideBFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`SideB\`.\\"\\"\\"
+    """The method to use when ordering \`SideB\`."""
     orderBy: [SideBsOrderBy!] = [PRIMARY_KEY_ASC]
   ): SideBsConnection
   unfilterable(id: Int!): Unfilterable
 
-  \\"\\"\\"Reads a single \`Unfilterable\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`Unfilterable\` using its globally unique \`ID\`."""
   unfilterableByNodeId(
-    \\"\\"\\"
+    """
     The globally unique \`ID\` to be used in selecting a single \`Unfilterable\`.
-    \\"\\"\\"
+    """
     nodeId: ID!
   ): Unfilterable
 
-  \\"\\"\\"Reads a set of \`Unfilterable\`.\\"\\"\\"
+  """Reads a set of \`Unfilterable\`."""
   unfilterables(
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Skip the first \`n\` values.\\"\\"\\"
+    """Skip the first \`n\` values."""
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`Unfilterable\`.\\"\\"\\"
+    """The method to use when ordering \`Unfilterable\`."""
     orderBy: [UnfilterablesOrderBy!]
   ): [Unfilterable!]
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Unfilterable\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Unfilterable\`."""
   unfilterablesConnection(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`Unfilterable\`.\\"\\"\\"
+    """The method to use when ordering \`Unfilterable\`."""
     orderBy: [UnfilterablesOrderBy!] = [PRIMARY_KEY_ASC]
   ): UnfilterablesConnection
 }
@@ -6192,77 +6192,77 @@ type RangeArrayType implements Node {
   int4RangeArray: [IntRange]
   int8RangeArray: [BigIntRange]
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
   numericRangeArray: [BigFloatRange]
   timestampRangeArray: [DatetimeRange]
   timestamptzRangeArray: [DatetimeRange]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`RangeArrayType\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input RangeArrayTypeFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [RangeArrayTypeFilter!]
 
-  \\"\\"\\"Filter by the object’s \`dateRangeArray\` field.\\"\\"\\"
+  """Filter by the object’s \`dateRangeArray\` field."""
   dateRangeArray: DateRangeListFilter
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`int4RangeArray\` field.\\"\\"\\"
+  """Filter by the object’s \`int4RangeArray\` field."""
   int4RangeArray: IntRangeListFilter
 
-  \\"\\"\\"Filter by the object’s \`int8RangeArray\` field.\\"\\"\\"
+  """Filter by the object’s \`int8RangeArray\` field."""
   int8RangeArray: BigIntRangeListFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: RangeArrayTypeFilter
 
-  \\"\\"\\"Filter by the object’s \`numericRangeArray\` field.\\"\\"\\"
+  """Filter by the object’s \`numericRangeArray\` field."""
   numericRangeArray: BigFloatRangeListFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [RangeArrayTypeFilter!]
 
-  \\"\\"\\"Filter by the object’s \`timestampRangeArray\` field.\\"\\"\\"
+  """Filter by the object’s \`timestampRangeArray\` field."""
   timestampRangeArray: DatetimeRangeListFilter
 
-  \\"\\"\\"Filter by the object’s \`timestamptzRangeArray\` field.\\"\\"\\"
+  """Filter by the object’s \`timestamptzRangeArray\` field."""
   timestamptzRangeArray: DatetimeRangeListFilter
 }
 
-\\"\\"\\"A connection to a list of \`RangeArrayType\` values.\\"\\"\\"
+"""A connection to a list of \`RangeArrayType\` values."""
 type RangeArrayTypesConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`RangeArrayType\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [RangeArrayTypesEdge!]!
 
-  \\"\\"\\"A list of \`RangeArrayType\` objects.\\"\\"\\"
+  """A list of \`RangeArrayType\` objects."""
   nodes: [RangeArrayType]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`RangeArrayType\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`RangeArrayType\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`RangeArrayType\` edge in the connection.\\"\\"\\"
+"""A \`RangeArrayType\` edge in the connection."""
 type RangeArrayTypesEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`RangeArrayType\` at the end of the edge.\\"\\"\\"
+  """The \`RangeArrayType\` at the end of the edge."""
   node: RangeArrayType
 }
 
-\\"\\"\\"Methods to use when ordering \`RangeArrayType\`.\\"\\"\\"
+"""Methods to use when ordering \`RangeArrayType\`."""
 enum RangeArrayTypesOrderBy {
   DATE_RANGE_ARRAY_ASC
   DATE_RANGE_ARRAY_DESC
@@ -6289,77 +6289,77 @@ type RangeType implements Node {
   int4Range: IntRange
   int8Range: BigIntRange
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
   numericRange: BigFloatRange
   timestampRange: DatetimeRange
   timestamptzRange: DatetimeRange
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`RangeType\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input RangeTypeFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [RangeTypeFilter!]
 
-  \\"\\"\\"Filter by the object’s \`dateRange\` field.\\"\\"\\"
+  """Filter by the object’s \`dateRange\` field."""
   dateRange: DateRangeFilter
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`int4Range\` field.\\"\\"\\"
+  """Filter by the object’s \`int4Range\` field."""
   int4Range: IntRangeFilter
 
-  \\"\\"\\"Filter by the object’s \`int8Range\` field.\\"\\"\\"
+  """Filter by the object’s \`int8Range\` field."""
   int8Range: BigIntRangeFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: RangeTypeFilter
 
-  \\"\\"\\"Filter by the object’s \`numericRange\` field.\\"\\"\\"
+  """Filter by the object’s \`numericRange\` field."""
   numericRange: BigFloatRangeFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [RangeTypeFilter!]
 
-  \\"\\"\\"Filter by the object’s \`timestampRange\` field.\\"\\"\\"
+  """Filter by the object’s \`timestampRange\` field."""
   timestampRange: DatetimeRangeFilter
 
-  \\"\\"\\"Filter by the object’s \`timestamptzRange\` field.\\"\\"\\"
+  """Filter by the object’s \`timestamptzRange\` field."""
   timestamptzRange: DatetimeRangeFilter
 }
 
-\\"\\"\\"A connection to a list of \`RangeType\` values.\\"\\"\\"
+"""A connection to a list of \`RangeType\` values."""
 type RangeTypesConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`RangeType\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [RangeTypesEdge!]!
 
-  \\"\\"\\"A list of \`RangeType\` objects.\\"\\"\\"
+  """A list of \`RangeType\` objects."""
   nodes: [RangeType]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`RangeType\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`RangeType\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`RangeType\` edge in the connection.\\"\\"\\"
+"""A \`RangeType\` edge in the connection."""
 type RangeTypesEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`RangeType\` at the end of the edge.\\"\\"\\"
+  """The \`RangeType\` at the end of the edge."""
   node: RangeType
 }
 
-\\"\\"\\"Methods to use when ordering \`RangeType\`.\\"\\"\\"
+"""Methods to use when ordering \`RangeType\`."""
 enum RangeTypesOrderBy {
   DATE_RANGE_ASC
   DATE_RANGE_DESC
@@ -6383,112 +6383,112 @@ enum RangeTypesOrderBy {
 type SideA implements Node {
   aId: Int!
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Junction\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Junction\`."""
   junctions(
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: JunctionFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Skip the first \`n\` values.\\"\\"\\"
+    """Skip the first \`n\` values."""
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`Junction\`.\\"\\"\\"
+    """The method to use when ordering \`Junction\`."""
     orderBy: [JunctionsOrderBy!]
   ): [Junction!]!
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Junction\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Junction\`."""
   junctionsConnection(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: JunctionFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`Junction\`.\\"\\"\\"
+    """The method to use when ordering \`Junction\`."""
     orderBy: [JunctionsOrderBy!] = [PRIMARY_KEY_ASC]
   ): JunctionsConnection!
   name: String!
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`SideA\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input SideAFilter {
-  \\"\\"\\"Filter by the object’s \`aId\` field.\\"\\"\\"
+  """Filter by the object’s \`aId\` field."""
   aId: IntFilter
 
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [SideAFilter!]
 
-  \\"\\"\\"Filter by the object’s \`junctions\` relation.\\"\\"\\"
+  """Filter by the object’s \`junctions\` relation."""
   junctions: SideAToManyJunctionFilter
 
-  \\"\\"\\"Some related \`junctions\` exist.\\"\\"\\"
+  """Some related \`junctions\` exist."""
   junctionsExist: Boolean
 
-  \\"\\"\\"Filter by the object’s \`name\` field.\\"\\"\\"
+  """Filter by the object’s \`name\` field."""
   name: StringFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: SideAFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [SideAFilter!]
 }
 
-\\"\\"\\"A connection to a list of \`SideA\` values.\\"\\"\\"
+"""A connection to a list of \`SideA\` values."""
 type SideAsConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`SideA\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [SideAsEdge!]!
 
-  \\"\\"\\"A list of \`SideA\` objects.\\"\\"\\"
+  """A list of \`SideA\` objects."""
   nodes: [SideA]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`SideA\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`SideA\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`SideA\` edge in the connection.\\"\\"\\"
+"""A \`SideA\` edge in the connection."""
 type SideAsEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`SideA\` at the end of the edge.\\"\\"\\"
+  """The \`SideA\` at the end of the edge."""
   node: SideA
 }
 
-\\"\\"\\"Methods to use when ordering \`SideA\`.\\"\\"\\"
+"""Methods to use when ordering \`SideA\`."""
 enum SideAsOrderBy {
   A_ID_ASC
   A_ID_DESC
@@ -6499,135 +6499,135 @@ enum SideAsOrderBy {
   PRIMARY_KEY_DESC
 }
 
-\\"\\"\\"
+"""
 A filter to be used against many \`Junction\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input SideAToManyJunctionFilter {
-  \\"\\"\\"
+  """
   Every related \`Junction\` matches the filter criteria. All fields are combined with a logical ‘and.’
-  \\"\\"\\"
+  """
   every: JunctionFilter
 
-  \\"\\"\\"
+  """
   No related \`Junction\` matches the filter criteria. All fields are combined with a logical ‘and.’
-  \\"\\"\\"
+  """
   none: JunctionFilter
 
-  \\"\\"\\"
+  """
   Some related \`Junction\` matches the filter criteria. All fields are combined with a logical ‘and.’
-  \\"\\"\\"
+  """
   some: JunctionFilter
 }
 
 type SideB implements Node {
   bId: Int!
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Junction\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Junction\`."""
   junctions(
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: JunctionFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Skip the first \`n\` values.\\"\\"\\"
+    """Skip the first \`n\` values."""
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`Junction\`.\\"\\"\\"
+    """The method to use when ordering \`Junction\`."""
     orderBy: [JunctionsOrderBy!]
   ): [Junction!]!
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Junction\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Junction\`."""
   junctionsConnection(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: JunctionFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`Junction\`.\\"\\"\\"
+    """The method to use when ordering \`Junction\`."""
     orderBy: [JunctionsOrderBy!] = [PRIMARY_KEY_ASC]
   ): JunctionsConnection!
   name: String!
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`SideB\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input SideBFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [SideBFilter!]
 
-  \\"\\"\\"Filter by the object’s \`bId\` field.\\"\\"\\"
+  """Filter by the object’s \`bId\` field."""
   bId: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`junctions\` relation.\\"\\"\\"
+  """Filter by the object’s \`junctions\` relation."""
   junctions: SideBToManyJunctionFilter
 
-  \\"\\"\\"Some related \`junctions\` exist.\\"\\"\\"
+  """Some related \`junctions\` exist."""
   junctionsExist: Boolean
 
-  \\"\\"\\"Filter by the object’s \`name\` field.\\"\\"\\"
+  """Filter by the object’s \`name\` field."""
   name: StringFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: SideBFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [SideBFilter!]
 }
 
-\\"\\"\\"A connection to a list of \`SideB\` values.\\"\\"\\"
+"""A connection to a list of \`SideB\` values."""
 type SideBsConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`SideB\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [SideBsEdge!]!
 
-  \\"\\"\\"A list of \`SideB\` objects.\\"\\"\\"
+  """A list of \`SideB\` objects."""
   nodes: [SideB]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`SideB\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`SideB\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`SideB\` edge in the connection.\\"\\"\\"
+"""A \`SideB\` edge in the connection."""
 type SideBsEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`SideB\` at the end of the edge.\\"\\"\\"
+  """The \`SideB\` at the end of the edge."""
   node: SideB
 }
 
-\\"\\"\\"Methods to use when ordering \`SideB\`.\\"\\"\\"
+"""Methods to use when ordering \`SideB\`."""
 enum SideBsOrderBy {
   B_ID_ASC
   B_ID_DESC
@@ -6638,419 +6638,419 @@ enum SideBsOrderBy {
   PRIMARY_KEY_DESC
 }
 
-\\"\\"\\"
+"""
 A filter to be used against many \`Junction\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input SideBToManyJunctionFilter {
-  \\"\\"\\"
+  """
   Every related \`Junction\` matches the filter criteria. All fields are combined with a logical ‘and.’
-  \\"\\"\\"
+  """
   every: JunctionFilter
 
-  \\"\\"\\"
+  """
   No related \`Junction\` matches the filter criteria. All fields are combined with a logical ‘and.’
-  \\"\\"\\"
+  """
   none: JunctionFilter
 
-  \\"\\"\\"
+  """
   Some related \`Junction\` matches the filter criteria. All fields are combined with a logical ‘and.’
-  \\"\\"\\"
+  """
   some: JunctionFilter
 }
 
-\\"\\"\\"
+"""
 A filter to be used against String fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input StringFilter {
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: String
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value (case-insensitive).
-  \\"\\"\\"
+  """
   distinctFromInsensitive: String
 
-  \\"\\"\\"Ends with the specified string (case-sensitive).\\"\\"\\"
+  """Ends with the specified string (case-sensitive)."""
   endsWith: String
 
-  \\"\\"\\"Ends with the specified string (case-insensitive).\\"\\"\\"
+  """Ends with the specified string (case-insensitive)."""
   endsWithInsensitive: String
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: String
 
-  \\"\\"\\"Equal to the specified value (case-insensitive).\\"\\"\\"
+  """Equal to the specified value (case-insensitive)."""
   equalToInsensitive: String
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: String
 
-  \\"\\"\\"Greater than the specified value (case-insensitive).\\"\\"\\"
+  """Greater than the specified value (case-insensitive)."""
   greaterThanInsensitive: String
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: String
 
-  \\"\\"\\"Greater than or equal to the specified value (case-insensitive).\\"\\"\\"
+  """Greater than or equal to the specified value (case-insensitive)."""
   greaterThanOrEqualToInsensitive: String
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [String!]
 
-  \\"\\"\\"Included in the specified list (case-insensitive).\\"\\"\\"
-  inInsensitive: [String!]
-
-  \\"\\"\\"Contains the specified string (case-sensitive).\\"\\"\\"
+  """Contains the specified string (case-sensitive)."""
   includes: String
 
-  \\"\\"\\"Contains the specified string (case-insensitive).\\"\\"\\"
+  """Contains the specified string (case-insensitive)."""
   includesInsensitive: String
 
-  \\"\\"\\"
+  """Included in the specified list (case-insensitive)."""
+  inInsensitive: [String!]
+
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: String
 
-  \\"\\"\\"Less than the specified value (case-insensitive).\\"\\"\\"
+  """Less than the specified value (case-insensitive)."""
   lessThanInsensitive: String
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: String
 
-  \\"\\"\\"Less than or equal to the specified value (case-insensitive).\\"\\"\\"
+  """Less than or equal to the specified value (case-insensitive)."""
   lessThanOrEqualToInsensitive: String
 
-  \\"\\"\\"
+  """
   Matches the specified pattern (case-sensitive). An underscore (_) matches any
   single character; a percent sign (%) matches any sequence of zero or more characters.
-  \\"\\"\\"
+  """
   like: String
 
-  \\"\\"\\"
+  """
   Matches the specified pattern (case-insensitive). An underscore (_) matches
   any single character; a percent sign (%) matches any sequence of zero or more characters.
-  \\"\\"\\"
+  """
   likeInsensitive: String
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: String
 
-  \\"\\"\\"
+  """
   Equal to the specified value, treating null like an ordinary value (case-insensitive).
-  \\"\\"\\"
+  """
   notDistinctFromInsensitive: String
 
-  \\"\\"\\"Does not end with the specified string (case-sensitive).\\"\\"\\"
+  """Does not end with the specified string (case-sensitive)."""
   notEndsWith: String
 
-  \\"\\"\\"Does not end with the specified string (case-insensitive).\\"\\"\\"
+  """Does not end with the specified string (case-insensitive)."""
   notEndsWithInsensitive: String
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: String
 
-  \\"\\"\\"Not equal to the specified value (case-insensitive).\\"\\"\\"
+  """Not equal to the specified value (case-insensitive)."""
   notEqualToInsensitive: String
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [String!]
 
-  \\"\\"\\"Not included in the specified list (case-insensitive).\\"\\"\\"
-  notInInsensitive: [String!]
-
-  \\"\\"\\"Does not contain the specified string (case-sensitive).\\"\\"\\"
+  """Does not contain the specified string (case-sensitive)."""
   notIncludes: String
 
-  \\"\\"\\"Does not contain the specified string (case-insensitive).\\"\\"\\"
+  """Does not contain the specified string (case-insensitive)."""
   notIncludesInsensitive: String
 
-  \\"\\"\\"
+  """Not included in the specified list (case-insensitive)."""
+  notInInsensitive: [String!]
+
+  """
   Does not match the specified pattern (case-sensitive). An underscore (_)
   matches any single character; a percent sign (%) matches any sequence of zero
   or more characters.
-  \\"\\"\\"
+  """
   notLike: String
 
-  \\"\\"\\"
+  """
   Does not match the specified pattern (case-insensitive). An underscore (_)
   matches any single character; a percent sign (%) matches any sequence of zero
   or more characters.
-  \\"\\"\\"
+  """
   notLikeInsensitive: String
 
-  \\"\\"\\"Does not start with the specified string (case-sensitive).\\"\\"\\"
+  """Does not start with the specified string (case-sensitive)."""
   notStartsWith: String
 
-  \\"\\"\\"Does not start with the specified string (case-insensitive).\\"\\"\\"
+  """Does not start with the specified string (case-insensitive)."""
   notStartsWithInsensitive: String
 
-  \\"\\"\\"Starts with the specified string (case-sensitive).\\"\\"\\"
+  """Starts with the specified string (case-sensitive)."""
   startsWith: String
 
-  \\"\\"\\"Starts with the specified string (case-insensitive).\\"\\"\\"
+  """Starts with the specified string (case-insensitive)."""
   startsWithInsensitive: String
 }
 
-\\"\\"\\"
+"""
 A filter to be used against String List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input StringListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: String
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: String
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: String
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: String
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: String
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: String
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [String]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [String]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [String]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [String]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [String]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [String]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [String]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [String]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [String]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [String]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [String]
 }
 
-\\"\\"\\"
+"""
 The exact time of day, does not include the date. May or may not have a timezone offset.
-\\"\\"\\"
+"""
 scalar Time
 
-\\"\\"\\"
+"""
 A filter to be used against Time fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input TimeFilter {
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: Time
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: Time
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: Time
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: Time
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [Time!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: Time
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: Time
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: Time
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: Time
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [Time!]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against Time List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input TimeListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: Time
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: Time
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: Time
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: Time
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: Time
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: Time
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [Time]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [Time]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [Time]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [Time]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [Time]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [Time]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [Time]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [Time]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [Time]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [Time]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [Time]
 }
 
 type Unfilterable implements Node {
-  \\"\\"\\"Reads and enables pagination through a set of \`ChildNoRelatedFilter\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`ChildNoRelatedFilter\`."""
   childNoRelatedFilters(
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: ChildNoRelatedFilterFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Skip the first \`n\` values.\\"\\"\\"
+    """Skip the first \`n\` values."""
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`ChildNoRelatedFilter\`.\\"\\"\\"
+    """The method to use when ordering \`ChildNoRelatedFilter\`."""
     orderBy: [ChildNoRelatedFiltersOrderBy!]
   ): [ChildNoRelatedFilter!]!
 
-  \\"\\"\\"Reads and enables pagination through a set of \`ChildNoRelatedFilter\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`ChildNoRelatedFilter\`."""
   childNoRelatedFiltersConnection(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: ChildNoRelatedFilterFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`ChildNoRelatedFilter\`.\\"\\"\\"
+    """The method to use when ordering \`ChildNoRelatedFilter\`."""
     orderBy: [ChildNoRelatedFiltersOrderBy!] = [PRIMARY_KEY_ASC]
   ): ChildNoRelatedFiltersConnection!
   id: Int!
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
   text: String
 }
 
-\\"\\"\\"A connection to a list of \`Unfilterable\` values.\\"\\"\\"
+"""A connection to a list of \`Unfilterable\` values."""
 type UnfilterablesConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`Unfilterable\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [UnfilterablesEdge!]!
 
-  \\"\\"\\"A list of \`Unfilterable\` objects.\\"\\"\\"
+  """A list of \`Unfilterable\` objects."""
   nodes: [Unfilterable]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`Unfilterable\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`Unfilterable\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`Unfilterable\` edge in the connection.\\"\\"\\"
+"""A \`Unfilterable\` edge in the connection."""
 type UnfilterablesEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`Unfilterable\` at the end of the edge.\\"\\"\\"
+  """The \`Unfilterable\` at the end of the edge."""
   node: Unfilterable
 }
 
-\\"\\"\\"Methods to use when ordering \`Unfilterable\`.\\"\\"\\"
+"""Methods to use when ordering \`Unfilterable\`."""
 enum UnfilterablesOrderBy {
   ID_ASC
   ID_DESC
@@ -7061,114 +7061,114 @@ enum UnfilterablesOrderBy {
   TEXT_DESC
 }
 
-\\"\\"\\"
+"""
 A universally unique identifier as defined by [RFC 4122](https://tools.ietf.org/html/rfc4122).
-\\"\\"\\"
+"""
 scalar UUID
 
-\\"\\"\\"
+"""
 A filter to be used against UUID fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input UUIDFilter {
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: UUID
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: UUID
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: UUID
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: UUID
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [UUID!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: UUID
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: UUID
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: UUID
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: UUID
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [UUID!]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against UUID List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input UUIDListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: UUID
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: UUID
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: UUID
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: UUID
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: UUID
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: UUID
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [UUID]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [UUID]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [UUID]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [UUID]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [UUID]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [UUID]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [UUID]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [UUID]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [UUID]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [UUID]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [UUID]
 }
-"
+
 `;

--- a/__tests__/integration/schema/__snapshots__/setofFunctionsFalse.test.ts.snap
+++ b/__tests__/integration/schema/__snapshots__/setofFunctionsFalse.test.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`prints a schema with the filter plugin and the \`connectionFilterSetofFunctions: false\` option 1`] = `
-"type ArrayType implements Node {
+type ArrayType implements Node {
   bit4Array: [BitString]
   boolArray: [Boolean]
   bpchar4Array: [String]
@@ -25,9 +25,9 @@ exports[`prints a schema with the filter plugin and the \`connectionFilterSetofF
   moneyArray: [Float]
   nameArray: [String]
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
   numericArray: [BigFloat]
   textArray: [String]
@@ -41,128 +41,128 @@ exports[`prints a schema with the filter plugin and the \`connectionFilterSetofF
   xmlArray: [String]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`ArrayType\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input ArrayTypeFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [ArrayTypeFilter!]
 
-  \\"\\"\\"Filter by the object’s \`bit4Array\` field.\\"\\"\\"
+  """Filter by the object’s \`bit4Array\` field."""
   bit4Array: BitStringListFilter
 
-  \\"\\"\\"Filter by the object’s \`boolArray\` field.\\"\\"\\"
+  """Filter by the object’s \`boolArray\` field."""
   boolArray: BooleanListFilter
 
-  \\"\\"\\"Filter by the object’s \`bpchar4Array\` field.\\"\\"\\"
+  """Filter by the object’s \`bpchar4Array\` field."""
   bpchar4Array: StringListFilter
 
-  \\"\\"\\"Filter by the object’s \`char4Array\` field.\\"\\"\\"
+  """Filter by the object’s \`char4Array\` field."""
   char4Array: StringListFilter
 
-  \\"\\"\\"Filter by the object’s \`citextArray\` field.\\"\\"\\"
+  """Filter by the object’s \`citextArray\` field."""
   citextArray: StringListFilter
 
-  \\"\\"\\"Filter by the object’s \`dateArray\` field.\\"\\"\\"
+  """Filter by the object’s \`dateArray\` field."""
   dateArray: DateListFilter
 
-  \\"\\"\\"Filter by the object’s \`float4Array\` field.\\"\\"\\"
+  """Filter by the object’s \`float4Array\` field."""
   float4Array: FloatListFilter
 
-  \\"\\"\\"Filter by the object’s \`float8Array\` field.\\"\\"\\"
+  """Filter by the object’s \`float8Array\` field."""
   float8Array: FloatListFilter
 
-  \\"\\"\\"Filter by the object’s \`hstoreArray\` field.\\"\\"\\"
+  """Filter by the object’s \`hstoreArray\` field."""
   hstoreArray: KeyValueHashListFilter
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`inetArray\` field.\\"\\"\\"
+  """Filter by the object’s \`inetArray\` field."""
   inetArray: InternetAddressListFilter
 
-  \\"\\"\\"Filter by the object’s \`int2Array\` field.\\"\\"\\"
+  """Filter by the object’s \`int2Array\` field."""
   int2Array: IntListFilter
 
-  \\"\\"\\"Filter by the object’s \`int4Array\` field.\\"\\"\\"
+  """Filter by the object’s \`int4Array\` field."""
   int4Array: IntListFilter
 
-  \\"\\"\\"Filter by the object’s \`int8Array\` field.\\"\\"\\"
+  """Filter by the object’s \`int8Array\` field."""
   int8Array: BigIntListFilter
 
-  \\"\\"\\"Filter by the object’s \`intervalArray\` field.\\"\\"\\"
+  """Filter by the object’s \`intervalArray\` field."""
   intervalArray: IntervalListFilter
 
-  \\"\\"\\"Filter by the object’s \`jsonbArray\` field.\\"\\"\\"
+  """Filter by the object’s \`jsonbArray\` field."""
   jsonbArray: JSONListFilter
 
-  \\"\\"\\"Filter by the object’s \`moneyArray\` field.\\"\\"\\"
+  """Filter by the object’s \`moneyArray\` field."""
   moneyArray: FloatListFilter
 
-  \\"\\"\\"Filter by the object’s \`nameArray\` field.\\"\\"\\"
+  """Filter by the object’s \`nameArray\` field."""
   nameArray: StringListFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: ArrayTypeFilter
 
-  \\"\\"\\"Filter by the object’s \`numericArray\` field.\\"\\"\\"
+  """Filter by the object’s \`numericArray\` field."""
   numericArray: BigFloatListFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [ArrayTypeFilter!]
 
-  \\"\\"\\"Filter by the object’s \`textArray\` field.\\"\\"\\"
+  """Filter by the object’s \`textArray\` field."""
   textArray: StringListFilter
 
-  \\"\\"\\"Filter by the object’s \`timeArray\` field.\\"\\"\\"
+  """Filter by the object’s \`timeArray\` field."""
   timeArray: TimeListFilter
 
-  \\"\\"\\"Filter by the object’s \`timestampArray\` field.\\"\\"\\"
+  """Filter by the object’s \`timestampArray\` field."""
   timestampArray: DatetimeListFilter
 
-  \\"\\"\\"Filter by the object’s \`timestamptzArray\` field.\\"\\"\\"
+  """Filter by the object’s \`timestamptzArray\` field."""
   timestamptzArray: DatetimeListFilter
 
-  \\"\\"\\"Filter by the object’s \`timetzArray\` field.\\"\\"\\"
+  """Filter by the object’s \`timetzArray\` field."""
   timetzArray: TimeListFilter
 
-  \\"\\"\\"Filter by the object’s \`uuidArray\` field.\\"\\"\\"
+  """Filter by the object’s \`uuidArray\` field."""
   uuidArray: UUIDListFilter
 
-  \\"\\"\\"Filter by the object’s \`varbitArray\` field.\\"\\"\\"
+  """Filter by the object’s \`varbitArray\` field."""
   varbitArray: BitStringListFilter
 
-  \\"\\"\\"Filter by the object’s \`varcharArray\` field.\\"\\"\\"
+  """Filter by the object’s \`varcharArray\` field."""
   varcharArray: StringListFilter
 }
 
-\\"\\"\\"A connection to a list of \`ArrayType\` values.\\"\\"\\"
+"""A connection to a list of \`ArrayType\` values."""
 type ArrayTypesConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`ArrayType\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [ArrayTypesEdge!]!
 
-  \\"\\"\\"A list of \`ArrayType\` objects.\\"\\"\\"
+  """A list of \`ArrayType\` objects."""
   nodes: [ArrayType]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`ArrayType\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`ArrayType\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`ArrayType\` edge in the connection.\\"\\"\\"
+"""A \`ArrayType\` edge in the connection."""
 type ArrayTypesEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`ArrayType\` at the end of the edge.\\"\\"\\"
+  """The \`ArrayType\` at the end of the edge."""
   node: ArrayType
 }
 
-\\"\\"\\"Methods to use when ordering \`ArrayType\`.\\"\\"\\"
+"""Methods to use when ordering \`ArrayType\`."""
 enum ArrayTypesOrderBy {
   BIT4_ARRAY_ASC
   BIT4_ARRAY_DESC
@@ -234,15 +234,15 @@ enum ArrayTypesOrderBy {
 }
 
 type Backward implements Node {
-  \\"\\"\\"Reads a single \`Filterable\` that is related to this \`Backward\`.\\"\\"\\"
+  """Reads a single \`Filterable\` that is related to this \`Backward\`."""
   filterableByFilterableId: Filterable
   filterableId: Int
   id: Int!
   name: String!
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
@@ -250,70 +250,70 @@ type BackwardCompound implements Node {
   backwardCompound1: Int!
   backwardCompound2: Int!
 
-  \\"\\"\\"
+  """
   Reads a single \`Filterable\` that is related to this \`BackwardCompound\`.
-  \\"\\"\\"
+  """
   filterableByBackwardCompound1AndBackwardCompound2: Filterable
   name: String
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`BackwardCompound\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input BackwardCompoundFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [BackwardCompoundFilter!]
 
-  \\"\\"\\"Filter by the object’s \`backwardCompound1\` field.\\"\\"\\"
+  """Filter by the object’s \`backwardCompound1\` field."""
   backwardCompound1: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`backwardCompound2\` field.\\"\\"\\"
+  """Filter by the object’s \`backwardCompound2\` field."""
   backwardCompound2: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`name\` field.\\"\\"\\"
+  """Filter by the object’s \`name\` field."""
   name: StringFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: BackwardCompoundFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [BackwardCompoundFilter!]
 }
 
-\\"\\"\\"A connection to a list of \`BackwardCompound\` values.\\"\\"\\"
+"""A connection to a list of \`BackwardCompound\` values."""
 type BackwardCompoundsConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`BackwardCompound\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [BackwardCompoundsEdge!]!
 
-  \\"\\"\\"A list of \`BackwardCompound\` objects.\\"\\"\\"
+  """A list of \`BackwardCompound\` objects."""
   nodes: [BackwardCompound]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"
+  """
   The count of *all* \`BackwardCompound\` you could get from the connection.
-  \\"\\"\\"
+  """
   totalCount: Int!
 }
 
-\\"\\"\\"A \`BackwardCompound\` edge in the connection.\\"\\"\\"
+"""A \`BackwardCompound\` edge in the connection."""
 type BackwardCompoundsEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`BackwardCompound\` at the end of the edge.\\"\\"\\"
+  """The \`BackwardCompound\` at the end of the edge."""
   node: BackwardCompound
 }
 
-\\"\\"\\"Methods to use when ordering \`BackwardCompound\`.\\"\\"\\"
+"""Methods to use when ordering \`BackwardCompound\`."""
 enum BackwardCompoundsOrderBy {
   BACKWARD_COMPOUND_1_ASC
   BACKWARD_COMPOUND_1_DESC
@@ -326,56 +326,56 @@ enum BackwardCompoundsOrderBy {
   PRIMARY_KEY_DESC
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`Backward\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input BackwardFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [BackwardFilter!]
 
-  \\"\\"\\"Filter by the object’s \`filterableId\` field.\\"\\"\\"
+  """Filter by the object’s \`filterableId\` field."""
   filterableId: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`name\` field.\\"\\"\\"
+  """Filter by the object’s \`name\` field."""
   name: StringFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: BackwardFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [BackwardFilter!]
 }
 
-\\"\\"\\"A connection to a list of \`Backward\` values.\\"\\"\\"
+"""A connection to a list of \`Backward\` values."""
 type BackwardsConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`Backward\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [BackwardsEdge!]!
 
-  \\"\\"\\"A list of \`Backward\` objects.\\"\\"\\"
+  """A list of \`Backward\` objects."""
   nodes: [Backward]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`Backward\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`Backward\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`Backward\` edge in the connection.\\"\\"\\"
+"""A \`Backward\` edge in the connection."""
 type BackwardsEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`Backward\` at the end of the edge.\\"\\"\\"
+  """The \`Backward\` at the end of the edge."""
   node: Backward
 }
 
-\\"\\"\\"Methods to use when ordering \`Backward\`.\\"\\"\\"
+"""Methods to use when ordering \`Backward\`."""
 enum BackwardsOrderBy {
   FILTERABLE_ID_ASC
   FILTERABLE_ID_DESC
@@ -388,1037 +388,1037 @@ enum BackwardsOrderBy {
   PRIMARY_KEY_DESC
 }
 
-\\"\\"\\"
+"""
 A floating point number that requires more precision than IEEE 754 binary 64
-\\"\\"\\"
+"""
 scalar BigFloat
 
-\\"\\"\\"
+"""
 A filter to be used against BigFloat fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input BigFloatFilter {
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: BigFloat
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: BigFloat
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: BigFloat
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: BigFloat
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [BigFloat!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: BigFloat
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: BigFloat
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: BigFloat
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: BigFloat
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [BigFloat!]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against BigFloat List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input BigFloatListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: BigFloat
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: BigFloat
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: BigFloat
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: BigFloat
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: BigFloat
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: BigFloat
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [BigFloat]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [BigFloat]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [BigFloat]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [BigFloat]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [BigFloat]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [BigFloat]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [BigFloat]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [BigFloat]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [BigFloat]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [BigFloat]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [BigFloat]
 }
 
-\\"\\"\\"A range of \`BigFloat\`.\\"\\"\\"
+"""A range of \`BigFloat\`."""
 type BigFloatRange {
-  \\"\\"\\"The ending bound of our range.\\"\\"\\"
+  """The ending bound of our range."""
   end: BigFloatRangeBound
 
-  \\"\\"\\"The starting bound of our range.\\"\\"\\"
+  """The starting bound of our range."""
   start: BigFloatRangeBound
 }
 
-\\"\\"\\"
+"""
 The value at one end of a range. A range can either include this value, or not.
-\\"\\"\\"
+"""
 type BigFloatRangeBound {
-  \\"\\"\\"Whether or not the value of this bound is included in the range.\\"\\"\\"
+  """Whether or not the value of this bound is included in the range."""
   inclusive: Boolean!
 
-  \\"\\"\\"The value at one end of our range.\\"\\"\\"
+  """The value at one end of our range."""
   value: BigFloat!
 }
 
-\\"\\"\\"
+"""
 The value at one end of a range. A range can either include this value, or not.
-\\"\\"\\"
+"""
 input BigFloatRangeBoundInput {
-  \\"\\"\\"Whether or not the value of this bound is included in the range.\\"\\"\\"
+  """Whether or not the value of this bound is included in the range."""
   inclusive: Boolean!
 
-  \\"\\"\\"The value at one end of our range.\\"\\"\\"
+  """The value at one end of our range."""
   value: BigFloat!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against BigFloatRange fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input BigFloatRangeFilter {
-  \\"\\"\\"Adjacent to the specified range.\\"\\"\\"
+  """Adjacent to the specified range."""
   adjacentTo: BigFloatRangeInput
 
-  \\"\\"\\"Contained by the specified range.\\"\\"\\"
+  """Contained by the specified range."""
   containedBy: BigFloatRangeInput
 
-  \\"\\"\\"Contains the specified range.\\"\\"\\"
+  """Contains the specified range."""
   contains: BigFloatRangeInput
 
-  \\"\\"\\"Contains the specified value.\\"\\"\\"
+  """Contains the specified value."""
   containsElement: BigFloat
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: BigFloatRangeInput
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: BigFloatRangeInput
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: BigFloatRangeInput
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: BigFloatRangeInput
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [BigFloatRangeInput!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: BigFloatRangeInput
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: BigFloatRangeInput
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: BigFloatRangeInput
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: BigFloatRangeInput
 
-  \\"\\"\\"Does not extend left of the specified range.\\"\\"\\"
+  """Does not extend left of the specified range."""
   notExtendsLeftOf: BigFloatRangeInput
 
-  \\"\\"\\"Does not extend right of the specified range.\\"\\"\\"
+  """Does not extend right of the specified range."""
   notExtendsRightOf: BigFloatRangeInput
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [BigFloatRangeInput!]
 
-  \\"\\"\\"Overlaps the specified range.\\"\\"\\"
+  """Overlaps the specified range."""
   overlaps: BigFloatRangeInput
 
-  \\"\\"\\"Strictly left of the specified range.\\"\\"\\"
+  """Strictly left of the specified range."""
   strictlyLeftOf: BigFloatRangeInput
 
-  \\"\\"\\"Strictly right of the specified range.\\"\\"\\"
+  """Strictly right of the specified range."""
   strictlyRightOf: BigFloatRangeInput
 }
 
-\\"\\"\\"A range of \`BigFloat\`.\\"\\"\\"
+"""A range of \`BigFloat\`."""
 input BigFloatRangeInput {
-  \\"\\"\\"The ending bound of our range.\\"\\"\\"
+  """The ending bound of our range."""
   end: BigFloatRangeBoundInput
 
-  \\"\\"\\"The starting bound of our range.\\"\\"\\"
+  """The starting bound of our range."""
   start: BigFloatRangeBoundInput
 }
 
-\\"\\"\\"
+"""
 A filter to be used against BigFloatRange List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input BigFloatRangeListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: BigFloatRangeInput
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: BigFloatRangeInput
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: BigFloatRangeInput
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: BigFloatRangeInput
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: BigFloatRangeInput
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: BigFloatRangeInput
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [BigFloatRangeInput]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [BigFloatRangeInput]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [BigFloatRangeInput]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [BigFloatRangeInput]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [BigFloatRangeInput]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [BigFloatRangeInput]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [BigFloatRangeInput]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [BigFloatRangeInput]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [BigFloatRangeInput]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [BigFloatRangeInput]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [BigFloatRangeInput]
 }
 
-\\"\\"\\"
+"""
 A signed eight-byte integer. The upper big integer values are greater than the
 max value for a JavaScript number. Therefore all big integers will be output as
 strings and not numbers.
-\\"\\"\\"
+"""
 scalar BigInt
 
-\\"\\"\\"
+"""
 A filter to be used against BigInt fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input BigIntFilter {
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: BigInt
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: BigInt
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: BigInt
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: BigInt
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [BigInt!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: BigInt
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: BigInt
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: BigInt
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: BigInt
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [BigInt!]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against BigInt List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input BigIntListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: BigInt
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: BigInt
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: BigInt
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: BigInt
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: BigInt
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: BigInt
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [BigInt]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [BigInt]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [BigInt]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [BigInt]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [BigInt]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [BigInt]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [BigInt]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [BigInt]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [BigInt]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [BigInt]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [BigInt]
 }
 
-\\"\\"\\"A range of \`BigInt\`.\\"\\"\\"
+"""A range of \`BigInt\`."""
 type BigIntRange {
-  \\"\\"\\"The ending bound of our range.\\"\\"\\"
+  """The ending bound of our range."""
   end: BigIntRangeBound
 
-  \\"\\"\\"The starting bound of our range.\\"\\"\\"
+  """The starting bound of our range."""
   start: BigIntRangeBound
 }
 
-\\"\\"\\"
+"""
 The value at one end of a range. A range can either include this value, or not.
-\\"\\"\\"
+"""
 type BigIntRangeBound {
-  \\"\\"\\"Whether or not the value of this bound is included in the range.\\"\\"\\"
+  """Whether or not the value of this bound is included in the range."""
   inclusive: Boolean!
 
-  \\"\\"\\"The value at one end of our range.\\"\\"\\"
+  """The value at one end of our range."""
   value: BigInt!
 }
 
-\\"\\"\\"
+"""
 The value at one end of a range. A range can either include this value, or not.
-\\"\\"\\"
+"""
 input BigIntRangeBoundInput {
-  \\"\\"\\"Whether or not the value of this bound is included in the range.\\"\\"\\"
+  """Whether or not the value of this bound is included in the range."""
   inclusive: Boolean!
 
-  \\"\\"\\"The value at one end of our range.\\"\\"\\"
+  """The value at one end of our range."""
   value: BigInt!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against BigIntRange fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input BigIntRangeFilter {
-  \\"\\"\\"Adjacent to the specified range.\\"\\"\\"
+  """Adjacent to the specified range."""
   adjacentTo: BigIntRangeInput
 
-  \\"\\"\\"Contained by the specified range.\\"\\"\\"
+  """Contained by the specified range."""
   containedBy: BigIntRangeInput
 
-  \\"\\"\\"Contains the specified range.\\"\\"\\"
+  """Contains the specified range."""
   contains: BigIntRangeInput
 
-  \\"\\"\\"Contains the specified value.\\"\\"\\"
+  """Contains the specified value."""
   containsElement: BigInt
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: BigIntRangeInput
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: BigIntRangeInput
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: BigIntRangeInput
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: BigIntRangeInput
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [BigIntRangeInput!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: BigIntRangeInput
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: BigIntRangeInput
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: BigIntRangeInput
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: BigIntRangeInput
 
-  \\"\\"\\"Does not extend left of the specified range.\\"\\"\\"
+  """Does not extend left of the specified range."""
   notExtendsLeftOf: BigIntRangeInput
 
-  \\"\\"\\"Does not extend right of the specified range.\\"\\"\\"
+  """Does not extend right of the specified range."""
   notExtendsRightOf: BigIntRangeInput
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [BigIntRangeInput!]
 
-  \\"\\"\\"Overlaps the specified range.\\"\\"\\"
+  """Overlaps the specified range."""
   overlaps: BigIntRangeInput
 
-  \\"\\"\\"Strictly left of the specified range.\\"\\"\\"
+  """Strictly left of the specified range."""
   strictlyLeftOf: BigIntRangeInput
 
-  \\"\\"\\"Strictly right of the specified range.\\"\\"\\"
+  """Strictly right of the specified range."""
   strictlyRightOf: BigIntRangeInput
 }
 
-\\"\\"\\"A range of \`BigInt\`.\\"\\"\\"
+"""A range of \`BigInt\`."""
 input BigIntRangeInput {
-  \\"\\"\\"The ending bound of our range.\\"\\"\\"
+  """The ending bound of our range."""
   end: BigIntRangeBoundInput
 
-  \\"\\"\\"The starting bound of our range.\\"\\"\\"
+  """The starting bound of our range."""
   start: BigIntRangeBoundInput
 }
 
-\\"\\"\\"
+"""
 A filter to be used against BigIntRange List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input BigIntRangeListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: BigIntRangeInput
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: BigIntRangeInput
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: BigIntRangeInput
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: BigIntRangeInput
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: BigIntRangeInput
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: BigIntRangeInput
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [BigIntRangeInput]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [BigIntRangeInput]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [BigIntRangeInput]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [BigIntRangeInput]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [BigIntRangeInput]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [BigIntRangeInput]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [BigIntRangeInput]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [BigIntRangeInput]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [BigIntRangeInput]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [BigIntRangeInput]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [BigIntRangeInput]
 }
 
-\\"\\"\\"A string representing a series of binary bits\\"\\"\\"
+"""A string representing a series of binary bits"""
 scalar BitString
 
-\\"\\"\\"
+"""
 A filter to be used against BitString fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input BitStringFilter {
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: BitString
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: BitString
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: BitString
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: BitString
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [BitString!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: BitString
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: BitString
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: BitString
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: BitString
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [BitString!]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against BitString List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input BitStringListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: BitString
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: BitString
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: BitString
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: BitString
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: BitString
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: BitString
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [BitString]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [BitString]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [BitString]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [BitString]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [BitString]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [BitString]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [BitString]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [BitString]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [BitString]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [BitString]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [BitString]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against Boolean fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input BooleanFilter {
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: Boolean
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: Boolean
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: Boolean
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: Boolean
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [Boolean!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: Boolean
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: Boolean
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: Boolean
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: Boolean
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [Boolean!]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against Boolean List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input BooleanListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: Boolean
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: Boolean
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: Boolean
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: Boolean
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: Boolean
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: Boolean
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [Boolean]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [Boolean]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [Boolean]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [Boolean]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [Boolean]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [Boolean]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [Boolean]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [Boolean]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [Boolean]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [Boolean]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [Boolean]
 }
 
 scalar Char4Domain
 
-\\"\\"\\"
+"""
 A filter to be used against Char4Domain fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input Char4DomainFilter {
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: Char4Domain
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value (case-insensitive).
-  \\"\\"\\"
+  """
   distinctFromInsensitive: Char4Domain
 
-  \\"\\"\\"Ends with the specified string (case-sensitive).\\"\\"\\"
+  """Ends with the specified string (case-sensitive)."""
   endsWith: Char4Domain
 
-  \\"\\"\\"Ends with the specified string (case-insensitive).\\"\\"\\"
+  """Ends with the specified string (case-insensitive)."""
   endsWithInsensitive: Char4Domain
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: Char4Domain
 
-  \\"\\"\\"Equal to the specified value (case-insensitive).\\"\\"\\"
+  """Equal to the specified value (case-insensitive)."""
   equalToInsensitive: Char4Domain
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: Char4Domain
 
-  \\"\\"\\"Greater than the specified value (case-insensitive).\\"\\"\\"
+  """Greater than the specified value (case-insensitive)."""
   greaterThanInsensitive: Char4Domain
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: Char4Domain
 
-  \\"\\"\\"Greater than or equal to the specified value (case-insensitive).\\"\\"\\"
+  """Greater than or equal to the specified value (case-insensitive)."""
   greaterThanOrEqualToInsensitive: Char4Domain
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [Char4Domain!]
 
-  \\"\\"\\"Included in the specified list (case-insensitive).\\"\\"\\"
-  inInsensitive: [Char4Domain!]
-
-  \\"\\"\\"Contains the specified string (case-sensitive).\\"\\"\\"
+  """Contains the specified string (case-sensitive)."""
   includes: Char4Domain
 
-  \\"\\"\\"Contains the specified string (case-insensitive).\\"\\"\\"
+  """Contains the specified string (case-insensitive)."""
   includesInsensitive: Char4Domain
 
-  \\"\\"\\"
+  """Included in the specified list (case-insensitive)."""
+  inInsensitive: [Char4Domain!]
+
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: Char4Domain
 
-  \\"\\"\\"Less than the specified value (case-insensitive).\\"\\"\\"
+  """Less than the specified value (case-insensitive)."""
   lessThanInsensitive: Char4Domain
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: Char4Domain
 
-  \\"\\"\\"Less than or equal to the specified value (case-insensitive).\\"\\"\\"
+  """Less than or equal to the specified value (case-insensitive)."""
   lessThanOrEqualToInsensitive: Char4Domain
 
-  \\"\\"\\"
+  """
   Matches the specified pattern (case-sensitive). An underscore (_) matches any
   single character; a percent sign (%) matches any sequence of zero or more characters.
-  \\"\\"\\"
+  """
   like: Char4Domain
 
-  \\"\\"\\"
+  """
   Matches the specified pattern (case-insensitive). An underscore (_) matches
   any single character; a percent sign (%) matches any sequence of zero or more characters.
-  \\"\\"\\"
+  """
   likeInsensitive: Char4Domain
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: Char4Domain
 
-  \\"\\"\\"
+  """
   Equal to the specified value, treating null like an ordinary value (case-insensitive).
-  \\"\\"\\"
+  """
   notDistinctFromInsensitive: Char4Domain
 
-  \\"\\"\\"Does not end with the specified string (case-sensitive).\\"\\"\\"
+  """Does not end with the specified string (case-sensitive)."""
   notEndsWith: Char4Domain
 
-  \\"\\"\\"Does not end with the specified string (case-insensitive).\\"\\"\\"
+  """Does not end with the specified string (case-insensitive)."""
   notEndsWithInsensitive: Char4Domain
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: Char4Domain
 
-  \\"\\"\\"Not equal to the specified value (case-insensitive).\\"\\"\\"
+  """Not equal to the specified value (case-insensitive)."""
   notEqualToInsensitive: Char4Domain
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [Char4Domain!]
 
-  \\"\\"\\"Not included in the specified list (case-insensitive).\\"\\"\\"
-  notInInsensitive: [Char4Domain!]
-
-  \\"\\"\\"Does not contain the specified string (case-sensitive).\\"\\"\\"
+  """Does not contain the specified string (case-sensitive)."""
   notIncludes: Char4Domain
 
-  \\"\\"\\"Does not contain the specified string (case-insensitive).\\"\\"\\"
+  """Does not contain the specified string (case-insensitive)."""
   notIncludesInsensitive: Char4Domain
 
-  \\"\\"\\"
+  """Not included in the specified list (case-insensitive)."""
+  notInInsensitive: [Char4Domain!]
+
+  """
   Does not match the specified pattern (case-sensitive). An underscore (_)
   matches any single character; a percent sign (%) matches any sequence of zero
   or more characters.
-  \\"\\"\\"
+  """
   notLike: Char4Domain
 
-  \\"\\"\\"
+  """
   Does not match the specified pattern (case-insensitive). An underscore (_)
   matches any single character; a percent sign (%) matches any sequence of zero
   or more characters.
-  \\"\\"\\"
+  """
   notLikeInsensitive: Char4Domain
 
-  \\"\\"\\"Does not start with the specified string (case-sensitive).\\"\\"\\"
+  """Does not start with the specified string (case-sensitive)."""
   notStartsWith: Char4Domain
 
-  \\"\\"\\"Does not start with the specified string (case-insensitive).\\"\\"\\"
+  """Does not start with the specified string (case-insensitive)."""
   notStartsWithInsensitive: Char4Domain
 
-  \\"\\"\\"Starts with the specified string (case-sensitive).\\"\\"\\"
+  """Starts with the specified string (case-sensitive)."""
   startsWith: Char4Domain
 
-  \\"\\"\\"Starts with the specified string (case-insensitive).\\"\\"\\"
+  """Starts with the specified string (case-insensitive)."""
   startsWithInsensitive: Char4Domain
 }
 
 type Child implements Node {
-  \\"\\"\\"Reads a single \`Filterable\` that is related to this \`Child\`.\\"\\"\\"
+  """Reads a single \`Filterable\` that is related to this \`Child\`."""
   filterableByFilterableId: Filterable
   filterableId: Int
   id: Int!
   name: String!
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`Child\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input ChildFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [ChildFilter!]
 
-  \\"\\"\\"Filter by the object’s \`filterableId\` field.\\"\\"\\"
+  """Filter by the object’s \`filterableId\` field."""
   filterableId: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`name\` field.\\"\\"\\"
+  """Filter by the object’s \`name\` field."""
   name: StringFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: ChildFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [ChildFilter!]
 }
 
 type ChildNoRelatedFilter implements Node {
-  \\"\\"\\"
+  """
   Reads a single \`Filterable\` that is related to this \`ChildNoRelatedFilter\`.
-  \\"\\"\\"
+  """
   filterableByFilterableId: Filterable
   filterableId: Int
   id: Int!
   name: String!
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 
-  \\"\\"\\"
+  """
   Reads a single \`Unfilterable\` that is related to this \`ChildNoRelatedFilter\`.
-  \\"\\"\\"
+  """
   unfilterableByUnfilterableId: Unfilterable
   unfilterableId: Int
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`ChildNoRelatedFilter\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input ChildNoRelatedFilterFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [ChildNoRelatedFilterFilter!]
 
-  \\"\\"\\"Filter by the object’s \`filterableId\` field.\\"\\"\\"
+  """Filter by the object’s \`filterableId\` field."""
   filterableId: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`name\` field.\\"\\"\\"
+  """Filter by the object’s \`name\` field."""
   name: StringFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: ChildNoRelatedFilterFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [ChildNoRelatedFilterFilter!]
 
-  \\"\\"\\"Filter by the object’s \`unfilterableId\` field.\\"\\"\\"
+  """Filter by the object’s \`unfilterableId\` field."""
   unfilterableId: IntFilter
 }
 
-\\"\\"\\"A connection to a list of \`ChildNoRelatedFilter\` values.\\"\\"\\"
+"""A connection to a list of \`ChildNoRelatedFilter\` values."""
 type ChildNoRelatedFiltersConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`ChildNoRelatedFilter\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [ChildNoRelatedFiltersEdge!]!
 
-  \\"\\"\\"A list of \`ChildNoRelatedFilter\` objects.\\"\\"\\"
+  """A list of \`ChildNoRelatedFilter\` objects."""
   nodes: [ChildNoRelatedFilter]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"
+  """
   The count of *all* \`ChildNoRelatedFilter\` you could get from the connection.
-  \\"\\"\\"
+  """
   totalCount: Int!
 }
 
-\\"\\"\\"A \`ChildNoRelatedFilter\` edge in the connection.\\"\\"\\"
+"""A \`ChildNoRelatedFilter\` edge in the connection."""
 type ChildNoRelatedFiltersEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`ChildNoRelatedFilter\` at the end of the edge.\\"\\"\\"
+  """The \`ChildNoRelatedFilter\` at the end of the edge."""
   node: ChildNoRelatedFilter
 }
 
-\\"\\"\\"Methods to use when ordering \`ChildNoRelatedFilter\`.\\"\\"\\"
+"""Methods to use when ordering \`ChildNoRelatedFilter\`."""
 enum ChildNoRelatedFiltersOrderBy {
   FILTERABLE_ID_ASC
   FILTERABLE_ID_DESC
@@ -1433,33 +1433,33 @@ enum ChildNoRelatedFiltersOrderBy {
   UNFILTERABLE_ID_DESC
 }
 
-\\"\\"\\"A connection to a list of \`Child\` values.\\"\\"\\"
+"""A connection to a list of \`Child\` values."""
 type ChildrenConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`Child\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [ChildrenEdge!]!
 
-  \\"\\"\\"A list of \`Child\` objects.\\"\\"\\"
+  """A list of \`Child\` objects."""
   nodes: [Child]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`Child\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`Child\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`Child\` edge in the connection.\\"\\"\\"
+"""A \`Child\` edge in the connection."""
 type ChildrenEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`Child\` at the end of the edge.\\"\\"\\"
+  """The \`Child\` at the end of the edge."""
   node: Child
 }
 
-\\"\\"\\"Methods to use when ordering \`Child\`.\\"\\"\\"
+"""Methods to use when ordering \`Child\`."""
 enum ChildrenOrderBy {
   FILTERABLE_ID_ASC
   FILTERABLE_ID_DESC
@@ -1477,633 +1477,633 @@ type Composite {
   b: String
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`Composite\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input CompositeFilter {
-  \\"\\"\\"Filter by the object’s \`a\` field.\\"\\"\\"
+  """Filter by the object’s \`a\` field."""
   a: IntFilter
 
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [CompositeFilter!]
 
-  \\"\\"\\"Filter by the object’s \`b\` field.\\"\\"\\"
+  """Filter by the object’s \`b\` field."""
   b: StringFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: CompositeFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [CompositeFilter!]
 }
 
-\\"\\"\\"A location in a connection that can be used for resuming pagination.\\"\\"\\"
+"""A location in a connection that can be used for resuming pagination."""
 scalar Cursor
 
-\\"\\"\\"The day, does not include a time.\\"\\"\\"
+"""The day, does not include a time."""
 scalar Date
 
 scalar DateDomain
 
-\\"\\"\\"
+"""
 A filter to be used against DateDomain fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input DateDomainFilter {
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: DateDomain
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: DateDomain
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: DateDomain
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: DateDomain
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [DateDomain!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: DateDomain
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: DateDomain
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: DateDomain
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: DateDomain
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [DateDomain!]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against Date fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input DateFilter {
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: Date
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: Date
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: Date
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: Date
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [Date!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: Date
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: Date
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: Date
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: Date
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [Date!]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against Date List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input DateListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: Date
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: Date
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: Date
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: Date
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: Date
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: Date
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [Date]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [Date]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [Date]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [Date]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [Date]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [Date]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [Date]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [Date]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [Date]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [Date]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [Date]
 }
 
-\\"\\"\\"A range of \`Date\`.\\"\\"\\"
+"""A range of \`Date\`."""
 type DateRange {
-  \\"\\"\\"The ending bound of our range.\\"\\"\\"
+  """The ending bound of our range."""
   end: DateRangeBound
 
-  \\"\\"\\"The starting bound of our range.\\"\\"\\"
+  """The starting bound of our range."""
   start: DateRangeBound
 }
 
-\\"\\"\\"
+"""
 The value at one end of a range. A range can either include this value, or not.
-\\"\\"\\"
+"""
 type DateRangeBound {
-  \\"\\"\\"Whether or not the value of this bound is included in the range.\\"\\"\\"
+  """Whether or not the value of this bound is included in the range."""
   inclusive: Boolean!
 
-  \\"\\"\\"The value at one end of our range.\\"\\"\\"
+  """The value at one end of our range."""
   value: Date!
 }
 
-\\"\\"\\"
+"""
 The value at one end of a range. A range can either include this value, or not.
-\\"\\"\\"
+"""
 input DateRangeBoundInput {
-  \\"\\"\\"Whether or not the value of this bound is included in the range.\\"\\"\\"
+  """Whether or not the value of this bound is included in the range."""
   inclusive: Boolean!
 
-  \\"\\"\\"The value at one end of our range.\\"\\"\\"
+  """The value at one end of our range."""
   value: Date!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against DateRange fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input DateRangeFilter {
-  \\"\\"\\"Adjacent to the specified range.\\"\\"\\"
+  """Adjacent to the specified range."""
   adjacentTo: DateRangeInput
 
-  \\"\\"\\"Contained by the specified range.\\"\\"\\"
+  """Contained by the specified range."""
   containedBy: DateRangeInput
 
-  \\"\\"\\"Contains the specified range.\\"\\"\\"
+  """Contains the specified range."""
   contains: DateRangeInput
 
-  \\"\\"\\"Contains the specified value.\\"\\"\\"
+  """Contains the specified value."""
   containsElement: Date
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: DateRangeInput
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: DateRangeInput
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: DateRangeInput
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: DateRangeInput
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [DateRangeInput!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: DateRangeInput
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: DateRangeInput
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: DateRangeInput
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: DateRangeInput
 
-  \\"\\"\\"Does not extend left of the specified range.\\"\\"\\"
+  """Does not extend left of the specified range."""
   notExtendsLeftOf: DateRangeInput
 
-  \\"\\"\\"Does not extend right of the specified range.\\"\\"\\"
+  """Does not extend right of the specified range."""
   notExtendsRightOf: DateRangeInput
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [DateRangeInput!]
 
-  \\"\\"\\"Overlaps the specified range.\\"\\"\\"
+  """Overlaps the specified range."""
   overlaps: DateRangeInput
 
-  \\"\\"\\"Strictly left of the specified range.\\"\\"\\"
+  """Strictly left of the specified range."""
   strictlyLeftOf: DateRangeInput
 
-  \\"\\"\\"Strictly right of the specified range.\\"\\"\\"
+  """Strictly right of the specified range."""
   strictlyRightOf: DateRangeInput
 }
 
-\\"\\"\\"A range of \`Date\`.\\"\\"\\"
+"""A range of \`Date\`."""
 input DateRangeInput {
-  \\"\\"\\"The ending bound of our range.\\"\\"\\"
+  """The ending bound of our range."""
   end: DateRangeBoundInput
 
-  \\"\\"\\"The starting bound of our range.\\"\\"\\"
+  """The starting bound of our range."""
   start: DateRangeBoundInput
 }
 
-\\"\\"\\"
+"""
 A filter to be used against DateRange List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input DateRangeListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: DateRangeInput
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: DateRangeInput
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: DateRangeInput
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: DateRangeInput
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: DateRangeInput
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: DateRangeInput
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [DateRangeInput]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [DateRangeInput]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [DateRangeInput]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [DateRangeInput]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [DateRangeInput]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [DateRangeInput]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [DateRangeInput]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [DateRangeInput]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [DateRangeInput]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [DateRangeInput]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [DateRangeInput]
 }
 
-\\"\\"\\"
+"""
 A point in time as described by the [ISO
 8601](https://en.wikipedia.org/wiki/ISO_8601) standard. May or may not include a timezone.
-\\"\\"\\"
+"""
 scalar Datetime
 
-\\"\\"\\"
+"""
 A filter to be used against Datetime fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input DatetimeFilter {
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: Datetime
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: Datetime
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: Datetime
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: Datetime
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [Datetime!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: Datetime
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: Datetime
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: Datetime
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: Datetime
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [Datetime!]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against Datetime List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input DatetimeListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: Datetime
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: Datetime
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: Datetime
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: Datetime
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: Datetime
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: Datetime
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [Datetime]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [Datetime]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [Datetime]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [Datetime]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [Datetime]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [Datetime]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [Datetime]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [Datetime]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [Datetime]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [Datetime]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [Datetime]
 }
 
-\\"\\"\\"A range of \`Datetime\`.\\"\\"\\"
+"""A range of \`Datetime\`."""
 type DatetimeRange {
-  \\"\\"\\"The ending bound of our range.\\"\\"\\"
+  """The ending bound of our range."""
   end: DatetimeRangeBound
 
-  \\"\\"\\"The starting bound of our range.\\"\\"\\"
+  """The starting bound of our range."""
   start: DatetimeRangeBound
 }
 
-\\"\\"\\"
+"""
 The value at one end of a range. A range can either include this value, or not.
-\\"\\"\\"
+"""
 type DatetimeRangeBound {
-  \\"\\"\\"Whether or not the value of this bound is included in the range.\\"\\"\\"
+  """Whether or not the value of this bound is included in the range."""
   inclusive: Boolean!
 
-  \\"\\"\\"The value at one end of our range.\\"\\"\\"
+  """The value at one end of our range."""
   value: Datetime!
 }
 
-\\"\\"\\"
+"""
 The value at one end of a range. A range can either include this value, or not.
-\\"\\"\\"
+"""
 input DatetimeRangeBoundInput {
-  \\"\\"\\"Whether or not the value of this bound is included in the range.\\"\\"\\"
+  """Whether or not the value of this bound is included in the range."""
   inclusive: Boolean!
 
-  \\"\\"\\"The value at one end of our range.\\"\\"\\"
+  """The value at one end of our range."""
   value: Datetime!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against DatetimeRange fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input DatetimeRangeFilter {
-  \\"\\"\\"Adjacent to the specified range.\\"\\"\\"
+  """Adjacent to the specified range."""
   adjacentTo: DatetimeRangeInput
 
-  \\"\\"\\"Contained by the specified range.\\"\\"\\"
+  """Contained by the specified range."""
   containedBy: DatetimeRangeInput
 
-  \\"\\"\\"Contains the specified range.\\"\\"\\"
+  """Contains the specified range."""
   contains: DatetimeRangeInput
 
-  \\"\\"\\"Contains the specified value.\\"\\"\\"
+  """Contains the specified value."""
   containsElement: Datetime
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: DatetimeRangeInput
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: DatetimeRangeInput
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: DatetimeRangeInput
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: DatetimeRangeInput
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [DatetimeRangeInput!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: DatetimeRangeInput
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: DatetimeRangeInput
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: DatetimeRangeInput
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: DatetimeRangeInput
 
-  \\"\\"\\"Does not extend left of the specified range.\\"\\"\\"
+  """Does not extend left of the specified range."""
   notExtendsLeftOf: DatetimeRangeInput
 
-  \\"\\"\\"Does not extend right of the specified range.\\"\\"\\"
+  """Does not extend right of the specified range."""
   notExtendsRightOf: DatetimeRangeInput
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [DatetimeRangeInput!]
 
-  \\"\\"\\"Overlaps the specified range.\\"\\"\\"
+  """Overlaps the specified range."""
   overlaps: DatetimeRangeInput
 
-  \\"\\"\\"Strictly left of the specified range.\\"\\"\\"
+  """Strictly left of the specified range."""
   strictlyLeftOf: DatetimeRangeInput
 
-  \\"\\"\\"Strictly right of the specified range.\\"\\"\\"
+  """Strictly right of the specified range."""
   strictlyRightOf: DatetimeRangeInput
 }
 
-\\"\\"\\"A range of \`Datetime\`.\\"\\"\\"
+"""A range of \`Datetime\`."""
 input DatetimeRangeInput {
-  \\"\\"\\"The ending bound of our range.\\"\\"\\"
+  """The ending bound of our range."""
   end: DatetimeRangeBoundInput
 
-  \\"\\"\\"The starting bound of our range.\\"\\"\\"
+  """The starting bound of our range."""
   start: DatetimeRangeBoundInput
 }
 
-\\"\\"\\"
+"""
 A filter to be used against DatetimeRange List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input DatetimeRangeListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: DatetimeRangeInput
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: DatetimeRangeInput
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: DatetimeRangeInput
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: DatetimeRangeInput
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: DatetimeRangeInput
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: DatetimeRangeInput
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [DatetimeRangeInput]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [DatetimeRangeInput]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [DatetimeRangeInput]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [DatetimeRangeInput]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [DatetimeRangeInput]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [DatetimeRangeInput]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [DatetimeRangeInput]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [DatetimeRangeInput]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [DatetimeRangeInput]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [DatetimeRangeInput]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [DatetimeRangeInput]
 }
 
@@ -2113,65 +2113,65 @@ type DomainType implements Node {
   id: Int!
   int4Domain: Int4Domain
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`DomainType\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input DomainTypeFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [DomainTypeFilter!]
 
-  \\"\\"\\"Filter by the object’s \`char4Domain\` field.\\"\\"\\"
+  """Filter by the object’s \`char4Domain\` field."""
   char4Domain: Char4DomainFilter
 
-  \\"\\"\\"Filter by the object’s \`dateDomain\` field.\\"\\"\\"
+  """Filter by the object’s \`dateDomain\` field."""
   dateDomain: DateDomainFilter
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`int4Domain\` field.\\"\\"\\"
+  """Filter by the object’s \`int4Domain\` field."""
   int4Domain: Int4DomainFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: DomainTypeFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [DomainTypeFilter!]
 }
 
-\\"\\"\\"A connection to a list of \`DomainType\` values.\\"\\"\\"
+"""A connection to a list of \`DomainType\` values."""
 type DomainTypesConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`DomainType\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [DomainTypesEdge!]!
 
-  \\"\\"\\"A list of \`DomainType\` objects.\\"\\"\\"
+  """A list of \`DomainType\` objects."""
   nodes: [DomainType]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`DomainType\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`DomainType\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`DomainType\` edge in the connection.\\"\\"\\"
+"""A \`DomainType\` edge in the connection."""
 type DomainTypesEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`DomainType\` at the end of the edge.\\"\\"\\"
+  """The \`DomainType\` at the end of the edge."""
   node: DomainType
 }
 
-\\"\\"\\"Methods to use when ordering \`DomainType\`.\\"\\"\\"
+"""Methods to use when ordering \`DomainType\`."""
 enum DomainTypesOrderBy {
   CHAR4_DOMAIN_ASC
   CHAR4_DOMAIN_DESC
@@ -2190,59 +2190,59 @@ type EnumArrayType implements Node {
   enumArray: [Mood]
   id: Int!
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`EnumArrayType\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input EnumArrayTypeFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [EnumArrayTypeFilter!]
 
-  \\"\\"\\"Filter by the object’s \`enumArray\` field.\\"\\"\\"
+  """Filter by the object’s \`enumArray\` field."""
   enumArray: MoodListFilter
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: EnumArrayTypeFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [EnumArrayTypeFilter!]
 }
 
-\\"\\"\\"A connection to a list of \`EnumArrayType\` values.\\"\\"\\"
+"""A connection to a list of \`EnumArrayType\` values."""
 type EnumArrayTypesConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`EnumArrayType\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [EnumArrayTypesEdge!]!
 
-  \\"\\"\\"A list of \`EnumArrayType\` objects.\\"\\"\\"
+  """A list of \`EnumArrayType\` objects."""
   nodes: [EnumArrayType]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`EnumArrayType\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`EnumArrayType\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`EnumArrayType\` edge in the connection.\\"\\"\\"
+"""A \`EnumArrayType\` edge in the connection."""
 type EnumArrayTypesEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`EnumArrayType\` at the end of the edge.\\"\\"\\"
+  """The \`EnumArrayType\` at the end of the edge."""
   node: EnumArrayType
 }
 
-\\"\\"\\"Methods to use when ordering \`EnumArrayType\`.\\"\\"\\"
+"""Methods to use when ordering \`EnumArrayType\`."""
 enum EnumArrayTypesOrderBy {
   ENUM_ARRAY_ASC
   ENUM_ARRAY_DESC
@@ -2257,59 +2257,59 @@ type EnumType implements Node {
   enum: Mood
   id: Int!
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`EnumType\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input EnumTypeFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [EnumTypeFilter!]
 
-  \\"\\"\\"Filter by the object’s \`enum\` field.\\"\\"\\"
+  """Filter by the object’s \`enum\` field."""
   enum: MoodFilter
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: EnumTypeFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [EnumTypeFilter!]
 }
 
-\\"\\"\\"A connection to a list of \`EnumType\` values.\\"\\"\\"
+"""A connection to a list of \`EnumType\` values."""
 type EnumTypesConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`EnumType\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [EnumTypesEdge!]!
 
-  \\"\\"\\"A list of \`EnumType\` objects.\\"\\"\\"
+  """A list of \`EnumType\` objects."""
   nodes: [EnumType]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`EnumType\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`EnumType\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`EnumType\` edge in the connection.\\"\\"\\"
+"""A \`EnumType\` edge in the connection."""
 type EnumTypesEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`EnumType\` at the end of the edge.\\"\\"\\"
+  """The \`EnumType\` at the end of the edge."""
   node: EnumType
 }
 
-\\"\\"\\"Methods to use when ordering \`EnumType\`.\\"\\"\\"
+"""Methods to use when ordering \`EnumType\`."""
 enum EnumTypesOrderBy {
   ENUM_ASC
   ENUM_DESC
@@ -2321,14 +2321,14 @@ enum EnumTypesOrderBy {
 }
 
 type Filterable implements Node {
-  \\"\\"\\"Reads a single \`Backward\` that is related to this \`Filterable\`.\\"\\"\\"
+  """Reads a single \`Backward\` that is related to this \`Filterable\`."""
   backwardByFilterableId: Backward
   backwardCompound1: Int
   backwardCompound2: Int
 
-  \\"\\"\\"
+  """
   Reads a single \`BackwardCompound\` that is related to this \`Filterable\`.
-  \\"\\"\\"
+  """
   backwardCompoundByBackwardCompound1AndBackwardCompound2: BackwardCompound
   bit4: BitString
   bool: Boolean
@@ -2336,61 +2336,61 @@ type Filterable implements Node {
   bytea: String
   char4: String
 
-  \\"\\"\\"Reads and enables pagination through a set of \`ChildNoRelatedFilter\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`ChildNoRelatedFilter\`."""
   childNoRelatedFiltersByFilterableId(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: ChildNoRelatedFilterFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`ChildNoRelatedFilter\`.\\"\\"\\"
+    """The method to use when ordering \`ChildNoRelatedFilter\`."""
     orderBy: [ChildNoRelatedFiltersOrderBy!] = [PRIMARY_KEY_ASC]
   ): ChildNoRelatedFiltersConnection!
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Child\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Child\`."""
   childrenByFilterableId(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: ChildFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`Child\`.\\"\\"\\"
+    """The method to use when ordering \`Child\`."""
     orderBy: [ChildrenOrderBy!] = [PRIMARY_KEY_ASC]
   ): ChildrenConnection!
   cidr: String
@@ -2401,116 +2401,116 @@ type Filterable implements Node {
   computedChild: Child
   computedIntArray: [Int]
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Child\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Child\`."""
   computedSetofChild(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
   ): ChildrenConnection!
   computedSetofInt(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
   ): FilterableComputedSetofIntConnection!
   computedTaggedFilterable: Int
   computedWithRequiredArg(i: Int!): Int
   date: Date
 
-  \\"\\"\\"Reads and enables pagination through a set of \`FilterableClosure\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`FilterableClosure\`."""
   filterableClosuresByAncestorId(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: FilterableClosureFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`FilterableClosure\`.\\"\\"\\"
+    """The method to use when ordering \`FilterableClosure\`."""
     orderBy: [FilterableClosuresOrderBy!] = [PRIMARY_KEY_ASC]
   ): FilterableClosuresConnection!
 
-  \\"\\"\\"Reads and enables pagination through a set of \`FilterableClosure\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`FilterableClosure\`."""
   filterableClosuresByDescendantId(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: FilterableClosureFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`FilterableClosure\`.\\"\\"\\"
+    """The method to use when ordering \`FilterableClosure\`."""
     orderBy: [FilterableClosuresOrderBy!] = [PRIMARY_KEY_ASC]
   ): FilterableClosuresConnection!
   float4: Float
   float8: Float
 
-  \\"\\"\\"Reads a single \`Forward\` that is related to this \`Filterable\`.\\"\\"\\"
+  """Reads a single \`Forward\` that is related to this \`Filterable\`."""
   forwardByForwardId: Forward
   forwardColumn: Forward
   forwardCompound1: Int
   forwardCompound2: Int
 
-  \\"\\"\\"Reads a single \`ForwardCompound\` that is related to this \`Filterable\`.\\"\\"\\"
+  """Reads a single \`ForwardCompound\` that is related to this \`Filterable\`."""
   forwardCompoundByForwardCompound1AndForwardCompound2: ForwardCompound
   forwardId: Int
   hstore: KeyValueHash
@@ -2526,13 +2526,13 @@ type Filterable implements Node {
   money: Float
   name: String
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
   numeric: BigFloat
 
-  \\"\\"\\"Reads a single \`Parent\` that is related to this \`Filterable\`.\\"\\"\\"
+  """Reads a single \`Parent\` that is related to this \`Filterable\`."""
   parentByParentId: Parent
   parentId: Int
   text: String
@@ -2552,78 +2552,78 @@ type FilterableClosure implements Node {
   depth: Int!
   descendantId: Int!
 
-  \\"\\"\\"
+  """
   Reads a single \`Filterable\` that is related to this \`FilterableClosure\`.
-  \\"\\"\\"
+  """
   filterableByAncestorId: Filterable
 
-  \\"\\"\\"
+  """
   Reads a single \`Filterable\` that is related to this \`FilterableClosure\`.
-  \\"\\"\\"
+  """
   filterableByDescendantId: Filterable
   id: Int!
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`FilterableClosure\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input FilterableClosureFilter {
-  \\"\\"\\"Filter by the object’s \`ancestorId\` field.\\"\\"\\"
+  """Filter by the object’s \`ancestorId\` field."""
   ancestorId: IntFilter
 
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [FilterableClosureFilter!]
 
-  \\"\\"\\"Filter by the object’s \`depth\` field.\\"\\"\\"
+  """Filter by the object’s \`depth\` field."""
   depth: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`descendantId\` field.\\"\\"\\"
+  """Filter by the object’s \`descendantId\` field."""
   descendantId: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: FilterableClosureFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [FilterableClosureFilter!]
 }
 
-\\"\\"\\"A connection to a list of \`FilterableClosure\` values.\\"\\"\\"
+"""A connection to a list of \`FilterableClosure\` values."""
 type FilterableClosuresConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`FilterableClosure\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [FilterableClosuresEdge!]!
 
-  \\"\\"\\"A list of \`FilterableClosure\` objects.\\"\\"\\"
+  """A list of \`FilterableClosure\` objects."""
   nodes: [FilterableClosure]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"
+  """
   The count of *all* \`FilterableClosure\` you could get from the connection.
-  \\"\\"\\"
+  """
   totalCount: Int!
 }
 
-\\"\\"\\"A \`FilterableClosure\` edge in the connection.\\"\\"\\"
+"""A \`FilterableClosure\` edge in the connection."""
 type FilterableClosuresEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`FilterableClosure\` at the end of the edge.\\"\\"\\"
+  """The \`FilterableClosure\` at the end of the edge."""
   node: FilterableClosure
 }
 
-\\"\\"\\"Methods to use when ordering \`FilterableClosure\`.\\"\\"\\"
+"""Methods to use when ordering \`FilterableClosure\`."""
 enum FilterableClosuresOrderBy {
   ANCESTOR_ID_ASC
   ANCESTOR_ID_DESC
@@ -2638,181 +2638,181 @@ enum FilterableClosuresOrderBy {
   PRIMARY_KEY_DESC
 }
 
-\\"\\"\\"A connection to a list of \`Int\` values.\\"\\"\\"
+"""A connection to a list of \`Int\` values."""
 type FilterableComputedSetofIntConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`Int\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [FilterableComputedSetofIntEdge!]!
 
-  \\"\\"\\"A list of \`Int\` objects.\\"\\"\\"
+  """A list of \`Int\` objects."""
   nodes: [Int]!
 
-  \\"\\"\\"The count of *all* \`Int\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`Int\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`Int\` edge in the connection.\\"\\"\\"
+"""A \`Int\` edge in the connection."""
 type FilterableComputedSetofIntEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`Int\` at the end of the edge.\\"\\"\\"
+  """The \`Int\` at the end of the edge."""
   node: Int
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`Filterable\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input FilterableFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [FilterableFilter!]
 
-  \\"\\"\\"Filter by the object’s \`backwardCompound1\` field.\\"\\"\\"
+  """Filter by the object’s \`backwardCompound1\` field."""
   backwardCompound1: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`backwardCompound2\` field.\\"\\"\\"
+  """Filter by the object’s \`backwardCompound2\` field."""
   backwardCompound2: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`bit4\` field.\\"\\"\\"
+  """Filter by the object’s \`bit4\` field."""
   bit4: BitStringFilter
 
-  \\"\\"\\"Filter by the object’s \`bool\` field.\\"\\"\\"
+  """Filter by the object’s \`bool\` field."""
   bool: BooleanFilter
 
-  \\"\\"\\"Filter by the object’s \`bpchar4\` field.\\"\\"\\"
+  """Filter by the object’s \`bpchar4\` field."""
   bpchar4: StringFilter
 
-  \\"\\"\\"Filter by the object’s \`char4\` field.\\"\\"\\"
+  """Filter by the object’s \`char4\` field."""
   char4: StringFilter
 
-  \\"\\"\\"Filter by the object’s \`citext\` field.\\"\\"\\"
+  """Filter by the object’s \`citext\` field."""
   citext: StringFilter
 
-  \\"\\"\\"Filter by the object’s \`compositeColumn\` field.\\"\\"\\"
+  """Filter by the object’s \`compositeColumn\` field."""
   compositeColumn: CompositeFilter
 
-  \\"\\"\\"Filter by the object’s \`computed\` field.\\"\\"\\"
+  """Filter by the object’s \`computed\` field."""
   computed: StringFilter
 
-  \\"\\"\\"Filter by the object’s \`computedIntArray\` field.\\"\\"\\"
+  """Filter by the object’s \`computedIntArray\` field."""
   computedIntArray: IntListFilter
 
-  \\"\\"\\"Filter by the object’s \`computedTaggedFilterable\` field.\\"\\"\\"
+  """Filter by the object’s \`computedTaggedFilterable\` field."""
   computedTaggedFilterable: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`date\` field.\\"\\"\\"
+  """Filter by the object’s \`date\` field."""
   date: DateFilter
 
-  \\"\\"\\"Filter by the object’s \`float4\` field.\\"\\"\\"
+  """Filter by the object’s \`float4\` field."""
   float4: FloatFilter
 
-  \\"\\"\\"Filter by the object’s \`float8\` field.\\"\\"\\"
+  """Filter by the object’s \`float8\` field."""
   float8: FloatFilter
 
-  \\"\\"\\"Filter by the object’s \`forwardCompound1\` field.\\"\\"\\"
+  """Filter by the object’s \`forwardCompound1\` field."""
   forwardCompound1: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`forwardCompound2\` field.\\"\\"\\"
+  """Filter by the object’s \`forwardCompound2\` field."""
   forwardCompound2: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`forwardId\` field.\\"\\"\\"
+  """Filter by the object’s \`forwardId\` field."""
   forwardId: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`hstore\` field.\\"\\"\\"
+  """Filter by the object’s \`hstore\` field."""
   hstore: KeyValueHashFilter
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`inet\` field.\\"\\"\\"
+  """Filter by the object’s \`inet\` field."""
   inet: InternetAddressFilter
 
-  \\"\\"\\"Filter by the object’s \`int2\` field.\\"\\"\\"
+  """Filter by the object’s \`int2\` field."""
   int2: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`int4\` field.\\"\\"\\"
+  """Filter by the object’s \`int4\` field."""
   int4: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`int8\` field.\\"\\"\\"
+  """Filter by the object’s \`int8\` field."""
   int8: BigIntFilter
 
-  \\"\\"\\"Filter by the object’s \`interval\` field.\\"\\"\\"
+  """Filter by the object’s \`interval\` field."""
   interval: IntervalFilter
 
-  \\"\\"\\"Filter by the object’s \`jsonb\` field.\\"\\"\\"
+  """Filter by the object’s \`jsonb\` field."""
   jsonb: JSONFilter
 
-  \\"\\"\\"Filter by the object’s \`money\` field.\\"\\"\\"
+  """Filter by the object’s \`money\` field."""
   money: FloatFilter
 
-  \\"\\"\\"Filter by the object’s \`name\` field.\\"\\"\\"
+  """Filter by the object’s \`name\` field."""
   name: StringFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: FilterableFilter
 
-  \\"\\"\\"Filter by the object’s \`numeric\` field.\\"\\"\\"
+  """Filter by the object’s \`numeric\` field."""
   numeric: BigFloatFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [FilterableFilter!]
 
-  \\"\\"\\"Filter by the object’s \`parentId\` field.\\"\\"\\"
+  """Filter by the object’s \`parentId\` field."""
   parentId: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`text\` field.\\"\\"\\"
+  """Filter by the object’s \`text\` field."""
   text: StringFilter
 
-  \\"\\"\\"Filter by the object’s \`time\` field.\\"\\"\\"
+  """Filter by the object’s \`time\` field."""
   time: TimeFilter
 
-  \\"\\"\\"Filter by the object’s \`timestamp\` field.\\"\\"\\"
+  """Filter by the object’s \`timestamp\` field."""
   timestamp: DatetimeFilter
 
-  \\"\\"\\"Filter by the object’s \`timestamptz\` field.\\"\\"\\"
+  """Filter by the object’s \`timestamptz\` field."""
   timestamptz: DatetimeFilter
 
-  \\"\\"\\"Filter by the object’s \`timetz\` field.\\"\\"\\"
+  """Filter by the object’s \`timetz\` field."""
   timetz: TimeFilter
 
-  \\"\\"\\"Filter by the object’s \`uuid\` field.\\"\\"\\"
+  """Filter by the object’s \`uuid\` field."""
   uuid: UUIDFilter
 
-  \\"\\"\\"Filter by the object’s \`varbit\` field.\\"\\"\\"
+  """Filter by the object’s \`varbit\` field."""
   varbit: BitStringFilter
 
-  \\"\\"\\"Filter by the object’s \`varchar\` field.\\"\\"\\"
+  """Filter by the object’s \`varchar\` field."""
   varchar: StringFilter
 }
 
-\\"\\"\\"A connection to a list of \`Filterable\` values.\\"\\"\\"
+"""A connection to a list of \`Filterable\` values."""
 type FilterablesConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`Filterable\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [FilterablesEdge!]!
 
-  \\"\\"\\"A list of \`Filterable\` objects.\\"\\"\\"
+  """A list of \`Filterable\` objects."""
   nodes: [Filterable]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`Filterable\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`Filterable\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`Filterable\` edge in the connection.\\"\\"\\"
+"""A \`Filterable\` edge in the connection."""
 type FilterablesEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`Filterable\` at the end of the edge.\\"\\"\\"
+  """The \`Filterable\` at the end of the edge."""
   node: Filterable
 }
 
-\\"\\"\\"Methods to use when ordering \`Filterable\`.\\"\\"\\"
+"""Methods to use when ordering \`Filterable\`."""
 enum FilterablesOrderBy {
   BACKWARD_COMPOUND_1_ASC
   BACKWARD_COMPOUND_1_DESC
@@ -2901,188 +2901,188 @@ enum FilterablesOrderBy {
   XML_DESC
 }
 
-\\"\\"\\"
+"""
 A filter to be used against Float fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input FloatFilter {
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: Float
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: Float
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: Float
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: Float
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [Float!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: Float
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: Float
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: Float
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: Float
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [Float!]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against Float List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input FloatListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: Float
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: Float
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: Float
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: Float
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: Float
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: Float
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [Float]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [Float]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [Float]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [Float]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [Float]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [Float]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [Float]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [Float]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [Float]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [Float]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [Float]
 }
 
 type Forward implements Node {
-  \\"\\"\\"Reads a single \`Filterable\` that is related to this \`Forward\`.\\"\\"\\"
+  """Reads a single \`Filterable\` that is related to this \`Forward\`."""
   filterableByForwardId: Filterable
   id: Int!
   name: String!
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
 type ForwardCompound implements Node {
-  \\"\\"\\"Reads a single \`Filterable\` that is related to this \`ForwardCompound\`.\\"\\"\\"
+  """Reads a single \`Filterable\` that is related to this \`ForwardCompound\`."""
   filterableByForwardCompound1AndForwardCompound2: Filterable
   forwardCompound1: Int!
   forwardCompound2: Int!
   name: String
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`ForwardCompound\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input ForwardCompoundFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [ForwardCompoundFilter!]
 
-  \\"\\"\\"Filter by the object’s \`forwardCompound1\` field.\\"\\"\\"
+  """Filter by the object’s \`forwardCompound1\` field."""
   forwardCompound1: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`forwardCompound2\` field.\\"\\"\\"
+  """Filter by the object’s \`forwardCompound2\` field."""
   forwardCompound2: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`name\` field.\\"\\"\\"
+  """Filter by the object’s \`name\` field."""
   name: StringFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: ForwardCompoundFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [ForwardCompoundFilter!]
 }
 
-\\"\\"\\"A connection to a list of \`ForwardCompound\` values.\\"\\"\\"
+"""A connection to a list of \`ForwardCompound\` values."""
 type ForwardCompoundsConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`ForwardCompound\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [ForwardCompoundsEdge!]!
 
-  \\"\\"\\"A list of \`ForwardCompound\` objects.\\"\\"\\"
+  """A list of \`ForwardCompound\` objects."""
   nodes: [ForwardCompound]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"
+  """
   The count of *all* \`ForwardCompound\` you could get from the connection.
-  \\"\\"\\"
+  """
   totalCount: Int!
 }
 
-\\"\\"\\"A \`ForwardCompound\` edge in the connection.\\"\\"\\"
+"""A \`ForwardCompound\` edge in the connection."""
 type ForwardCompoundsEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`ForwardCompound\` at the end of the edge.\\"\\"\\"
+  """The \`ForwardCompound\` at the end of the edge."""
   node: ForwardCompound
 }
 
-\\"\\"\\"Methods to use when ordering \`ForwardCompound\`.\\"\\"\\"
+"""Methods to use when ordering \`ForwardCompound\`."""
 enum ForwardCompoundsOrderBy {
   FORWARD_COMPOUND_1_ASC
   FORWARD_COMPOUND_1_DESC
@@ -3095,53 +3095,53 @@ enum ForwardCompoundsOrderBy {
   PRIMARY_KEY_DESC
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`Forward\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input ForwardFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [ForwardFilter!]
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`name\` field.\\"\\"\\"
+  """Filter by the object’s \`name\` field."""
   name: StringFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: ForwardFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [ForwardFilter!]
 }
 
-\\"\\"\\"A connection to a list of \`Forward\` values.\\"\\"\\"
+"""A connection to a list of \`Forward\` values."""
 type ForwardsConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`Forward\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [ForwardsEdge!]!
 
-  \\"\\"\\"A list of \`Forward\` objects.\\"\\"\\"
+  """A list of \`Forward\` objects."""
   nodes: [Forward]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`Forward\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`Forward\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`Forward\` edge in the connection.\\"\\"\\"
+"""A \`Forward\` edge in the connection."""
 type ForwardsEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`Forward\` at the end of the edge.\\"\\"\\"
+  """The \`Forward\` at the end of the edge."""
   node: Forward
 }
 
-\\"\\"\\"Methods to use when ordering \`Forward\`.\\"\\"\\"
+"""Methods to use when ordering \`Forward\`."""
 enum ForwardsOrderBy {
   ID_ASC
   ID_DESC
@@ -3155,40 +3155,40 @@ enum ForwardsOrderBy {
 type FullyOmitted implements Node {
   id: Int!
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
   text: String
 }
 
-\\"\\"\\"A connection to a list of \`FullyOmitted\` values.\\"\\"\\"
+"""A connection to a list of \`FullyOmitted\` values."""
 type FullyOmittedsConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`FullyOmitted\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [FullyOmittedsEdge!]!
 
-  \\"\\"\\"A list of \`FullyOmitted\` objects.\\"\\"\\"
+  """A list of \`FullyOmitted\` objects."""
   nodes: [FullyOmitted]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`FullyOmitted\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`FullyOmitted\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`FullyOmitted\` edge in the connection.\\"\\"\\"
+"""A \`FullyOmitted\` edge in the connection."""
 type FullyOmittedsEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`FullyOmitted\` at the end of the edge.\\"\\"\\"
+  """The \`FullyOmitted\` at the end of the edge."""
   node: FullyOmitted
 }
 
-\\"\\"\\"Methods to use when ordering \`FullyOmitted\`.\\"\\"\\"
+"""Methods to use when ordering \`FullyOmitted\`."""
 enum FullyOmittedsOrderBy {
   ID_ASC
   ID_DESC
@@ -3199,726 +3199,726 @@ enum FullyOmittedsOrderBy {
   TEXT_DESC
 }
 
-\\"\\"\\"A connection to a list of \`FuncReturnsTableMultiColRecord\` values.\\"\\"\\"
+"""A connection to a list of \`FuncReturnsTableMultiColRecord\` values."""
 type FuncReturnsTableMultiColConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`FuncReturnsTableMultiColRecord\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [FuncReturnsTableMultiColEdge!]!
 
-  \\"\\"\\"A list of \`FuncReturnsTableMultiColRecord\` objects.\\"\\"\\"
+  """A list of \`FuncReturnsTableMultiColRecord\` objects."""
   nodes: [FuncReturnsTableMultiColRecord]!
 
-  \\"\\"\\"
+  """
   The count of *all* \`FuncReturnsTableMultiColRecord\` you could get from the connection.
-  \\"\\"\\"
+  """
   totalCount: Int!
 }
 
-\\"\\"\\"A \`FuncReturnsTableMultiColRecord\` edge in the connection.\\"\\"\\"
+"""A \`FuncReturnsTableMultiColRecord\` edge in the connection."""
 type FuncReturnsTableMultiColEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`FuncReturnsTableMultiColRecord\` at the end of the edge.\\"\\"\\"
+  """The \`FuncReturnsTableMultiColRecord\` at the end of the edge."""
   node: FuncReturnsTableMultiColRecord
 }
 
-\\"\\"\\"The return type of our \`funcReturnsTableMultiCol\` query.\\"\\"\\"
+"""The return type of our \`funcReturnsTableMultiCol\` query."""
 type FuncReturnsTableMultiColRecord {
   col1: Int
   col2: String
 }
 
-\\"\\"\\"A connection to a list of \`Int\` values.\\"\\"\\"
+"""A connection to a list of \`Int\` values."""
 type FuncReturnsTableOneColConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`Int\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [FuncReturnsTableOneColEdge!]!
 
-  \\"\\"\\"A list of \`Int\` objects.\\"\\"\\"
+  """A list of \`Int\` objects."""
   nodes: [Int]!
 
-  \\"\\"\\"The count of *all* \`Int\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`Int\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`Int\` edge in the connection.\\"\\"\\"
+"""A \`Int\` edge in the connection."""
 type FuncReturnsTableOneColEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`Int\` at the end of the edge.\\"\\"\\"
+  """The \`Int\` at the end of the edge."""
   node: Int
 }
 
-\\"\\"\\"
+"""
 A connection to a list of \`FuncTaggedFilterableReturnsTableMultiColRecord\` values.
-\\"\\"\\"
+"""
 type FuncTaggedFilterableReturnsTableMultiColConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`FuncTaggedFilterableReturnsTableMultiColRecord\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [FuncTaggedFilterableReturnsTableMultiColEdge!]!
 
-  \\"\\"\\"A list of \`FuncTaggedFilterableReturnsTableMultiColRecord\` objects.\\"\\"\\"
+  """A list of \`FuncTaggedFilterableReturnsTableMultiColRecord\` objects."""
   nodes: [FuncTaggedFilterableReturnsTableMultiColRecord]!
 
-  \\"\\"\\"
+  """
   The count of *all* \`FuncTaggedFilterableReturnsTableMultiColRecord\` you could get from the connection.
-  \\"\\"\\"
+  """
   totalCount: Int!
 }
 
-\\"\\"\\"
+"""
 A \`FuncTaggedFilterableReturnsTableMultiColRecord\` edge in the connection.
-\\"\\"\\"
+"""
 type FuncTaggedFilterableReturnsTableMultiColEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"
+  """
   The \`FuncTaggedFilterableReturnsTableMultiColRecord\` at the end of the edge.
-  \\"\\"\\"
+  """
   node: FuncTaggedFilterableReturnsTableMultiColRecord
 }
 
-\\"\\"\\"
+"""
 The return type of our \`funcTaggedFilterableReturnsTableMultiCol\` query.
-\\"\\"\\"
+"""
 type FuncTaggedFilterableReturnsTableMultiColRecord {
   col1: Int
   col2: String
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`FuncTaggedFilterableReturnsTableMultiColRecord\`
 object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input FuncTaggedFilterableReturnsTableMultiColRecordFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [FuncTaggedFilterableReturnsTableMultiColRecordFilter!]
 
-  \\"\\"\\"Filter by the object’s \`col1\` field.\\"\\"\\"
+  """Filter by the object’s \`col1\` field."""
   col1: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`col2\` field.\\"\\"\\"
+  """Filter by the object’s \`col2\` field."""
   col2: StringFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: FuncTaggedFilterableReturnsTableMultiColRecordFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [FuncTaggedFilterableReturnsTableMultiColRecordFilter!]
 }
 
 scalar Int4Domain
 
-\\"\\"\\"
+"""
 A filter to be used against Int4Domain fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input Int4DomainFilter {
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: Int4Domain
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: Int4Domain
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: Int4Domain
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: Int4Domain
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [Int4Domain!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: Int4Domain
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: Int4Domain
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: Int4Domain
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: Int4Domain
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [Int4Domain!]
 }
 
-\\"\\"\\"An IPv4 or IPv6 host address, and optionally its subnet.\\"\\"\\"
+"""An IPv4 or IPv6 host address, and optionally its subnet."""
 scalar InternetAddress
 
-\\"\\"\\"
+"""
 A filter to be used against InternetAddress fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input InternetAddressFilter {
-  \\"\\"\\"Contained by the specified internet address.\\"\\"\\"
+  """Contained by the specified internet address."""
   containedBy: InternetAddress
 
-  \\"\\"\\"Contained by or equal to the specified internet address.\\"\\"\\"
+  """Contained by or equal to the specified internet address."""
   containedByOrEqualTo: InternetAddress
 
-  \\"\\"\\"Contains the specified internet address.\\"\\"\\"
+  """Contains the specified internet address."""
   contains: InternetAddress
 
-  \\"\\"\\"Contains or contained by the specified internet address.\\"\\"\\"
+  """Contains or contained by the specified internet address."""
   containsOrContainedBy: InternetAddress
 
-  \\"\\"\\"Contains or equal to the specified internet address.\\"\\"\\"
+  """Contains or equal to the specified internet address."""
   containsOrEqualTo: InternetAddress
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: InternetAddress
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: InternetAddress
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: InternetAddress
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: InternetAddress
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [InternetAddress!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: InternetAddress
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: InternetAddress
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: InternetAddress
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: InternetAddress
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [InternetAddress!]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against InternetAddress List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input InternetAddressListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: InternetAddress
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: InternetAddress
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: InternetAddress
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: InternetAddress
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: InternetAddress
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: InternetAddress
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [InternetAddress]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [InternetAddress]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [InternetAddress]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [InternetAddress]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [InternetAddress]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [InternetAddress]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [InternetAddress]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [InternetAddress]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [InternetAddress]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [InternetAddress]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [InternetAddress]
 }
 
-\\"\\"\\"
+"""
 An interval of time that has passed where the smallest distinct unit is a second.
-\\"\\"\\"
+"""
 type Interval {
-  \\"\\"\\"A quantity of days.\\"\\"\\"
+  """A quantity of days."""
   days: Int
 
-  \\"\\"\\"A quantity of hours.\\"\\"\\"
+  """A quantity of hours."""
   hours: Int
 
-  \\"\\"\\"A quantity of minutes.\\"\\"\\"
+  """A quantity of minutes."""
   minutes: Int
 
-  \\"\\"\\"A quantity of months.\\"\\"\\"
+  """A quantity of months."""
   months: Int
 
-  \\"\\"\\"
+  """
   A quantity of seconds. This is the only non-integer field, as all the other
   fields will dump their overflow into a smaller unit of time. Intervals don’t
   have a smaller unit than seconds.
-  \\"\\"\\"
+  """
   seconds: Float
 
-  \\"\\"\\"A quantity of years.\\"\\"\\"
+  """A quantity of years."""
   years: Int
 }
 
-\\"\\"\\"
+"""
 A filter to be used against Interval fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input IntervalFilter {
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: IntervalInput
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: IntervalInput
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: IntervalInput
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: IntervalInput
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [IntervalInput!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: IntervalInput
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: IntervalInput
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: IntervalInput
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: IntervalInput
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [IntervalInput!]
 }
 
-\\"\\"\\"
+"""
 An interval of time that has passed where the smallest distinct unit is a second.
-\\"\\"\\"
+"""
 input IntervalInput {
-  \\"\\"\\"A quantity of days.\\"\\"\\"
+  """A quantity of days."""
   days: Int
 
-  \\"\\"\\"A quantity of hours.\\"\\"\\"
+  """A quantity of hours."""
   hours: Int
 
-  \\"\\"\\"A quantity of minutes.\\"\\"\\"
+  """A quantity of minutes."""
   minutes: Int
 
-  \\"\\"\\"A quantity of months.\\"\\"\\"
+  """A quantity of months."""
   months: Int
 
-  \\"\\"\\"
+  """
   A quantity of seconds. This is the only non-integer field, as all the other
   fields will dump their overflow into a smaller unit of time. Intervals don’t
   have a smaller unit than seconds.
-  \\"\\"\\"
+  """
   seconds: Float
 
-  \\"\\"\\"A quantity of years.\\"\\"\\"
+  """A quantity of years."""
   years: Int
 }
 
-\\"\\"\\"
+"""
 A filter to be used against Interval List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input IntervalListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: IntervalInput
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: IntervalInput
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: IntervalInput
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: IntervalInput
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: IntervalInput
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: IntervalInput
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [IntervalInput]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [IntervalInput]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [IntervalInput]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [IntervalInput]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [IntervalInput]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [IntervalInput]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [IntervalInput]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [IntervalInput]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [IntervalInput]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [IntervalInput]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [IntervalInput]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against Int fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input IntFilter {
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: Int
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: Int
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: Int
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: Int
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [Int!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: Int
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: Int
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: Int
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: Int
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [Int!]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against Int List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input IntListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: Int
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: Int
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: Int
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: Int
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: Int
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: Int
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [Int]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [Int]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [Int]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [Int]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [Int]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [Int]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [Int]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [Int]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [Int]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [Int]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [Int]
 }
 
-\\"\\"\\"A range of \`Int\`.\\"\\"\\"
+"""A range of \`Int\`."""
 type IntRange {
-  \\"\\"\\"The ending bound of our range.\\"\\"\\"
+  """The ending bound of our range."""
   end: IntRangeBound
 
-  \\"\\"\\"The starting bound of our range.\\"\\"\\"
+  """The starting bound of our range."""
   start: IntRangeBound
 }
 
-\\"\\"\\"
+"""
 The value at one end of a range. A range can either include this value, or not.
-\\"\\"\\"
+"""
 type IntRangeBound {
-  \\"\\"\\"Whether or not the value of this bound is included in the range.\\"\\"\\"
+  """Whether or not the value of this bound is included in the range."""
   inclusive: Boolean!
 
-  \\"\\"\\"The value at one end of our range.\\"\\"\\"
+  """The value at one end of our range."""
   value: Int!
 }
 
-\\"\\"\\"
+"""
 The value at one end of a range. A range can either include this value, or not.
-\\"\\"\\"
+"""
 input IntRangeBoundInput {
-  \\"\\"\\"Whether or not the value of this bound is included in the range.\\"\\"\\"
+  """Whether or not the value of this bound is included in the range."""
   inclusive: Boolean!
 
-  \\"\\"\\"The value at one end of our range.\\"\\"\\"
+  """The value at one end of our range."""
   value: Int!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against IntRange fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input IntRangeFilter {
-  \\"\\"\\"Adjacent to the specified range.\\"\\"\\"
+  """Adjacent to the specified range."""
   adjacentTo: IntRangeInput
 
-  \\"\\"\\"Contained by the specified range.\\"\\"\\"
+  """Contained by the specified range."""
   containedBy: IntRangeInput
 
-  \\"\\"\\"Contains the specified range.\\"\\"\\"
+  """Contains the specified range."""
   contains: IntRangeInput
 
-  \\"\\"\\"Contains the specified value.\\"\\"\\"
+  """Contains the specified value."""
   containsElement: Int
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: IntRangeInput
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: IntRangeInput
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: IntRangeInput
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: IntRangeInput
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [IntRangeInput!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: IntRangeInput
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: IntRangeInput
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: IntRangeInput
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: IntRangeInput
 
-  \\"\\"\\"Does not extend left of the specified range.\\"\\"\\"
+  """Does not extend left of the specified range."""
   notExtendsLeftOf: IntRangeInput
 
-  \\"\\"\\"Does not extend right of the specified range.\\"\\"\\"
+  """Does not extend right of the specified range."""
   notExtendsRightOf: IntRangeInput
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [IntRangeInput!]
 
-  \\"\\"\\"Overlaps the specified range.\\"\\"\\"
+  """Overlaps the specified range."""
   overlaps: IntRangeInput
 
-  \\"\\"\\"Strictly left of the specified range.\\"\\"\\"
+  """Strictly left of the specified range."""
   strictlyLeftOf: IntRangeInput
 
-  \\"\\"\\"Strictly right of the specified range.\\"\\"\\"
+  """Strictly right of the specified range."""
   strictlyRightOf: IntRangeInput
 }
 
-\\"\\"\\"A range of \`Int\`.\\"\\"\\"
+"""A range of \`Int\`."""
 input IntRangeInput {
-  \\"\\"\\"The ending bound of our range.\\"\\"\\"
+  """The ending bound of our range."""
   end: IntRangeBoundInput
 
-  \\"\\"\\"The starting bound of our range.\\"\\"\\"
+  """The starting bound of our range."""
   start: IntRangeBoundInput
 }
 
-\\"\\"\\"
+"""
 A filter to be used against IntRange List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input IntRangeListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: IntRangeInput
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: IntRangeInput
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: IntRangeInput
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: IntRangeInput
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: IntRangeInput
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: IntRangeInput
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [IntRangeInput]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [IntRangeInput]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [IntRangeInput]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [IntRangeInput]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [IntRangeInput]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [IntRangeInput]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [IntRangeInput]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [IntRangeInput]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [IntRangeInput]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [IntRangeInput]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [IntRangeInput]
 }
 
-\\"\\"\\"
+"""
 A JavaScript object encoded in the JSON format as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf).
-\\"\\"\\"
+"""
 scalar JSON
 
 type JsonbTest implements Node {
@@ -3926,62 +3926,62 @@ type JsonbTest implements Node {
   jsonbWithArray: JSON
   jsonbWithObject: JSON
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`JsonbTest\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input JsonbTestFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [JsonbTestFilter!]
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`jsonbWithArray\` field.\\"\\"\\"
+  """Filter by the object’s \`jsonbWithArray\` field."""
   jsonbWithArray: JSONFilter
 
-  \\"\\"\\"Filter by the object’s \`jsonbWithObject\` field.\\"\\"\\"
+  """Filter by the object’s \`jsonbWithObject\` field."""
   jsonbWithObject: JSONFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: JsonbTestFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [JsonbTestFilter!]
 }
 
-\\"\\"\\"A connection to a list of \`JsonbTest\` values.\\"\\"\\"
+"""A connection to a list of \`JsonbTest\` values."""
 type JsonbTestsConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`JsonbTest\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [JsonbTestsEdge!]!
 
-  \\"\\"\\"A list of \`JsonbTest\` objects.\\"\\"\\"
+  """A list of \`JsonbTest\` objects."""
   nodes: [JsonbTest]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`JsonbTest\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`JsonbTest\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`JsonbTest\` edge in the connection.\\"\\"\\"
+"""A \`JsonbTest\` edge in the connection."""
 type JsonbTestsEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`JsonbTest\` at the end of the edge.\\"\\"\\"
+  """The \`JsonbTest\` at the end of the edge."""
   node: JsonbTest
 }
 
-\\"\\"\\"Methods to use when ordering \`JsonbTest\`.\\"\\"\\"
+"""Methods to use when ordering \`JsonbTest\`."""
 enum JsonbTestsOrderBy {
   ID_ASC
   ID_DESC
@@ -3994,188 +3994,188 @@ enum JsonbTestsOrderBy {
   PRIMARY_KEY_DESC
 }
 
-\\"\\"\\"
+"""
 A filter to be used against JSON fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input JSONFilter {
-  \\"\\"\\"Contained by the specified JSON.\\"\\"\\"
+  """Contained by the specified JSON."""
   containedBy: JSON
 
-  \\"\\"\\"Contains the specified JSON.\\"\\"\\"
+  """Contains the specified JSON."""
   contains: JSON
 
-  \\"\\"\\"Contains all of the specified keys.\\"\\"\\"
+  """Contains all of the specified keys."""
   containsAllKeys: [String!]
 
-  \\"\\"\\"Contains any of the specified keys.\\"\\"\\"
+  """Contains any of the specified keys."""
   containsAnyKeys: [String!]
 
-  \\"\\"\\"Contains the specified key.\\"\\"\\"
+  """Contains the specified key."""
   containsKey: String
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: JSON
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: JSON
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: JSON
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: JSON
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [JSON!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: JSON
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: JSON
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: JSON
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: JSON
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [JSON!]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against JSON List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input JSONListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: JSON
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: JSON
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: JSON
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: JSON
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: JSON
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: JSON
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [JSON]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [JSON]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [JSON]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [JSON]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [JSON]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [JSON]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [JSON]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [JSON]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [JSON]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [JSON]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [JSON]
 }
 
 type Junction implements Node {
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 
-  \\"\\"\\"Reads a single \`SideA\` that is related to this \`Junction\`.\\"\\"\\"
+  """Reads a single \`SideA\` that is related to this \`Junction\`."""
   sideABySideAId: SideA
   sideAId: Int!
 
-  \\"\\"\\"Reads a single \`SideB\` that is related to this \`Junction\`.\\"\\"\\"
+  """Reads a single \`SideB\` that is related to this \`Junction\`."""
   sideBBySideBId: SideB
   sideBId: Int!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`Junction\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input JunctionFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [JunctionFilter!]
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: JunctionFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [JunctionFilter!]
 
-  \\"\\"\\"Filter by the object’s \`sideAId\` field.\\"\\"\\"
+  """Filter by the object’s \`sideAId\` field."""
   sideAId: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`sideBId\` field.\\"\\"\\"
+  """Filter by the object’s \`sideBId\` field."""
   sideBId: IntFilter
 }
 
-\\"\\"\\"A connection to a list of \`Junction\` values.\\"\\"\\"
+"""A connection to a list of \`Junction\` values."""
 type JunctionsConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`Junction\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [JunctionsEdge!]!
 
-  \\"\\"\\"A list of \`Junction\` objects.\\"\\"\\"
+  """A list of \`Junction\` objects."""
   nodes: [Junction]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`Junction\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`Junction\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`Junction\` edge in the connection.\\"\\"\\"
+"""A \`Junction\` edge in the connection."""
 type JunctionsEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`Junction\` at the end of the edge.\\"\\"\\"
+  """The \`Junction\` at the end of the edge."""
   node: Junction
 }
 
-\\"\\"\\"Methods to use when ordering \`Junction\`.\\"\\"\\"
+"""Methods to use when ordering \`Junction\`."""
 enum JunctionsOrderBy {
   NATURAL
   PRIMARY_KEY_ASC
@@ -4186,116 +4186,116 @@ enum JunctionsOrderBy {
   SIDE_B_ID_DESC
 }
 
-\\"\\"\\"
+"""
 A set of key/value pairs, keys are strings, values may be a string or null. Exposed as a JSON object.
-\\"\\"\\"
+"""
 scalar KeyValueHash
 
-\\"\\"\\"
+"""
 A filter to be used against KeyValueHash fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input KeyValueHashFilter {
-  \\"\\"\\"Contained by the specified KeyValueHash.\\"\\"\\"
+  """Contained by the specified KeyValueHash."""
   containedBy: KeyValueHash
 
-  \\"\\"\\"Contains the specified KeyValueHash.\\"\\"\\"
+  """Contains the specified KeyValueHash."""
   contains: KeyValueHash
 
-  \\"\\"\\"Contains all of the specified keys.\\"\\"\\"
+  """Contains all of the specified keys."""
   containsAllKeys: [String!]
 
-  \\"\\"\\"Contains any of the specified keys.\\"\\"\\"
+  """Contains any of the specified keys."""
   containsAnyKeys: [String!]
 
-  \\"\\"\\"Contains the specified key.\\"\\"\\"
+  """Contains the specified key."""
   containsKey: String
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: KeyValueHash
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: KeyValueHash
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [KeyValueHash!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: KeyValueHash
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: KeyValueHash
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [KeyValueHash!]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against KeyValueHash List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input KeyValueHashListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: KeyValueHash
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: KeyValueHash
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: KeyValueHash
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: KeyValueHash
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: KeyValueHash
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: KeyValueHash
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [KeyValueHash]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [KeyValueHash]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [KeyValueHash]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [KeyValueHash]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [KeyValueHash]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [KeyValueHash]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [KeyValueHash]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [KeyValueHash]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [KeyValueHash]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [KeyValueHash]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [KeyValueHash]
 }
 
@@ -4305,219 +4305,219 @@ enum Mood {
   SAD
 }
 
-\\"\\"\\"
+"""
 A filter to be used against Mood fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input MoodFilter {
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: Mood
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: Mood
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: Mood
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: Mood
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [Mood!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: Mood
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: Mood
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: Mood
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: Mood
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [Mood!]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against Mood List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input MoodListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: Mood
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: Mood
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: Mood
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: Mood
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: Mood
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: Mood
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [Mood]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [Mood]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [Mood]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [Mood]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [Mood]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [Mood]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [Mood]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [Mood]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [Mood]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [Mood]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [Mood]
 }
 
-\\"\\"\\"An object with a globally unique \`ID\`.\\"\\"\\"
+"""An object with a globally unique \`ID\`."""
 interface Node {
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
-\\"\\"\\"Information about pagination in a connection.\\"\\"\\"
+"""Information about pagination in a connection."""
 type PageInfo {
-  \\"\\"\\"When paginating forwards, the cursor to continue.\\"\\"\\"
+  """When paginating forwards, the cursor to continue."""
   endCursor: Cursor
 
-  \\"\\"\\"When paginating forwards, are there more items?\\"\\"\\"
+  """When paginating forwards, are there more items?"""
   hasNextPage: Boolean!
 
-  \\"\\"\\"When paginating backwards, are there more items?\\"\\"\\"
+  """When paginating backwards, are there more items?"""
   hasPreviousPage: Boolean!
 
-  \\"\\"\\"When paginating backwards, the cursor to continue.\\"\\"\\"
+  """When paginating backwards, the cursor to continue."""
   startCursor: Cursor
 }
 
 type Parent implements Node {
-  \\"\\"\\"Reads and enables pagination through a set of \`Filterable\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Filterable\`."""
   filterablesByParentId(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: FilterableFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`Filterable\`.\\"\\"\\"
+    """The method to use when ordering \`Filterable\`."""
     orderBy: [FilterablesOrderBy!] = [PRIMARY_KEY_ASC]
   ): FilterablesConnection!
   id: Int!
   name: String!
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`Parent\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input ParentFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [ParentFilter!]
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`name\` field.\\"\\"\\"
+  """Filter by the object’s \`name\` field."""
   name: StringFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: ParentFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [ParentFilter!]
 }
 
-\\"\\"\\"A connection to a list of \`Parent\` values.\\"\\"\\"
+"""A connection to a list of \`Parent\` values."""
 type ParentsConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`Parent\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [ParentsEdge!]!
 
-  \\"\\"\\"A list of \`Parent\` objects.\\"\\"\\"
+  """A list of \`Parent\` objects."""
   nodes: [Parent]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`Parent\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`Parent\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`Parent\` edge in the connection.\\"\\"\\"
+"""A \`Parent\` edge in the connection."""
 type ParentsEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`Parent\` at the end of the edge.\\"\\"\\"
+  """The \`Parent\` at the end of the edge."""
   node: Parent
 }
 
-\\"\\"\\"Methods to use when ordering \`Parent\`.\\"\\"\\"
+"""Methods to use when ordering \`Parent\`."""
 enum ParentsOrderBy {
   ID_ASC
   ID_DESC
@@ -4532,681 +4532,681 @@ type Protected implements Node {
   id: Int!
   name: String
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
   otherId: Int
 }
 
-\\"\\"\\"A connection to a list of \`Protected\` values.\\"\\"\\"
+"""A connection to a list of \`Protected\` values."""
 type ProtectedsConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`Protected\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [ProtectedsEdge!]!
 
-  \\"\\"\\"A list of \`Protected\` objects.\\"\\"\\"
+  """A list of \`Protected\` objects."""
   nodes: [Protected]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`Protected\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`Protected\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`Protected\` edge in the connection.\\"\\"\\"
+"""A \`Protected\` edge in the connection."""
 type ProtectedsEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`Protected\` at the end of the edge.\\"\\"\\"
+  """The \`Protected\` at the end of the edge."""
   node: Protected
 }
 
-\\"\\"\\"The root query type which gives access points into the data universe.\\"\\"\\"
+"""The root query type which gives access points into the data universe."""
 type Query implements Node {
-  \\"\\"\\"Reads and enables pagination through a set of \`ArrayType\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`ArrayType\`."""
   allArrayTypes(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: ArrayTypeFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`ArrayType\`.\\"\\"\\"
+    """The method to use when ordering \`ArrayType\`."""
     orderBy: [ArrayTypesOrderBy!] = [PRIMARY_KEY_ASC]
   ): ArrayTypesConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`BackwardCompound\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`BackwardCompound\`."""
   allBackwardCompounds(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: BackwardCompoundFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`BackwardCompound\`.\\"\\"\\"
+    """The method to use when ordering \`BackwardCompound\`."""
     orderBy: [BackwardCompoundsOrderBy!] = [PRIMARY_KEY_ASC]
   ): BackwardCompoundsConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Backward\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Backward\`."""
   allBackwards(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: BackwardFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`Backward\`.\\"\\"\\"
+    """The method to use when ordering \`Backward\`."""
     orderBy: [BackwardsOrderBy!] = [PRIMARY_KEY_ASC]
   ): BackwardsConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`ChildNoRelatedFilter\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`ChildNoRelatedFilter\`."""
   allChildNoRelatedFilters(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: ChildNoRelatedFilterFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`ChildNoRelatedFilter\`.\\"\\"\\"
+    """The method to use when ordering \`ChildNoRelatedFilter\`."""
     orderBy: [ChildNoRelatedFiltersOrderBy!] = [PRIMARY_KEY_ASC]
   ): ChildNoRelatedFiltersConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Child\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Child\`."""
   allChildren(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: ChildFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`Child\`.\\"\\"\\"
+    """The method to use when ordering \`Child\`."""
     orderBy: [ChildrenOrderBy!] = [PRIMARY_KEY_ASC]
   ): ChildrenConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`DomainType\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`DomainType\`."""
   allDomainTypes(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: DomainTypeFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`DomainType\`.\\"\\"\\"
+    """The method to use when ordering \`DomainType\`."""
     orderBy: [DomainTypesOrderBy!] = [PRIMARY_KEY_ASC]
   ): DomainTypesConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`EnumArrayType\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`EnumArrayType\`."""
   allEnumArrayTypes(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: EnumArrayTypeFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`EnumArrayType\`.\\"\\"\\"
+    """The method to use when ordering \`EnumArrayType\`."""
     orderBy: [EnumArrayTypesOrderBy!] = [PRIMARY_KEY_ASC]
   ): EnumArrayTypesConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`EnumType\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`EnumType\`."""
   allEnumTypes(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: EnumTypeFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`EnumType\`.\\"\\"\\"
+    """The method to use when ordering \`EnumType\`."""
     orderBy: [EnumTypesOrderBy!] = [PRIMARY_KEY_ASC]
   ): EnumTypesConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Filterable\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Filterable\`."""
   allFilterables(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: FilterableFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`Filterable\`.\\"\\"\\"
+    """The method to use when ordering \`Filterable\`."""
     orderBy: [FilterablesOrderBy!] = [PRIMARY_KEY_ASC]
   ): FilterablesConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`ForwardCompound\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`ForwardCompound\`."""
   allForwardCompounds(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: ForwardCompoundFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`ForwardCompound\`.\\"\\"\\"
+    """The method to use when ordering \`ForwardCompound\`."""
     orderBy: [ForwardCompoundsOrderBy!] = [PRIMARY_KEY_ASC]
   ): ForwardCompoundsConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Forward\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Forward\`."""
   allForwards(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: ForwardFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`Forward\`.\\"\\"\\"
+    """The method to use when ordering \`Forward\`."""
     orderBy: [ForwardsOrderBy!] = [PRIMARY_KEY_ASC]
   ): ForwardsConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`FullyOmitted\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`FullyOmitted\`."""
   allFullyOmitteds(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`FullyOmitted\`.\\"\\"\\"
+    """The method to use when ordering \`FullyOmitted\`."""
     orderBy: [FullyOmittedsOrderBy!] = [PRIMARY_KEY_ASC]
   ): FullyOmittedsConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`JsonbTest\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`JsonbTest\`."""
   allJsonbTests(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: JsonbTestFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`JsonbTest\`.\\"\\"\\"
+    """The method to use when ordering \`JsonbTest\`."""
     orderBy: [JsonbTestsOrderBy!] = [PRIMARY_KEY_ASC]
   ): JsonbTestsConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Junction\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Junction\`."""
   allJunctions(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: JunctionFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`Junction\`.\\"\\"\\"
+    """The method to use when ordering \`Junction\`."""
     orderBy: [JunctionsOrderBy!] = [PRIMARY_KEY_ASC]
   ): JunctionsConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Parent\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Parent\`."""
   allParents(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: ParentFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`Parent\`.\\"\\"\\"
+    """The method to use when ordering \`Parent\`."""
     orderBy: [ParentsOrderBy!] = [PRIMARY_KEY_ASC]
   ): ParentsConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`RangeArrayType\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`RangeArrayType\`."""
   allRangeArrayTypes(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: RangeArrayTypeFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`RangeArrayType\`.\\"\\"\\"
+    """The method to use when ordering \`RangeArrayType\`."""
     orderBy: [RangeArrayTypesOrderBy!] = [PRIMARY_KEY_ASC]
   ): RangeArrayTypesConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`RangeType\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`RangeType\`."""
   allRangeTypes(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: RangeTypeFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`RangeType\`.\\"\\"\\"
+    """The method to use when ordering \`RangeType\`."""
     orderBy: [RangeTypesOrderBy!] = [PRIMARY_KEY_ASC]
   ): RangeTypesConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`SideA\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`SideA\`."""
   allSideAs(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: SideAFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`SideA\`.\\"\\"\\"
+    """The method to use when ordering \`SideA\`."""
     orderBy: [SideAsOrderBy!] = [PRIMARY_KEY_ASC]
   ): SideAsConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`SideB\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`SideB\`."""
   allSideBs(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: SideBFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`SideB\`.\\"\\"\\"
+    """The method to use when ordering \`SideB\`."""
     orderBy: [SideBsOrderBy!] = [PRIMARY_KEY_ASC]
   ): SideBsConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Unfilterable\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Unfilterable\`."""
   allUnfilterables(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`Unfilterable\`.\\"\\"\\"
+    """The method to use when ordering \`Unfilterable\`."""
     orderBy: [UnfilterablesOrderBy!] = [PRIMARY_KEY_ASC]
   ): UnfilterablesConnection
 
-  \\"\\"\\"Reads a single \`ArrayType\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`ArrayType\` using its globally unique \`ID\`."""
   arrayType(
-    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`ArrayType\`.\\"\\"\\"
+    """The globally unique \`ID\` to be used in selecting a single \`ArrayType\`."""
     nodeId: ID!
   ): ArrayType
   arrayTypeById(id: Int!): ArrayType
 
-  \\"\\"\\"Reads a single \`Backward\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`Backward\` using its globally unique \`ID\`."""
   backward(
-    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`Backward\`.\\"\\"\\"
+    """The globally unique \`ID\` to be used in selecting a single \`Backward\`."""
     nodeId: ID!
   ): Backward
   backwardByFilterableId(filterableId: Int!): Backward
   backwardById(id: Int!): Backward
 
-  \\"\\"\\"Reads a single \`BackwardCompound\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`BackwardCompound\` using its globally unique \`ID\`."""
   backwardCompound(
-    \\"\\"\\"
+    """
     The globally unique \`ID\` to be used in selecting a single \`BackwardCompound\`.
-    \\"\\"\\"
+    """
     nodeId: ID!
   ): BackwardCompound
   backwardCompoundByBackwardCompound1AndBackwardCompound2(backwardCompound1: Int!, backwardCompound2: Int!): BackwardCompound
 
-  \\"\\"\\"Reads a single \`Child\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`Child\` using its globally unique \`ID\`."""
   child(
-    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`Child\`.\\"\\"\\"
+    """The globally unique \`ID\` to be used in selecting a single \`Child\`."""
     nodeId: ID!
   ): Child
   childById(id: Int!): Child
 
-  \\"\\"\\"Reads a single \`ChildNoRelatedFilter\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`ChildNoRelatedFilter\` using its globally unique \`ID\`."""
   childNoRelatedFilter(
-    \\"\\"\\"
+    """
     The globally unique \`ID\` to be used in selecting a single \`ChildNoRelatedFilter\`.
-    \\"\\"\\"
+    """
     nodeId: ID!
   ): ChildNoRelatedFilter
   childNoRelatedFilterById(id: Int!): ChildNoRelatedFilter
 
-  \\"\\"\\"Reads a single \`DomainType\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`DomainType\` using its globally unique \`ID\`."""
   domainType(
-    \\"\\"\\"
+    """
     The globally unique \`ID\` to be used in selecting a single \`DomainType\`.
-    \\"\\"\\"
+    """
     nodeId: ID!
   ): DomainType
   domainTypeById(id: Int!): DomainType
 
-  \\"\\"\\"Reads a single \`EnumArrayType\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`EnumArrayType\` using its globally unique \`ID\`."""
   enumArrayType(
-    \\"\\"\\"
+    """
     The globally unique \`ID\` to be used in selecting a single \`EnumArrayType\`.
-    \\"\\"\\"
+    """
     nodeId: ID!
   ): EnumArrayType
   enumArrayTypeById(id: Int!): EnumArrayType
 
-  \\"\\"\\"Reads a single \`EnumType\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`EnumType\` using its globally unique \`ID\`."""
   enumType(
-    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`EnumType\`.\\"\\"\\"
+    """The globally unique \`ID\` to be used in selecting a single \`EnumType\`."""
     nodeId: ID!
   ): EnumType
   enumTypeById(id: Int!): EnumType
 
-  \\"\\"\\"Reads a single \`Filterable\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`Filterable\` using its globally unique \`ID\`."""
   filterable(
-    \\"\\"\\"
+    """
     The globally unique \`ID\` to be used in selecting a single \`Filterable\`.
-    \\"\\"\\"
+    """
     nodeId: ID!
   ): Filterable
   filterableByBackwardCompound1AndBackwardCompound2(backwardCompound1: Int!, backwardCompound2: Int!): Filterable
@@ -5214,232 +5214,232 @@ type Query implements Node {
   filterableByForwardId(forwardId: Int!): Filterable
   filterableById(id: Int!): Filterable
 
-  \\"\\"\\"Reads a single \`FilterableClosure\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`FilterableClosure\` using its globally unique \`ID\`."""
   filterableClosure(
-    \\"\\"\\"
+    """
     The globally unique \`ID\` to be used in selecting a single \`FilterableClosure\`.
-    \\"\\"\\"
+    """
     nodeId: ID!
   ): FilterableClosure
   filterableClosureById(id: Int!): FilterableClosure
 
-  \\"\\"\\"Reads a single \`Forward\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`Forward\` using its globally unique \`ID\`."""
   forward(
-    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`Forward\`.\\"\\"\\"
+    """The globally unique \`ID\` to be used in selecting a single \`Forward\`."""
     nodeId: ID!
   ): Forward
   forwardById(id: Int!): Forward
 
-  \\"\\"\\"Reads a single \`ForwardCompound\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`ForwardCompound\` using its globally unique \`ID\`."""
   forwardCompound(
-    \\"\\"\\"
+    """
     The globally unique \`ID\` to be used in selecting a single \`ForwardCompound\`.
-    \\"\\"\\"
+    """
     nodeId: ID!
   ): ForwardCompound
   forwardCompoundByForwardCompound1AndForwardCompound2(forwardCompound1: Int!, forwardCompound2: Int!): ForwardCompound
 
-  \\"\\"\\"Reads a single \`FullyOmitted\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`FullyOmitted\` using its globally unique \`ID\`."""
   fullyOmitted(
-    \\"\\"\\"
+    """
     The globally unique \`ID\` to be used in selecting a single \`FullyOmitted\`.
-    \\"\\"\\"
+    """
     nodeId: ID!
   ): FullyOmitted
   fullyOmittedById(id: Int!): FullyOmitted
   funcReturnsTableMultiCol(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
     i: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
   ): FuncReturnsTableMultiColConnection!
   funcReturnsTableOneCol(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
     i: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
   ): FuncReturnsTableOneColConnection!
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Filterable\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Filterable\`."""
   funcTaggedFilterableReturnsSetofFilterable(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: FilterableFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
   ): FilterablesConnection!
   funcTaggedFilterableReturnsTableMultiCol(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: FuncTaggedFilterableReturnsTableMultiColRecordFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
   ): FuncTaggedFilterableReturnsTableMultiColConnection!
 
-  \\"\\"\\"Reads a single \`JsonbTest\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`JsonbTest\` using its globally unique \`ID\`."""
   jsonbTest(
-    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`JsonbTest\`.\\"\\"\\"
+    """The globally unique \`ID\` to be used in selecting a single \`JsonbTest\`."""
     nodeId: ID!
   ): JsonbTest
   jsonbTestById(id: Int!): JsonbTest
 
-  \\"\\"\\"Reads a single \`Junction\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`Junction\` using its globally unique \`ID\`."""
   junction(
-    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`Junction\`.\\"\\"\\"
+    """The globally unique \`ID\` to be used in selecting a single \`Junction\`."""
     nodeId: ID!
   ): Junction
   junctionBySideAIdAndSideBId(sideAId: Int!, sideBId: Int!): Junction
 
-  \\"\\"\\"Fetches an object given its globally unique \`ID\`.\\"\\"\\"
+  """Fetches an object given its globally unique \`ID\`."""
   node(
-    \\"\\"\\"The globally unique \`ID\`.\\"\\"\\"
+    """The globally unique \`ID\`."""
     nodeId: ID!
   ): Node
 
-  \\"\\"\\"
+  """
   The root query type must be a \`Node\` to work well with Relay 1 mutations. This just resolves to \`query\`.
-  \\"\\"\\"
+  """
   nodeId: ID!
 
-  \\"\\"\\"Reads a single \`Parent\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`Parent\` using its globally unique \`ID\`."""
   parent(
-    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`Parent\`.\\"\\"\\"
+    """The globally unique \`ID\` to be used in selecting a single \`Parent\`."""
     nodeId: ID!
   ): Parent
   parentById(id: Int!): Parent
 
-  \\"\\"\\"Reads a single \`Protected\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`Protected\` using its globally unique \`ID\`."""
   protected(
-    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`Protected\`.\\"\\"\\"
+    """The globally unique \`ID\` to be used in selecting a single \`Protected\`."""
     nodeId: ID!
   ): Protected
   protectedById(id: Int!): Protected
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Protected\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Protected\`."""
   protectedsByOtherId(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
     otherId: Int
   ): ProtectedsConnection!
 
-  \\"\\"\\"
+  """
   Exposes the root query type nested one level down. This is helpful for Relay 1
   which can only query top level fields if they are in a particular form.
-  \\"\\"\\"
+  """
   query: Query!
 
-  \\"\\"\\"Reads a single \`RangeArrayType\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`RangeArrayType\` using its globally unique \`ID\`."""
   rangeArrayType(
-    \\"\\"\\"
+    """
     The globally unique \`ID\` to be used in selecting a single \`RangeArrayType\`.
-    \\"\\"\\"
+    """
     nodeId: ID!
   ): RangeArrayType
   rangeArrayTypeById(id: Int!): RangeArrayType
 
-  \\"\\"\\"Reads a single \`RangeType\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`RangeType\` using its globally unique \`ID\`."""
   rangeType(
-    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`RangeType\`.\\"\\"\\"
+    """The globally unique \`ID\` to be used in selecting a single \`RangeType\`."""
     nodeId: ID!
   ): RangeType
   rangeTypeById(id: Int!): RangeType
 
-  \\"\\"\\"Reads a single \`SideA\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`SideA\` using its globally unique \`ID\`."""
   sideA(
-    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`SideA\`.\\"\\"\\"
+    """The globally unique \`ID\` to be used in selecting a single \`SideA\`."""
     nodeId: ID!
   ): SideA
   sideAByAId(aId: Int!): SideA
 
-  \\"\\"\\"Reads a single \`SideB\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`SideB\` using its globally unique \`ID\`."""
   sideB(
-    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`SideB\`.\\"\\"\\"
+    """The globally unique \`ID\` to be used in selecting a single \`SideB\`."""
     nodeId: ID!
   ): SideB
   sideBByBId(bId: Int!): SideB
 
-  \\"\\"\\"Reads a single \`Unfilterable\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`Unfilterable\` using its globally unique \`ID\`."""
   unfilterable(
-    \\"\\"\\"
+    """
     The globally unique \`ID\` to be used in selecting a single \`Unfilterable\`.
-    \\"\\"\\"
+    """
     nodeId: ID!
   ): Unfilterable
   unfilterableById(id: Int!): Unfilterable
@@ -5451,77 +5451,77 @@ type RangeArrayType implements Node {
   int4RangeArray: [IntRange]
   int8RangeArray: [BigIntRange]
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
   numericRangeArray: [BigFloatRange]
   timestampRangeArray: [DatetimeRange]
   timestamptzRangeArray: [DatetimeRange]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`RangeArrayType\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input RangeArrayTypeFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [RangeArrayTypeFilter!]
 
-  \\"\\"\\"Filter by the object’s \`dateRangeArray\` field.\\"\\"\\"
+  """Filter by the object’s \`dateRangeArray\` field."""
   dateRangeArray: DateRangeListFilter
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`int4RangeArray\` field.\\"\\"\\"
+  """Filter by the object’s \`int4RangeArray\` field."""
   int4RangeArray: IntRangeListFilter
 
-  \\"\\"\\"Filter by the object’s \`int8RangeArray\` field.\\"\\"\\"
+  """Filter by the object’s \`int8RangeArray\` field."""
   int8RangeArray: BigIntRangeListFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: RangeArrayTypeFilter
 
-  \\"\\"\\"Filter by the object’s \`numericRangeArray\` field.\\"\\"\\"
+  """Filter by the object’s \`numericRangeArray\` field."""
   numericRangeArray: BigFloatRangeListFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [RangeArrayTypeFilter!]
 
-  \\"\\"\\"Filter by the object’s \`timestampRangeArray\` field.\\"\\"\\"
+  """Filter by the object’s \`timestampRangeArray\` field."""
   timestampRangeArray: DatetimeRangeListFilter
 
-  \\"\\"\\"Filter by the object’s \`timestamptzRangeArray\` field.\\"\\"\\"
+  """Filter by the object’s \`timestamptzRangeArray\` field."""
   timestamptzRangeArray: DatetimeRangeListFilter
 }
 
-\\"\\"\\"A connection to a list of \`RangeArrayType\` values.\\"\\"\\"
+"""A connection to a list of \`RangeArrayType\` values."""
 type RangeArrayTypesConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`RangeArrayType\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [RangeArrayTypesEdge!]!
 
-  \\"\\"\\"A list of \`RangeArrayType\` objects.\\"\\"\\"
+  """A list of \`RangeArrayType\` objects."""
   nodes: [RangeArrayType]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`RangeArrayType\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`RangeArrayType\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`RangeArrayType\` edge in the connection.\\"\\"\\"
+"""A \`RangeArrayType\` edge in the connection."""
 type RangeArrayTypesEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`RangeArrayType\` at the end of the edge.\\"\\"\\"
+  """The \`RangeArrayType\` at the end of the edge."""
   node: RangeArrayType
 }
 
-\\"\\"\\"Methods to use when ordering \`RangeArrayType\`.\\"\\"\\"
+"""Methods to use when ordering \`RangeArrayType\`."""
 enum RangeArrayTypesOrderBy {
   DATE_RANGE_ARRAY_ASC
   DATE_RANGE_ARRAY_DESC
@@ -5548,77 +5548,77 @@ type RangeType implements Node {
   int4Range: IntRange
   int8Range: BigIntRange
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
   numericRange: BigFloatRange
   timestampRange: DatetimeRange
   timestamptzRange: DatetimeRange
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`RangeType\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input RangeTypeFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [RangeTypeFilter!]
 
-  \\"\\"\\"Filter by the object’s \`dateRange\` field.\\"\\"\\"
+  """Filter by the object’s \`dateRange\` field."""
   dateRange: DateRangeFilter
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`int4Range\` field.\\"\\"\\"
+  """Filter by the object’s \`int4Range\` field."""
   int4Range: IntRangeFilter
 
-  \\"\\"\\"Filter by the object’s \`int8Range\` field.\\"\\"\\"
+  """Filter by the object’s \`int8Range\` field."""
   int8Range: BigIntRangeFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: RangeTypeFilter
 
-  \\"\\"\\"Filter by the object’s \`numericRange\` field.\\"\\"\\"
+  """Filter by the object’s \`numericRange\` field."""
   numericRange: BigFloatRangeFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [RangeTypeFilter!]
 
-  \\"\\"\\"Filter by the object’s \`timestampRange\` field.\\"\\"\\"
+  """Filter by the object’s \`timestampRange\` field."""
   timestampRange: DatetimeRangeFilter
 
-  \\"\\"\\"Filter by the object’s \`timestamptzRange\` field.\\"\\"\\"
+  """Filter by the object’s \`timestamptzRange\` field."""
   timestamptzRange: DatetimeRangeFilter
 }
 
-\\"\\"\\"A connection to a list of \`RangeType\` values.\\"\\"\\"
+"""A connection to a list of \`RangeType\` values."""
 type RangeTypesConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`RangeType\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [RangeTypesEdge!]!
 
-  \\"\\"\\"A list of \`RangeType\` objects.\\"\\"\\"
+  """A list of \`RangeType\` objects."""
   nodes: [RangeType]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`RangeType\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`RangeType\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`RangeType\` edge in the connection.\\"\\"\\"
+"""A \`RangeType\` edge in the connection."""
 type RangeTypesEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`RangeType\` at the end of the edge.\\"\\"\\"
+  """The \`RangeType\` at the end of the edge."""
   node: RangeType
 }
 
-\\"\\"\\"Methods to use when ordering \`RangeType\`.\\"\\"\\"
+"""Methods to use when ordering \`RangeType\`."""
 enum RangeTypesOrderBy {
   DATE_RANGE_ASC
   DATE_RANGE_DESC
@@ -5642,89 +5642,89 @@ enum RangeTypesOrderBy {
 type SideA implements Node {
   aId: Int!
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Junction\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Junction\`."""
   junctionsBySideAId(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: JunctionFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`Junction\`.\\"\\"\\"
+    """The method to use when ordering \`Junction\`."""
     orderBy: [JunctionsOrderBy!] = [PRIMARY_KEY_ASC]
   ): JunctionsConnection!
   name: String!
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`SideA\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input SideAFilter {
-  \\"\\"\\"Filter by the object’s \`aId\` field.\\"\\"\\"
+  """Filter by the object’s \`aId\` field."""
   aId: IntFilter
 
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [SideAFilter!]
 
-  \\"\\"\\"Filter by the object’s \`name\` field.\\"\\"\\"
+  """Filter by the object’s \`name\` field."""
   name: StringFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: SideAFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [SideAFilter!]
 }
 
-\\"\\"\\"A connection to a list of \`SideA\` values.\\"\\"\\"
+"""A connection to a list of \`SideA\` values."""
 type SideAsConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`SideA\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [SideAsEdge!]!
 
-  \\"\\"\\"A list of \`SideA\` objects.\\"\\"\\"
+  """A list of \`SideA\` objects."""
   nodes: [SideA]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`SideA\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`SideA\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`SideA\` edge in the connection.\\"\\"\\"
+"""A \`SideA\` edge in the connection."""
 type SideAsEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`SideA\` at the end of the edge.\\"\\"\\"
+  """The \`SideA\` at the end of the edge."""
   node: SideA
 }
 
-\\"\\"\\"Methods to use when ordering \`SideA\`.\\"\\"\\"
+"""Methods to use when ordering \`SideA\`."""
 enum SideAsOrderBy {
   A_ID_ASC
   A_ID_DESC
@@ -5738,89 +5738,89 @@ enum SideAsOrderBy {
 type SideB implements Node {
   bId: Int!
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Junction\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Junction\`."""
   junctionsBySideBId(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: JunctionFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`Junction\`.\\"\\"\\"
+    """The method to use when ordering \`Junction\`."""
     orderBy: [JunctionsOrderBy!] = [PRIMARY_KEY_ASC]
   ): JunctionsConnection!
   name: String!
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`SideB\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input SideBFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [SideBFilter!]
 
-  \\"\\"\\"Filter by the object’s \`bId\` field.\\"\\"\\"
+  """Filter by the object’s \`bId\` field."""
   bId: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`name\` field.\\"\\"\\"
+  """Filter by the object’s \`name\` field."""
   name: StringFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: SideBFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [SideBFilter!]
 }
 
-\\"\\"\\"A connection to a list of \`SideB\` values.\\"\\"\\"
+"""A connection to a list of \`SideB\` values."""
 type SideBsConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`SideB\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [SideBsEdge!]!
 
-  \\"\\"\\"A list of \`SideB\` objects.\\"\\"\\"
+  """A list of \`SideB\` objects."""
   nodes: [SideB]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`SideB\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`SideB\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`SideB\` edge in the connection.\\"\\"\\"
+"""A \`SideB\` edge in the connection."""
 type SideBsEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`SideB\` at the end of the edge.\\"\\"\\"
+  """The \`SideB\` at the end of the edge."""
   node: SideB
 }
 
-\\"\\"\\"Methods to use when ordering \`SideB\`.\\"\\"\\"
+"""Methods to use when ordering \`SideB\`."""
 enum SideBsOrderBy {
   B_ID_ASC
   B_ID_DESC
@@ -5831,382 +5831,382 @@ enum SideBsOrderBy {
   PRIMARY_KEY_DESC
 }
 
-\\"\\"\\"
+"""
 A filter to be used against String fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input StringFilter {
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: String
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value (case-insensitive).
-  \\"\\"\\"
+  """
   distinctFromInsensitive: String
 
-  \\"\\"\\"Ends with the specified string (case-sensitive).\\"\\"\\"
+  """Ends with the specified string (case-sensitive)."""
   endsWith: String
 
-  \\"\\"\\"Ends with the specified string (case-insensitive).\\"\\"\\"
+  """Ends with the specified string (case-insensitive)."""
   endsWithInsensitive: String
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: String
 
-  \\"\\"\\"Equal to the specified value (case-insensitive).\\"\\"\\"
+  """Equal to the specified value (case-insensitive)."""
   equalToInsensitive: String
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: String
 
-  \\"\\"\\"Greater than the specified value (case-insensitive).\\"\\"\\"
+  """Greater than the specified value (case-insensitive)."""
   greaterThanInsensitive: String
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: String
 
-  \\"\\"\\"Greater than or equal to the specified value (case-insensitive).\\"\\"\\"
+  """Greater than or equal to the specified value (case-insensitive)."""
   greaterThanOrEqualToInsensitive: String
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [String!]
 
-  \\"\\"\\"Included in the specified list (case-insensitive).\\"\\"\\"
-  inInsensitive: [String!]
-
-  \\"\\"\\"Contains the specified string (case-sensitive).\\"\\"\\"
+  """Contains the specified string (case-sensitive)."""
   includes: String
 
-  \\"\\"\\"Contains the specified string (case-insensitive).\\"\\"\\"
+  """Contains the specified string (case-insensitive)."""
   includesInsensitive: String
 
-  \\"\\"\\"
+  """Included in the specified list (case-insensitive)."""
+  inInsensitive: [String!]
+
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: String
 
-  \\"\\"\\"Less than the specified value (case-insensitive).\\"\\"\\"
+  """Less than the specified value (case-insensitive)."""
   lessThanInsensitive: String
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: String
 
-  \\"\\"\\"Less than or equal to the specified value (case-insensitive).\\"\\"\\"
+  """Less than or equal to the specified value (case-insensitive)."""
   lessThanOrEqualToInsensitive: String
 
-  \\"\\"\\"
+  """
   Matches the specified pattern (case-sensitive). An underscore (_) matches any
   single character; a percent sign (%) matches any sequence of zero or more characters.
-  \\"\\"\\"
+  """
   like: String
 
-  \\"\\"\\"
+  """
   Matches the specified pattern (case-insensitive). An underscore (_) matches
   any single character; a percent sign (%) matches any sequence of zero or more characters.
-  \\"\\"\\"
+  """
   likeInsensitive: String
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: String
 
-  \\"\\"\\"
+  """
   Equal to the specified value, treating null like an ordinary value (case-insensitive).
-  \\"\\"\\"
+  """
   notDistinctFromInsensitive: String
 
-  \\"\\"\\"Does not end with the specified string (case-sensitive).\\"\\"\\"
+  """Does not end with the specified string (case-sensitive)."""
   notEndsWith: String
 
-  \\"\\"\\"Does not end with the specified string (case-insensitive).\\"\\"\\"
+  """Does not end with the specified string (case-insensitive)."""
   notEndsWithInsensitive: String
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: String
 
-  \\"\\"\\"Not equal to the specified value (case-insensitive).\\"\\"\\"
+  """Not equal to the specified value (case-insensitive)."""
   notEqualToInsensitive: String
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [String!]
 
-  \\"\\"\\"Not included in the specified list (case-insensitive).\\"\\"\\"
-  notInInsensitive: [String!]
-
-  \\"\\"\\"Does not contain the specified string (case-sensitive).\\"\\"\\"
+  """Does not contain the specified string (case-sensitive)."""
   notIncludes: String
 
-  \\"\\"\\"Does not contain the specified string (case-insensitive).\\"\\"\\"
+  """Does not contain the specified string (case-insensitive)."""
   notIncludesInsensitive: String
 
-  \\"\\"\\"
+  """Not included in the specified list (case-insensitive)."""
+  notInInsensitive: [String!]
+
+  """
   Does not match the specified pattern (case-sensitive). An underscore (_)
   matches any single character; a percent sign (%) matches any sequence of zero
   or more characters.
-  \\"\\"\\"
+  """
   notLike: String
 
-  \\"\\"\\"
+  """
   Does not match the specified pattern (case-insensitive). An underscore (_)
   matches any single character; a percent sign (%) matches any sequence of zero
   or more characters.
-  \\"\\"\\"
+  """
   notLikeInsensitive: String
 
-  \\"\\"\\"Does not start with the specified string (case-sensitive).\\"\\"\\"
+  """Does not start with the specified string (case-sensitive)."""
   notStartsWith: String
 
-  \\"\\"\\"Does not start with the specified string (case-insensitive).\\"\\"\\"
+  """Does not start with the specified string (case-insensitive)."""
   notStartsWithInsensitive: String
 
-  \\"\\"\\"Starts with the specified string (case-sensitive).\\"\\"\\"
+  """Starts with the specified string (case-sensitive)."""
   startsWith: String
 
-  \\"\\"\\"Starts with the specified string (case-insensitive).\\"\\"\\"
+  """Starts with the specified string (case-insensitive)."""
   startsWithInsensitive: String
 }
 
-\\"\\"\\"
+"""
 A filter to be used against String List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input StringListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: String
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: String
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: String
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: String
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: String
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: String
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [String]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [String]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [String]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [String]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [String]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [String]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [String]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [String]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [String]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [String]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [String]
 }
 
-\\"\\"\\"
+"""
 The exact time of day, does not include the date. May or may not have a timezone offset.
-\\"\\"\\"
+"""
 scalar Time
 
-\\"\\"\\"
+"""
 A filter to be used against Time fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input TimeFilter {
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: Time
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: Time
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: Time
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: Time
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [Time!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: Time
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: Time
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: Time
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: Time
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [Time!]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against Time List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input TimeListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: Time
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: Time
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: Time
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: Time
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: Time
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: Time
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [Time]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [Time]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [Time]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [Time]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [Time]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [Time]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [Time]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [Time]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [Time]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [Time]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [Time]
 }
 
 type Unfilterable implements Node {
-  \\"\\"\\"Reads and enables pagination through a set of \`ChildNoRelatedFilter\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`ChildNoRelatedFilter\`."""
   childNoRelatedFiltersByUnfilterableId(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: ChildNoRelatedFilterFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`ChildNoRelatedFilter\`.\\"\\"\\"
+    """The method to use when ordering \`ChildNoRelatedFilter\`."""
     orderBy: [ChildNoRelatedFiltersOrderBy!] = [PRIMARY_KEY_ASC]
   ): ChildNoRelatedFiltersConnection!
   id: Int!
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
   text: String
 }
 
-\\"\\"\\"A connection to a list of \`Unfilterable\` values.\\"\\"\\"
+"""A connection to a list of \`Unfilterable\` values."""
 type UnfilterablesConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`Unfilterable\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [UnfilterablesEdge!]!
 
-  \\"\\"\\"A list of \`Unfilterable\` objects.\\"\\"\\"
+  """A list of \`Unfilterable\` objects."""
   nodes: [Unfilterable]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`Unfilterable\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`Unfilterable\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`Unfilterable\` edge in the connection.\\"\\"\\"
+"""A \`Unfilterable\` edge in the connection."""
 type UnfilterablesEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`Unfilterable\` at the end of the edge.\\"\\"\\"
+  """The \`Unfilterable\` at the end of the edge."""
   node: Unfilterable
 }
 
-\\"\\"\\"Methods to use when ordering \`Unfilterable\`.\\"\\"\\"
+"""Methods to use when ordering \`Unfilterable\`."""
 enum UnfilterablesOrderBy {
   ID_ASC
   ID_DESC
@@ -6217,114 +6217,114 @@ enum UnfilterablesOrderBy {
   TEXT_DESC
 }
 
-\\"\\"\\"
+"""
 A universally unique identifier as defined by [RFC 4122](https://tools.ietf.org/html/rfc4122).
-\\"\\"\\"
+"""
 scalar UUID
 
-\\"\\"\\"
+"""
 A filter to be used against UUID fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input UUIDFilter {
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: UUID
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: UUID
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: UUID
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: UUID
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [UUID!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: UUID
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: UUID
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: UUID
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: UUID
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [UUID!]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against UUID List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input UUIDListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: UUID
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: UUID
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: UUID
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: UUID
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: UUID
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: UUID
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [UUID]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [UUID]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [UUID]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [UUID]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [UUID]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [UUID]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [UUID]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [UUID]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [UUID]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [UUID]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [UUID]
 }
-"
+
 `;

--- a/__tests__/integration/schema/__snapshots__/useCustomNetworkScalars.test.ts.snap
+++ b/__tests__/integration/schema/__snapshots__/useCustomNetworkScalars.test.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`prints a schema with the filter plugin and the \`pgUseCustomNetworkScalars: true\` option 1`] = `
-"type ArrayType implements Node {
+type ArrayType implements Node {
   bit4Array: [BitString]
   boolArray: [Boolean]
   bpchar4Array: [String]
@@ -25,9 +25,9 @@ exports[`prints a schema with the filter plugin and the \`pgUseCustomNetworkScal
   moneyArray: [Float]
   nameArray: [String]
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
   numericArray: [BigFloat]
   textArray: [String]
@@ -41,134 +41,134 @@ exports[`prints a schema with the filter plugin and the \`pgUseCustomNetworkScal
   xmlArray: [String]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`ArrayType\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input ArrayTypeFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [ArrayTypeFilter!]
 
-  \\"\\"\\"Filter by the object’s \`bit4Array\` field.\\"\\"\\"
+  """Filter by the object’s \`bit4Array\` field."""
   bit4Array: BitStringListFilter
 
-  \\"\\"\\"Filter by the object’s \`boolArray\` field.\\"\\"\\"
+  """Filter by the object’s \`boolArray\` field."""
   boolArray: BooleanListFilter
 
-  \\"\\"\\"Filter by the object’s \`bpchar4Array\` field.\\"\\"\\"
+  """Filter by the object’s \`bpchar4Array\` field."""
   bpchar4Array: StringListFilter
 
-  \\"\\"\\"Filter by the object’s \`char4Array\` field.\\"\\"\\"
+  """Filter by the object’s \`char4Array\` field."""
   char4Array: StringListFilter
 
-  \\"\\"\\"Filter by the object’s \`cidrArray\` field.\\"\\"\\"
+  """Filter by the object’s \`cidrArray\` field."""
   cidrArray: CidrAddressListFilter
 
-  \\"\\"\\"Filter by the object’s \`citextArray\` field.\\"\\"\\"
+  """Filter by the object’s \`citextArray\` field."""
   citextArray: StringListFilter
 
-  \\"\\"\\"Filter by the object’s \`dateArray\` field.\\"\\"\\"
+  """Filter by the object’s \`dateArray\` field."""
   dateArray: DateListFilter
 
-  \\"\\"\\"Filter by the object’s \`float4Array\` field.\\"\\"\\"
+  """Filter by the object’s \`float4Array\` field."""
   float4Array: FloatListFilter
 
-  \\"\\"\\"Filter by the object’s \`float8Array\` field.\\"\\"\\"
+  """Filter by the object’s \`float8Array\` field."""
   float8Array: FloatListFilter
 
-  \\"\\"\\"Filter by the object’s \`hstoreArray\` field.\\"\\"\\"
+  """Filter by the object’s \`hstoreArray\` field."""
   hstoreArray: KeyValueHashListFilter
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`inetArray\` field.\\"\\"\\"
+  """Filter by the object’s \`inetArray\` field."""
   inetArray: InternetAddressListFilter
 
-  \\"\\"\\"Filter by the object’s \`int2Array\` field.\\"\\"\\"
+  """Filter by the object’s \`int2Array\` field."""
   int2Array: IntListFilter
 
-  \\"\\"\\"Filter by the object’s \`int4Array\` field.\\"\\"\\"
+  """Filter by the object’s \`int4Array\` field."""
   int4Array: IntListFilter
 
-  \\"\\"\\"Filter by the object’s \`int8Array\` field.\\"\\"\\"
+  """Filter by the object’s \`int8Array\` field."""
   int8Array: BigIntListFilter
 
-  \\"\\"\\"Filter by the object’s \`intervalArray\` field.\\"\\"\\"
+  """Filter by the object’s \`intervalArray\` field."""
   intervalArray: IntervalListFilter
 
-  \\"\\"\\"Filter by the object’s \`jsonbArray\` field.\\"\\"\\"
+  """Filter by the object’s \`jsonbArray\` field."""
   jsonbArray: JSONListFilter
 
-  \\"\\"\\"Filter by the object’s \`macaddrArray\` field.\\"\\"\\"
+  """Filter by the object’s \`macaddrArray\` field."""
   macaddrArray: MacAddressListFilter
 
-  \\"\\"\\"Filter by the object’s \`moneyArray\` field.\\"\\"\\"
+  """Filter by the object’s \`moneyArray\` field."""
   moneyArray: FloatListFilter
 
-  \\"\\"\\"Filter by the object’s \`nameArray\` field.\\"\\"\\"
+  """Filter by the object’s \`nameArray\` field."""
   nameArray: StringListFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: ArrayTypeFilter
 
-  \\"\\"\\"Filter by the object’s \`numericArray\` field.\\"\\"\\"
+  """Filter by the object’s \`numericArray\` field."""
   numericArray: BigFloatListFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [ArrayTypeFilter!]
 
-  \\"\\"\\"Filter by the object’s \`textArray\` field.\\"\\"\\"
+  """Filter by the object’s \`textArray\` field."""
   textArray: StringListFilter
 
-  \\"\\"\\"Filter by the object’s \`timeArray\` field.\\"\\"\\"
+  """Filter by the object’s \`timeArray\` field."""
   timeArray: TimeListFilter
 
-  \\"\\"\\"Filter by the object’s \`timestampArray\` field.\\"\\"\\"
+  """Filter by the object’s \`timestampArray\` field."""
   timestampArray: DatetimeListFilter
 
-  \\"\\"\\"Filter by the object’s \`timestamptzArray\` field.\\"\\"\\"
+  """Filter by the object’s \`timestamptzArray\` field."""
   timestamptzArray: DatetimeListFilter
 
-  \\"\\"\\"Filter by the object’s \`timetzArray\` field.\\"\\"\\"
+  """Filter by the object’s \`timetzArray\` field."""
   timetzArray: TimeListFilter
 
-  \\"\\"\\"Filter by the object’s \`uuidArray\` field.\\"\\"\\"
+  """Filter by the object’s \`uuidArray\` field."""
   uuidArray: UUIDListFilter
 
-  \\"\\"\\"Filter by the object’s \`varbitArray\` field.\\"\\"\\"
+  """Filter by the object’s \`varbitArray\` field."""
   varbitArray: BitStringListFilter
 
-  \\"\\"\\"Filter by the object’s \`varcharArray\` field.\\"\\"\\"
+  """Filter by the object’s \`varcharArray\` field."""
   varcharArray: StringListFilter
 }
 
-\\"\\"\\"A connection to a list of \`ArrayType\` values.\\"\\"\\"
+"""A connection to a list of \`ArrayType\` values."""
 type ArrayTypesConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`ArrayType\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [ArrayTypesEdge!]!
 
-  \\"\\"\\"A list of \`ArrayType\` objects.\\"\\"\\"
+  """A list of \`ArrayType\` objects."""
   nodes: [ArrayType]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`ArrayType\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`ArrayType\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`ArrayType\` edge in the connection.\\"\\"\\"
+"""A \`ArrayType\` edge in the connection."""
 type ArrayTypesEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`ArrayType\` at the end of the edge.\\"\\"\\"
+  """The \`ArrayType\` at the end of the edge."""
   node: ArrayType
 }
 
-\\"\\"\\"Methods to use when ordering \`ArrayType\`.\\"\\"\\"
+"""Methods to use when ordering \`ArrayType\`."""
 enum ArrayTypesOrderBy {
   BIT4_ARRAY_ASC
   BIT4_ARRAY_DESC
@@ -240,15 +240,15 @@ enum ArrayTypesOrderBy {
 }
 
 type Backward implements Node {
-  \\"\\"\\"Reads a single \`Filterable\` that is related to this \`Backward\`.\\"\\"\\"
+  """Reads a single \`Filterable\` that is related to this \`Backward\`."""
   filterableByFilterableId: Filterable
   filterableId: Int
   id: Int!
   name: String!
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
@@ -256,70 +256,70 @@ type BackwardCompound implements Node {
   backwardCompound1: Int!
   backwardCompound2: Int!
 
-  \\"\\"\\"
+  """
   Reads a single \`Filterable\` that is related to this \`BackwardCompound\`.
-  \\"\\"\\"
+  """
   filterableByBackwardCompound1AndBackwardCompound2: Filterable
   name: String
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`BackwardCompound\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input BackwardCompoundFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [BackwardCompoundFilter!]
 
-  \\"\\"\\"Filter by the object’s \`backwardCompound1\` field.\\"\\"\\"
+  """Filter by the object’s \`backwardCompound1\` field."""
   backwardCompound1: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`backwardCompound2\` field.\\"\\"\\"
+  """Filter by the object’s \`backwardCompound2\` field."""
   backwardCompound2: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`name\` field.\\"\\"\\"
+  """Filter by the object’s \`name\` field."""
   name: StringFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: BackwardCompoundFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [BackwardCompoundFilter!]
 }
 
-\\"\\"\\"A connection to a list of \`BackwardCompound\` values.\\"\\"\\"
+"""A connection to a list of \`BackwardCompound\` values."""
 type BackwardCompoundsConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`BackwardCompound\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [BackwardCompoundsEdge!]!
 
-  \\"\\"\\"A list of \`BackwardCompound\` objects.\\"\\"\\"
+  """A list of \`BackwardCompound\` objects."""
   nodes: [BackwardCompound]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"
+  """
   The count of *all* \`BackwardCompound\` you could get from the connection.
-  \\"\\"\\"
+  """
   totalCount: Int!
 }
 
-\\"\\"\\"A \`BackwardCompound\` edge in the connection.\\"\\"\\"
+"""A \`BackwardCompound\` edge in the connection."""
 type BackwardCompoundsEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`BackwardCompound\` at the end of the edge.\\"\\"\\"
+  """The \`BackwardCompound\` at the end of the edge."""
   node: BackwardCompound
 }
 
-\\"\\"\\"Methods to use when ordering \`BackwardCompound\`.\\"\\"\\"
+"""Methods to use when ordering \`BackwardCompound\`."""
 enum BackwardCompoundsOrderBy {
   BACKWARD_COMPOUND_1_ASC
   BACKWARD_COMPOUND_1_DESC
@@ -332,56 +332,56 @@ enum BackwardCompoundsOrderBy {
   PRIMARY_KEY_DESC
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`Backward\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input BackwardFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [BackwardFilter!]
 
-  \\"\\"\\"Filter by the object’s \`filterableId\` field.\\"\\"\\"
+  """Filter by the object’s \`filterableId\` field."""
   filterableId: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`name\` field.\\"\\"\\"
+  """Filter by the object’s \`name\` field."""
   name: StringFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: BackwardFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [BackwardFilter!]
 }
 
-\\"\\"\\"A connection to a list of \`Backward\` values.\\"\\"\\"
+"""A connection to a list of \`Backward\` values."""
 type BackwardsConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`Backward\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [BackwardsEdge!]!
 
-  \\"\\"\\"A list of \`Backward\` objects.\\"\\"\\"
+  """A list of \`Backward\` objects."""
   nodes: [Backward]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`Backward\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`Backward\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`Backward\` edge in the connection.\\"\\"\\"
+"""A \`Backward\` edge in the connection."""
 type BackwardsEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`Backward\` at the end of the edge.\\"\\"\\"
+  """The \`Backward\` at the end of the edge."""
   node: Backward
 }
 
-\\"\\"\\"Methods to use when ordering \`Backward\`.\\"\\"\\"
+"""Methods to use when ordering \`Backward\`."""
 enum BackwardsOrderBy {
   FILTERABLE_ID_ASC
   FILTERABLE_ID_DESC
@@ -394,1037 +394,1037 @@ enum BackwardsOrderBy {
   PRIMARY_KEY_DESC
 }
 
-\\"\\"\\"
+"""
 A floating point number that requires more precision than IEEE 754 binary 64
-\\"\\"\\"
+"""
 scalar BigFloat
 
-\\"\\"\\"
+"""
 A filter to be used against BigFloat fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input BigFloatFilter {
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: BigFloat
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: BigFloat
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: BigFloat
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: BigFloat
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [BigFloat!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: BigFloat
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: BigFloat
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: BigFloat
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: BigFloat
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [BigFloat!]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against BigFloat List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input BigFloatListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: BigFloat
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: BigFloat
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: BigFloat
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: BigFloat
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: BigFloat
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: BigFloat
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [BigFloat]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [BigFloat]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [BigFloat]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [BigFloat]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [BigFloat]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [BigFloat]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [BigFloat]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [BigFloat]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [BigFloat]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [BigFloat]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [BigFloat]
 }
 
-\\"\\"\\"A range of \`BigFloat\`.\\"\\"\\"
+"""A range of \`BigFloat\`."""
 type BigFloatRange {
-  \\"\\"\\"The ending bound of our range.\\"\\"\\"
+  """The ending bound of our range."""
   end: BigFloatRangeBound
 
-  \\"\\"\\"The starting bound of our range.\\"\\"\\"
+  """The starting bound of our range."""
   start: BigFloatRangeBound
 }
 
-\\"\\"\\"
+"""
 The value at one end of a range. A range can either include this value, or not.
-\\"\\"\\"
+"""
 type BigFloatRangeBound {
-  \\"\\"\\"Whether or not the value of this bound is included in the range.\\"\\"\\"
+  """Whether or not the value of this bound is included in the range."""
   inclusive: Boolean!
 
-  \\"\\"\\"The value at one end of our range.\\"\\"\\"
+  """The value at one end of our range."""
   value: BigFloat!
 }
 
-\\"\\"\\"
+"""
 The value at one end of a range. A range can either include this value, or not.
-\\"\\"\\"
+"""
 input BigFloatRangeBoundInput {
-  \\"\\"\\"Whether or not the value of this bound is included in the range.\\"\\"\\"
+  """Whether or not the value of this bound is included in the range."""
   inclusive: Boolean!
 
-  \\"\\"\\"The value at one end of our range.\\"\\"\\"
+  """The value at one end of our range."""
   value: BigFloat!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against BigFloatRange fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input BigFloatRangeFilter {
-  \\"\\"\\"Adjacent to the specified range.\\"\\"\\"
+  """Adjacent to the specified range."""
   adjacentTo: BigFloatRangeInput
 
-  \\"\\"\\"Contained by the specified range.\\"\\"\\"
+  """Contained by the specified range."""
   containedBy: BigFloatRangeInput
 
-  \\"\\"\\"Contains the specified range.\\"\\"\\"
+  """Contains the specified range."""
   contains: BigFloatRangeInput
 
-  \\"\\"\\"Contains the specified value.\\"\\"\\"
+  """Contains the specified value."""
   containsElement: BigFloat
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: BigFloatRangeInput
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: BigFloatRangeInput
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: BigFloatRangeInput
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: BigFloatRangeInput
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [BigFloatRangeInput!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: BigFloatRangeInput
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: BigFloatRangeInput
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: BigFloatRangeInput
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: BigFloatRangeInput
 
-  \\"\\"\\"Does not extend left of the specified range.\\"\\"\\"
+  """Does not extend left of the specified range."""
   notExtendsLeftOf: BigFloatRangeInput
 
-  \\"\\"\\"Does not extend right of the specified range.\\"\\"\\"
+  """Does not extend right of the specified range."""
   notExtendsRightOf: BigFloatRangeInput
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [BigFloatRangeInput!]
 
-  \\"\\"\\"Overlaps the specified range.\\"\\"\\"
+  """Overlaps the specified range."""
   overlaps: BigFloatRangeInput
 
-  \\"\\"\\"Strictly left of the specified range.\\"\\"\\"
+  """Strictly left of the specified range."""
   strictlyLeftOf: BigFloatRangeInput
 
-  \\"\\"\\"Strictly right of the specified range.\\"\\"\\"
+  """Strictly right of the specified range."""
   strictlyRightOf: BigFloatRangeInput
 }
 
-\\"\\"\\"A range of \`BigFloat\`.\\"\\"\\"
+"""A range of \`BigFloat\`."""
 input BigFloatRangeInput {
-  \\"\\"\\"The ending bound of our range.\\"\\"\\"
+  """The ending bound of our range."""
   end: BigFloatRangeBoundInput
 
-  \\"\\"\\"The starting bound of our range.\\"\\"\\"
+  """The starting bound of our range."""
   start: BigFloatRangeBoundInput
 }
 
-\\"\\"\\"
+"""
 A filter to be used against BigFloatRange List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input BigFloatRangeListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: BigFloatRangeInput
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: BigFloatRangeInput
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: BigFloatRangeInput
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: BigFloatRangeInput
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: BigFloatRangeInput
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: BigFloatRangeInput
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [BigFloatRangeInput]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [BigFloatRangeInput]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [BigFloatRangeInput]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [BigFloatRangeInput]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [BigFloatRangeInput]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [BigFloatRangeInput]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [BigFloatRangeInput]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [BigFloatRangeInput]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [BigFloatRangeInput]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [BigFloatRangeInput]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [BigFloatRangeInput]
 }
 
-\\"\\"\\"
+"""
 A signed eight-byte integer. The upper big integer values are greater than the
 max value for a JavaScript number. Therefore all big integers will be output as
 strings and not numbers.
-\\"\\"\\"
+"""
 scalar BigInt
 
-\\"\\"\\"
+"""
 A filter to be used against BigInt fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input BigIntFilter {
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: BigInt
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: BigInt
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: BigInt
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: BigInt
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [BigInt!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: BigInt
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: BigInt
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: BigInt
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: BigInt
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [BigInt!]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against BigInt List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input BigIntListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: BigInt
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: BigInt
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: BigInt
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: BigInt
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: BigInt
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: BigInt
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [BigInt]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [BigInt]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [BigInt]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [BigInt]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [BigInt]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [BigInt]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [BigInt]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [BigInt]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [BigInt]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [BigInt]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [BigInt]
 }
 
-\\"\\"\\"A range of \`BigInt\`.\\"\\"\\"
+"""A range of \`BigInt\`."""
 type BigIntRange {
-  \\"\\"\\"The ending bound of our range.\\"\\"\\"
+  """The ending bound of our range."""
   end: BigIntRangeBound
 
-  \\"\\"\\"The starting bound of our range.\\"\\"\\"
+  """The starting bound of our range."""
   start: BigIntRangeBound
 }
 
-\\"\\"\\"
+"""
 The value at one end of a range. A range can either include this value, or not.
-\\"\\"\\"
+"""
 type BigIntRangeBound {
-  \\"\\"\\"Whether or not the value of this bound is included in the range.\\"\\"\\"
+  """Whether or not the value of this bound is included in the range."""
   inclusive: Boolean!
 
-  \\"\\"\\"The value at one end of our range.\\"\\"\\"
+  """The value at one end of our range."""
   value: BigInt!
 }
 
-\\"\\"\\"
+"""
 The value at one end of a range. A range can either include this value, or not.
-\\"\\"\\"
+"""
 input BigIntRangeBoundInput {
-  \\"\\"\\"Whether or not the value of this bound is included in the range.\\"\\"\\"
+  """Whether or not the value of this bound is included in the range."""
   inclusive: Boolean!
 
-  \\"\\"\\"The value at one end of our range.\\"\\"\\"
+  """The value at one end of our range."""
   value: BigInt!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against BigIntRange fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input BigIntRangeFilter {
-  \\"\\"\\"Adjacent to the specified range.\\"\\"\\"
+  """Adjacent to the specified range."""
   adjacentTo: BigIntRangeInput
 
-  \\"\\"\\"Contained by the specified range.\\"\\"\\"
+  """Contained by the specified range."""
   containedBy: BigIntRangeInput
 
-  \\"\\"\\"Contains the specified range.\\"\\"\\"
+  """Contains the specified range."""
   contains: BigIntRangeInput
 
-  \\"\\"\\"Contains the specified value.\\"\\"\\"
+  """Contains the specified value."""
   containsElement: BigInt
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: BigIntRangeInput
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: BigIntRangeInput
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: BigIntRangeInput
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: BigIntRangeInput
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [BigIntRangeInput!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: BigIntRangeInput
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: BigIntRangeInput
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: BigIntRangeInput
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: BigIntRangeInput
 
-  \\"\\"\\"Does not extend left of the specified range.\\"\\"\\"
+  """Does not extend left of the specified range."""
   notExtendsLeftOf: BigIntRangeInput
 
-  \\"\\"\\"Does not extend right of the specified range.\\"\\"\\"
+  """Does not extend right of the specified range."""
   notExtendsRightOf: BigIntRangeInput
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [BigIntRangeInput!]
 
-  \\"\\"\\"Overlaps the specified range.\\"\\"\\"
+  """Overlaps the specified range."""
   overlaps: BigIntRangeInput
 
-  \\"\\"\\"Strictly left of the specified range.\\"\\"\\"
+  """Strictly left of the specified range."""
   strictlyLeftOf: BigIntRangeInput
 
-  \\"\\"\\"Strictly right of the specified range.\\"\\"\\"
+  """Strictly right of the specified range."""
   strictlyRightOf: BigIntRangeInput
 }
 
-\\"\\"\\"A range of \`BigInt\`.\\"\\"\\"
+"""A range of \`BigInt\`."""
 input BigIntRangeInput {
-  \\"\\"\\"The ending bound of our range.\\"\\"\\"
+  """The ending bound of our range."""
   end: BigIntRangeBoundInput
 
-  \\"\\"\\"The starting bound of our range.\\"\\"\\"
+  """The starting bound of our range."""
   start: BigIntRangeBoundInput
 }
 
-\\"\\"\\"
+"""
 A filter to be used against BigIntRange List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input BigIntRangeListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: BigIntRangeInput
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: BigIntRangeInput
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: BigIntRangeInput
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: BigIntRangeInput
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: BigIntRangeInput
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: BigIntRangeInput
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [BigIntRangeInput]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [BigIntRangeInput]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [BigIntRangeInput]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [BigIntRangeInput]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [BigIntRangeInput]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [BigIntRangeInput]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [BigIntRangeInput]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [BigIntRangeInput]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [BigIntRangeInput]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [BigIntRangeInput]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [BigIntRangeInput]
 }
 
-\\"\\"\\"A string representing a series of binary bits\\"\\"\\"
+"""A string representing a series of binary bits"""
 scalar BitString
 
-\\"\\"\\"
+"""
 A filter to be used against BitString fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input BitStringFilter {
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: BitString
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: BitString
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: BitString
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: BitString
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [BitString!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: BitString
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: BitString
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: BitString
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: BitString
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [BitString!]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against BitString List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input BitStringListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: BitString
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: BitString
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: BitString
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: BitString
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: BitString
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: BitString
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [BitString]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [BitString]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [BitString]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [BitString]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [BitString]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [BitString]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [BitString]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [BitString]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [BitString]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [BitString]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [BitString]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against Boolean fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input BooleanFilter {
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: Boolean
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: Boolean
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: Boolean
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: Boolean
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [Boolean!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: Boolean
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: Boolean
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: Boolean
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: Boolean
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [Boolean!]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against Boolean List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input BooleanListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: Boolean
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: Boolean
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: Boolean
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: Boolean
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: Boolean
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: Boolean
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [Boolean]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [Boolean]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [Boolean]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [Boolean]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [Boolean]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [Boolean]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [Boolean]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [Boolean]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [Boolean]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [Boolean]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [Boolean]
 }
 
 scalar Char4Domain
 
-\\"\\"\\"
+"""
 A filter to be used against Char4Domain fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input Char4DomainFilter {
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: Char4Domain
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value (case-insensitive).
-  \\"\\"\\"
+  """
   distinctFromInsensitive: Char4Domain
 
-  \\"\\"\\"Ends with the specified string (case-sensitive).\\"\\"\\"
+  """Ends with the specified string (case-sensitive)."""
   endsWith: Char4Domain
 
-  \\"\\"\\"Ends with the specified string (case-insensitive).\\"\\"\\"
+  """Ends with the specified string (case-insensitive)."""
   endsWithInsensitive: Char4Domain
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: Char4Domain
 
-  \\"\\"\\"Equal to the specified value (case-insensitive).\\"\\"\\"
+  """Equal to the specified value (case-insensitive)."""
   equalToInsensitive: Char4Domain
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: Char4Domain
 
-  \\"\\"\\"Greater than the specified value (case-insensitive).\\"\\"\\"
+  """Greater than the specified value (case-insensitive)."""
   greaterThanInsensitive: Char4Domain
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: Char4Domain
 
-  \\"\\"\\"Greater than or equal to the specified value (case-insensitive).\\"\\"\\"
+  """Greater than or equal to the specified value (case-insensitive)."""
   greaterThanOrEqualToInsensitive: Char4Domain
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [Char4Domain!]
 
-  \\"\\"\\"Included in the specified list (case-insensitive).\\"\\"\\"
-  inInsensitive: [Char4Domain!]
-
-  \\"\\"\\"Contains the specified string (case-sensitive).\\"\\"\\"
+  """Contains the specified string (case-sensitive)."""
   includes: Char4Domain
 
-  \\"\\"\\"Contains the specified string (case-insensitive).\\"\\"\\"
+  """Contains the specified string (case-insensitive)."""
   includesInsensitive: Char4Domain
 
-  \\"\\"\\"
+  """Included in the specified list (case-insensitive)."""
+  inInsensitive: [Char4Domain!]
+
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: Char4Domain
 
-  \\"\\"\\"Less than the specified value (case-insensitive).\\"\\"\\"
+  """Less than the specified value (case-insensitive)."""
   lessThanInsensitive: Char4Domain
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: Char4Domain
 
-  \\"\\"\\"Less than or equal to the specified value (case-insensitive).\\"\\"\\"
+  """Less than or equal to the specified value (case-insensitive)."""
   lessThanOrEqualToInsensitive: Char4Domain
 
-  \\"\\"\\"
+  """
   Matches the specified pattern (case-sensitive). An underscore (_) matches any
   single character; a percent sign (%) matches any sequence of zero or more characters.
-  \\"\\"\\"
+  """
   like: Char4Domain
 
-  \\"\\"\\"
+  """
   Matches the specified pattern (case-insensitive). An underscore (_) matches
   any single character; a percent sign (%) matches any sequence of zero or more characters.
-  \\"\\"\\"
+  """
   likeInsensitive: Char4Domain
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: Char4Domain
 
-  \\"\\"\\"
+  """
   Equal to the specified value, treating null like an ordinary value (case-insensitive).
-  \\"\\"\\"
+  """
   notDistinctFromInsensitive: Char4Domain
 
-  \\"\\"\\"Does not end with the specified string (case-sensitive).\\"\\"\\"
+  """Does not end with the specified string (case-sensitive)."""
   notEndsWith: Char4Domain
 
-  \\"\\"\\"Does not end with the specified string (case-insensitive).\\"\\"\\"
+  """Does not end with the specified string (case-insensitive)."""
   notEndsWithInsensitive: Char4Domain
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: Char4Domain
 
-  \\"\\"\\"Not equal to the specified value (case-insensitive).\\"\\"\\"
+  """Not equal to the specified value (case-insensitive)."""
   notEqualToInsensitive: Char4Domain
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [Char4Domain!]
 
-  \\"\\"\\"Not included in the specified list (case-insensitive).\\"\\"\\"
-  notInInsensitive: [Char4Domain!]
-
-  \\"\\"\\"Does not contain the specified string (case-sensitive).\\"\\"\\"
+  """Does not contain the specified string (case-sensitive)."""
   notIncludes: Char4Domain
 
-  \\"\\"\\"Does not contain the specified string (case-insensitive).\\"\\"\\"
+  """Does not contain the specified string (case-insensitive)."""
   notIncludesInsensitive: Char4Domain
 
-  \\"\\"\\"
+  """Not included in the specified list (case-insensitive)."""
+  notInInsensitive: [Char4Domain!]
+
+  """
   Does not match the specified pattern (case-sensitive). An underscore (_)
   matches any single character; a percent sign (%) matches any sequence of zero
   or more characters.
-  \\"\\"\\"
+  """
   notLike: Char4Domain
 
-  \\"\\"\\"
+  """
   Does not match the specified pattern (case-insensitive). An underscore (_)
   matches any single character; a percent sign (%) matches any sequence of zero
   or more characters.
-  \\"\\"\\"
+  """
   notLikeInsensitive: Char4Domain
 
-  \\"\\"\\"Does not start with the specified string (case-sensitive).\\"\\"\\"
+  """Does not start with the specified string (case-sensitive)."""
   notStartsWith: Char4Domain
 
-  \\"\\"\\"Does not start with the specified string (case-insensitive).\\"\\"\\"
+  """Does not start with the specified string (case-insensitive)."""
   notStartsWithInsensitive: Char4Domain
 
-  \\"\\"\\"Starts with the specified string (case-sensitive).\\"\\"\\"
+  """Starts with the specified string (case-sensitive)."""
   startsWith: Char4Domain
 
-  \\"\\"\\"Starts with the specified string (case-insensitive).\\"\\"\\"
+  """Starts with the specified string (case-insensitive)."""
   startsWithInsensitive: Char4Domain
 }
 
 type Child implements Node {
-  \\"\\"\\"Reads a single \`Filterable\` that is related to this \`Child\`.\\"\\"\\"
+  """Reads a single \`Filterable\` that is related to this \`Child\`."""
   filterableByFilterableId: Filterable
   filterableId: Int
   id: Int!
   name: String!
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`Child\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input ChildFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [ChildFilter!]
 
-  \\"\\"\\"Filter by the object’s \`filterableId\` field.\\"\\"\\"
+  """Filter by the object’s \`filterableId\` field."""
   filterableId: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`name\` field.\\"\\"\\"
+  """Filter by the object’s \`name\` field."""
   name: StringFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: ChildFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [ChildFilter!]
 }
 
 type ChildNoRelatedFilter implements Node {
-  \\"\\"\\"
+  """
   Reads a single \`Filterable\` that is related to this \`ChildNoRelatedFilter\`.
-  \\"\\"\\"
+  """
   filterableByFilterableId: Filterable
   filterableId: Int
   id: Int!
   name: String!
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 
-  \\"\\"\\"
+  """
   Reads a single \`Unfilterable\` that is related to this \`ChildNoRelatedFilter\`.
-  \\"\\"\\"
+  """
   unfilterableByUnfilterableId: Unfilterable
   unfilterableId: Int
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`ChildNoRelatedFilter\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input ChildNoRelatedFilterFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [ChildNoRelatedFilterFilter!]
 
-  \\"\\"\\"Filter by the object’s \`filterableId\` field.\\"\\"\\"
+  """Filter by the object’s \`filterableId\` field."""
   filterableId: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`name\` field.\\"\\"\\"
+  """Filter by the object’s \`name\` field."""
   name: StringFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: ChildNoRelatedFilterFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [ChildNoRelatedFilterFilter!]
 
-  \\"\\"\\"Filter by the object’s \`unfilterableId\` field.\\"\\"\\"
+  """Filter by the object’s \`unfilterableId\` field."""
   unfilterableId: IntFilter
 }
 
-\\"\\"\\"A connection to a list of \`ChildNoRelatedFilter\` values.\\"\\"\\"
+"""A connection to a list of \`ChildNoRelatedFilter\` values."""
 type ChildNoRelatedFiltersConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`ChildNoRelatedFilter\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [ChildNoRelatedFiltersEdge!]!
 
-  \\"\\"\\"A list of \`ChildNoRelatedFilter\` objects.\\"\\"\\"
+  """A list of \`ChildNoRelatedFilter\` objects."""
   nodes: [ChildNoRelatedFilter]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"
+  """
   The count of *all* \`ChildNoRelatedFilter\` you could get from the connection.
-  \\"\\"\\"
+  """
   totalCount: Int!
 }
 
-\\"\\"\\"A \`ChildNoRelatedFilter\` edge in the connection.\\"\\"\\"
+"""A \`ChildNoRelatedFilter\` edge in the connection."""
 type ChildNoRelatedFiltersEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`ChildNoRelatedFilter\` at the end of the edge.\\"\\"\\"
+  """The \`ChildNoRelatedFilter\` at the end of the edge."""
   node: ChildNoRelatedFilter
 }
 
-\\"\\"\\"Methods to use when ordering \`ChildNoRelatedFilter\`.\\"\\"\\"
+"""Methods to use when ordering \`ChildNoRelatedFilter\`."""
 enum ChildNoRelatedFiltersOrderBy {
   FILTERABLE_ID_ASC
   FILTERABLE_ID_DESC
@@ -1439,33 +1439,33 @@ enum ChildNoRelatedFiltersOrderBy {
   UNFILTERABLE_ID_DESC
 }
 
-\\"\\"\\"A connection to a list of \`Child\` values.\\"\\"\\"
+"""A connection to a list of \`Child\` values."""
 type ChildrenConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`Child\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [ChildrenEdge!]!
 
-  \\"\\"\\"A list of \`Child\` objects.\\"\\"\\"
+  """A list of \`Child\` objects."""
   nodes: [Child]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`Child\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`Child\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`Child\` edge in the connection.\\"\\"\\"
+"""A \`Child\` edge in the connection."""
 type ChildrenEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`Child\` at the end of the edge.\\"\\"\\"
+  """The \`Child\` at the end of the edge."""
   node: Child
 }
 
-\\"\\"\\"Methods to use when ordering \`Child\`.\\"\\"\\"
+"""Methods to use when ordering \`Child\`."""
 enum ChildrenOrderBy {
   FILTERABLE_ID_ASC
   FILTERABLE_ID_DESC
@@ -1478,126 +1478,126 @@ enum ChildrenOrderBy {
   PRIMARY_KEY_DESC
 }
 
-\\"\\"\\"An IPv4 or IPv6 CIDR address.\\"\\"\\"
+"""An IPv4 or IPv6 CIDR address."""
 scalar CidrAddress
 
-\\"\\"\\"
+"""
 A filter to be used against CidrAddress fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input CidrAddressFilter {
-  \\"\\"\\"Contained by the specified internet address.\\"\\"\\"
+  """Contained by the specified internet address."""
   containedBy: CidrAddress
 
-  \\"\\"\\"Contained by or equal to the specified internet address.\\"\\"\\"
+  """Contained by or equal to the specified internet address."""
   containedByOrEqualTo: CidrAddress
 
-  \\"\\"\\"Contains the specified internet address.\\"\\"\\"
+  """Contains the specified internet address."""
   contains: CidrAddress
 
-  \\"\\"\\"Contains or contained by the specified internet address.\\"\\"\\"
+  """Contains or contained by the specified internet address."""
   containsOrContainedBy: CidrAddress
 
-  \\"\\"\\"Contains or equal to the specified internet address.\\"\\"\\"
+  """Contains or equal to the specified internet address."""
   containsOrEqualTo: CidrAddress
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: CidrAddress
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: CidrAddress
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: CidrAddress
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: CidrAddress
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [CidrAddress!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: CidrAddress
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: CidrAddress
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: CidrAddress
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: CidrAddress
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [CidrAddress!]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against CidrAddress List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input CidrAddressListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: CidrAddress
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: CidrAddress
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: CidrAddress
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: CidrAddress
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: CidrAddress
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: CidrAddress
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [CidrAddress]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [CidrAddress]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [CidrAddress]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [CidrAddress]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [CidrAddress]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [CidrAddress]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [CidrAddress]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [CidrAddress]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [CidrAddress]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [CidrAddress]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [CidrAddress]
 }
 
@@ -1606,633 +1606,633 @@ type Composite {
   b: String
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`Composite\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input CompositeFilter {
-  \\"\\"\\"Filter by the object’s \`a\` field.\\"\\"\\"
+  """Filter by the object’s \`a\` field."""
   a: IntFilter
 
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [CompositeFilter!]
 
-  \\"\\"\\"Filter by the object’s \`b\` field.\\"\\"\\"
+  """Filter by the object’s \`b\` field."""
   b: StringFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: CompositeFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [CompositeFilter!]
 }
 
-\\"\\"\\"A location in a connection that can be used for resuming pagination.\\"\\"\\"
+"""A location in a connection that can be used for resuming pagination."""
 scalar Cursor
 
-\\"\\"\\"The day, does not include a time.\\"\\"\\"
+"""The day, does not include a time."""
 scalar Date
 
 scalar DateDomain
 
-\\"\\"\\"
+"""
 A filter to be used against DateDomain fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input DateDomainFilter {
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: DateDomain
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: DateDomain
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: DateDomain
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: DateDomain
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [DateDomain!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: DateDomain
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: DateDomain
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: DateDomain
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: DateDomain
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [DateDomain!]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against Date fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input DateFilter {
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: Date
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: Date
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: Date
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: Date
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [Date!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: Date
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: Date
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: Date
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: Date
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [Date!]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against Date List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input DateListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: Date
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: Date
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: Date
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: Date
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: Date
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: Date
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [Date]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [Date]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [Date]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [Date]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [Date]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [Date]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [Date]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [Date]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [Date]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [Date]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [Date]
 }
 
-\\"\\"\\"A range of \`Date\`.\\"\\"\\"
+"""A range of \`Date\`."""
 type DateRange {
-  \\"\\"\\"The ending bound of our range.\\"\\"\\"
+  """The ending bound of our range."""
   end: DateRangeBound
 
-  \\"\\"\\"The starting bound of our range.\\"\\"\\"
+  """The starting bound of our range."""
   start: DateRangeBound
 }
 
-\\"\\"\\"
+"""
 The value at one end of a range. A range can either include this value, or not.
-\\"\\"\\"
+"""
 type DateRangeBound {
-  \\"\\"\\"Whether or not the value of this bound is included in the range.\\"\\"\\"
+  """Whether or not the value of this bound is included in the range."""
   inclusive: Boolean!
 
-  \\"\\"\\"The value at one end of our range.\\"\\"\\"
+  """The value at one end of our range."""
   value: Date!
 }
 
-\\"\\"\\"
+"""
 The value at one end of a range. A range can either include this value, or not.
-\\"\\"\\"
+"""
 input DateRangeBoundInput {
-  \\"\\"\\"Whether or not the value of this bound is included in the range.\\"\\"\\"
+  """Whether or not the value of this bound is included in the range."""
   inclusive: Boolean!
 
-  \\"\\"\\"The value at one end of our range.\\"\\"\\"
+  """The value at one end of our range."""
   value: Date!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against DateRange fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input DateRangeFilter {
-  \\"\\"\\"Adjacent to the specified range.\\"\\"\\"
+  """Adjacent to the specified range."""
   adjacentTo: DateRangeInput
 
-  \\"\\"\\"Contained by the specified range.\\"\\"\\"
+  """Contained by the specified range."""
   containedBy: DateRangeInput
 
-  \\"\\"\\"Contains the specified range.\\"\\"\\"
+  """Contains the specified range."""
   contains: DateRangeInput
 
-  \\"\\"\\"Contains the specified value.\\"\\"\\"
+  """Contains the specified value."""
   containsElement: Date
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: DateRangeInput
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: DateRangeInput
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: DateRangeInput
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: DateRangeInput
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [DateRangeInput!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: DateRangeInput
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: DateRangeInput
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: DateRangeInput
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: DateRangeInput
 
-  \\"\\"\\"Does not extend left of the specified range.\\"\\"\\"
+  """Does not extend left of the specified range."""
   notExtendsLeftOf: DateRangeInput
 
-  \\"\\"\\"Does not extend right of the specified range.\\"\\"\\"
+  """Does not extend right of the specified range."""
   notExtendsRightOf: DateRangeInput
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [DateRangeInput!]
 
-  \\"\\"\\"Overlaps the specified range.\\"\\"\\"
+  """Overlaps the specified range."""
   overlaps: DateRangeInput
 
-  \\"\\"\\"Strictly left of the specified range.\\"\\"\\"
+  """Strictly left of the specified range."""
   strictlyLeftOf: DateRangeInput
 
-  \\"\\"\\"Strictly right of the specified range.\\"\\"\\"
+  """Strictly right of the specified range."""
   strictlyRightOf: DateRangeInput
 }
 
-\\"\\"\\"A range of \`Date\`.\\"\\"\\"
+"""A range of \`Date\`."""
 input DateRangeInput {
-  \\"\\"\\"The ending bound of our range.\\"\\"\\"
+  """The ending bound of our range."""
   end: DateRangeBoundInput
 
-  \\"\\"\\"The starting bound of our range.\\"\\"\\"
+  """The starting bound of our range."""
   start: DateRangeBoundInput
 }
 
-\\"\\"\\"
+"""
 A filter to be used against DateRange List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input DateRangeListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: DateRangeInput
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: DateRangeInput
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: DateRangeInput
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: DateRangeInput
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: DateRangeInput
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: DateRangeInput
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [DateRangeInput]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [DateRangeInput]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [DateRangeInput]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [DateRangeInput]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [DateRangeInput]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [DateRangeInput]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [DateRangeInput]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [DateRangeInput]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [DateRangeInput]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [DateRangeInput]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [DateRangeInput]
 }
 
-\\"\\"\\"
+"""
 A point in time as described by the [ISO
 8601](https://en.wikipedia.org/wiki/ISO_8601) standard. May or may not include a timezone.
-\\"\\"\\"
+"""
 scalar Datetime
 
-\\"\\"\\"
+"""
 A filter to be used against Datetime fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input DatetimeFilter {
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: Datetime
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: Datetime
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: Datetime
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: Datetime
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [Datetime!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: Datetime
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: Datetime
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: Datetime
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: Datetime
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [Datetime!]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against Datetime List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input DatetimeListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: Datetime
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: Datetime
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: Datetime
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: Datetime
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: Datetime
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: Datetime
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [Datetime]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [Datetime]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [Datetime]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [Datetime]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [Datetime]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [Datetime]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [Datetime]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [Datetime]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [Datetime]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [Datetime]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [Datetime]
 }
 
-\\"\\"\\"A range of \`Datetime\`.\\"\\"\\"
+"""A range of \`Datetime\`."""
 type DatetimeRange {
-  \\"\\"\\"The ending bound of our range.\\"\\"\\"
+  """The ending bound of our range."""
   end: DatetimeRangeBound
 
-  \\"\\"\\"The starting bound of our range.\\"\\"\\"
+  """The starting bound of our range."""
   start: DatetimeRangeBound
 }
 
-\\"\\"\\"
+"""
 The value at one end of a range. A range can either include this value, or not.
-\\"\\"\\"
+"""
 type DatetimeRangeBound {
-  \\"\\"\\"Whether or not the value of this bound is included in the range.\\"\\"\\"
+  """Whether or not the value of this bound is included in the range."""
   inclusive: Boolean!
 
-  \\"\\"\\"The value at one end of our range.\\"\\"\\"
+  """The value at one end of our range."""
   value: Datetime!
 }
 
-\\"\\"\\"
+"""
 The value at one end of a range. A range can either include this value, or not.
-\\"\\"\\"
+"""
 input DatetimeRangeBoundInput {
-  \\"\\"\\"Whether or not the value of this bound is included in the range.\\"\\"\\"
+  """Whether or not the value of this bound is included in the range."""
   inclusive: Boolean!
 
-  \\"\\"\\"The value at one end of our range.\\"\\"\\"
+  """The value at one end of our range."""
   value: Datetime!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against DatetimeRange fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input DatetimeRangeFilter {
-  \\"\\"\\"Adjacent to the specified range.\\"\\"\\"
+  """Adjacent to the specified range."""
   adjacentTo: DatetimeRangeInput
 
-  \\"\\"\\"Contained by the specified range.\\"\\"\\"
+  """Contained by the specified range."""
   containedBy: DatetimeRangeInput
 
-  \\"\\"\\"Contains the specified range.\\"\\"\\"
+  """Contains the specified range."""
   contains: DatetimeRangeInput
 
-  \\"\\"\\"Contains the specified value.\\"\\"\\"
+  """Contains the specified value."""
   containsElement: Datetime
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: DatetimeRangeInput
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: DatetimeRangeInput
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: DatetimeRangeInput
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: DatetimeRangeInput
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [DatetimeRangeInput!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: DatetimeRangeInput
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: DatetimeRangeInput
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: DatetimeRangeInput
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: DatetimeRangeInput
 
-  \\"\\"\\"Does not extend left of the specified range.\\"\\"\\"
+  """Does not extend left of the specified range."""
   notExtendsLeftOf: DatetimeRangeInput
 
-  \\"\\"\\"Does not extend right of the specified range.\\"\\"\\"
+  """Does not extend right of the specified range."""
   notExtendsRightOf: DatetimeRangeInput
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [DatetimeRangeInput!]
 
-  \\"\\"\\"Overlaps the specified range.\\"\\"\\"
+  """Overlaps the specified range."""
   overlaps: DatetimeRangeInput
 
-  \\"\\"\\"Strictly left of the specified range.\\"\\"\\"
+  """Strictly left of the specified range."""
   strictlyLeftOf: DatetimeRangeInput
 
-  \\"\\"\\"Strictly right of the specified range.\\"\\"\\"
+  """Strictly right of the specified range."""
   strictlyRightOf: DatetimeRangeInput
 }
 
-\\"\\"\\"A range of \`Datetime\`.\\"\\"\\"
+"""A range of \`Datetime\`."""
 input DatetimeRangeInput {
-  \\"\\"\\"The ending bound of our range.\\"\\"\\"
+  """The ending bound of our range."""
   end: DatetimeRangeBoundInput
 
-  \\"\\"\\"The starting bound of our range.\\"\\"\\"
+  """The starting bound of our range."""
   start: DatetimeRangeBoundInput
 }
 
-\\"\\"\\"
+"""
 A filter to be used against DatetimeRange List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input DatetimeRangeListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: DatetimeRangeInput
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: DatetimeRangeInput
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: DatetimeRangeInput
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: DatetimeRangeInput
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: DatetimeRangeInput
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: DatetimeRangeInput
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [DatetimeRangeInput]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [DatetimeRangeInput]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [DatetimeRangeInput]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [DatetimeRangeInput]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [DatetimeRangeInput]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [DatetimeRangeInput]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [DatetimeRangeInput]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [DatetimeRangeInput]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [DatetimeRangeInput]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [DatetimeRangeInput]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [DatetimeRangeInput]
 }
 
@@ -2242,65 +2242,65 @@ type DomainType implements Node {
   id: Int!
   int4Domain: Int4Domain
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`DomainType\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input DomainTypeFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [DomainTypeFilter!]
 
-  \\"\\"\\"Filter by the object’s \`char4Domain\` field.\\"\\"\\"
+  """Filter by the object’s \`char4Domain\` field."""
   char4Domain: Char4DomainFilter
 
-  \\"\\"\\"Filter by the object’s \`dateDomain\` field.\\"\\"\\"
+  """Filter by the object’s \`dateDomain\` field."""
   dateDomain: DateDomainFilter
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`int4Domain\` field.\\"\\"\\"
+  """Filter by the object’s \`int4Domain\` field."""
   int4Domain: Int4DomainFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: DomainTypeFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [DomainTypeFilter!]
 }
 
-\\"\\"\\"A connection to a list of \`DomainType\` values.\\"\\"\\"
+"""A connection to a list of \`DomainType\` values."""
 type DomainTypesConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`DomainType\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [DomainTypesEdge!]!
 
-  \\"\\"\\"A list of \`DomainType\` objects.\\"\\"\\"
+  """A list of \`DomainType\` objects."""
   nodes: [DomainType]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`DomainType\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`DomainType\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`DomainType\` edge in the connection.\\"\\"\\"
+"""A \`DomainType\` edge in the connection."""
 type DomainTypesEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`DomainType\` at the end of the edge.\\"\\"\\"
+  """The \`DomainType\` at the end of the edge."""
   node: DomainType
 }
 
-\\"\\"\\"Methods to use when ordering \`DomainType\`.\\"\\"\\"
+"""Methods to use when ordering \`DomainType\`."""
 enum DomainTypesOrderBy {
   CHAR4_DOMAIN_ASC
   CHAR4_DOMAIN_DESC
@@ -2319,59 +2319,59 @@ type EnumArrayType implements Node {
   enumArray: [Mood]
   id: Int!
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`EnumArrayType\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input EnumArrayTypeFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [EnumArrayTypeFilter!]
 
-  \\"\\"\\"Filter by the object’s \`enumArray\` field.\\"\\"\\"
+  """Filter by the object’s \`enumArray\` field."""
   enumArray: MoodListFilter
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: EnumArrayTypeFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [EnumArrayTypeFilter!]
 }
 
-\\"\\"\\"A connection to a list of \`EnumArrayType\` values.\\"\\"\\"
+"""A connection to a list of \`EnumArrayType\` values."""
 type EnumArrayTypesConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`EnumArrayType\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [EnumArrayTypesEdge!]!
 
-  \\"\\"\\"A list of \`EnumArrayType\` objects.\\"\\"\\"
+  """A list of \`EnumArrayType\` objects."""
   nodes: [EnumArrayType]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`EnumArrayType\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`EnumArrayType\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`EnumArrayType\` edge in the connection.\\"\\"\\"
+"""A \`EnumArrayType\` edge in the connection."""
 type EnumArrayTypesEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`EnumArrayType\` at the end of the edge.\\"\\"\\"
+  """The \`EnumArrayType\` at the end of the edge."""
   node: EnumArrayType
 }
 
-\\"\\"\\"Methods to use when ordering \`EnumArrayType\`.\\"\\"\\"
+"""Methods to use when ordering \`EnumArrayType\`."""
 enum EnumArrayTypesOrderBy {
   ENUM_ARRAY_ASC
   ENUM_ARRAY_DESC
@@ -2386,59 +2386,59 @@ type EnumType implements Node {
   enum: Mood
   id: Int!
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`EnumType\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input EnumTypeFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [EnumTypeFilter!]
 
-  \\"\\"\\"Filter by the object’s \`enum\` field.\\"\\"\\"
+  """Filter by the object’s \`enum\` field."""
   enum: MoodFilter
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: EnumTypeFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [EnumTypeFilter!]
 }
 
-\\"\\"\\"A connection to a list of \`EnumType\` values.\\"\\"\\"
+"""A connection to a list of \`EnumType\` values."""
 type EnumTypesConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`EnumType\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [EnumTypesEdge!]!
 
-  \\"\\"\\"A list of \`EnumType\` objects.\\"\\"\\"
+  """A list of \`EnumType\` objects."""
   nodes: [EnumType]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`EnumType\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`EnumType\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`EnumType\` edge in the connection.\\"\\"\\"
+"""A \`EnumType\` edge in the connection."""
 type EnumTypesEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`EnumType\` at the end of the edge.\\"\\"\\"
+  """The \`EnumType\` at the end of the edge."""
   node: EnumType
 }
 
-\\"\\"\\"Methods to use when ordering \`EnumType\`.\\"\\"\\"
+"""Methods to use when ordering \`EnumType\`."""
 enum EnumTypesOrderBy {
   ENUM_ASC
   ENUM_DESC
@@ -2450,14 +2450,14 @@ enum EnumTypesOrderBy {
 }
 
 type Filterable implements Node {
-  \\"\\"\\"Reads a single \`Backward\` that is related to this \`Filterable\`.\\"\\"\\"
+  """Reads a single \`Backward\` that is related to this \`Filterable\`."""
   backwardByFilterableId: Backward
   backwardCompound1: Int
   backwardCompound2: Int
 
-  \\"\\"\\"
+  """
   Reads a single \`BackwardCompound\` that is related to this \`Filterable\`.
-  \\"\\"\\"
+  """
   backwardCompoundByBackwardCompound1AndBackwardCompound2: BackwardCompound
   bit4: BitString
   bool: Boolean
@@ -2465,61 +2465,61 @@ type Filterable implements Node {
   bytea: String
   char4: String
 
-  \\"\\"\\"Reads and enables pagination through a set of \`ChildNoRelatedFilter\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`ChildNoRelatedFilter\`."""
   childNoRelatedFiltersByFilterableId(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: ChildNoRelatedFilterFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`ChildNoRelatedFilter\`.\\"\\"\\"
+    """The method to use when ordering \`ChildNoRelatedFilter\`."""
     orderBy: [ChildNoRelatedFiltersOrderBy!] = [PRIMARY_KEY_ASC]
   ): ChildNoRelatedFiltersConnection!
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Child\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Child\`."""
   childrenByFilterableId(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: ChildFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`Child\`.\\"\\"\\"
+    """The method to use when ordering \`Child\`."""
     orderBy: [ChildrenOrderBy!] = [PRIMARY_KEY_ASC]
   ): ChildrenConnection!
   cidr: CidrAddress
@@ -2530,126 +2530,126 @@ type Filterable implements Node {
   computedChild: Child
   computedIntArray: [Int]
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Child\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Child\`."""
   computedSetofChild(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: ChildFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
   ): ChildrenConnection!
   computedSetofInt(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: IntFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
   ): FilterableComputedSetofIntConnection!
   computedTaggedFilterable: Int
   computedWithRequiredArg(i: Int!): Int
   date: Date
 
-  \\"\\"\\"Reads and enables pagination through a set of \`FilterableClosure\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`FilterableClosure\`."""
   filterableClosuresByAncestorId(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: FilterableClosureFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`FilterableClosure\`.\\"\\"\\"
+    """The method to use when ordering \`FilterableClosure\`."""
     orderBy: [FilterableClosuresOrderBy!] = [PRIMARY_KEY_ASC]
   ): FilterableClosuresConnection!
 
-  \\"\\"\\"Reads and enables pagination through a set of \`FilterableClosure\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`FilterableClosure\`."""
   filterableClosuresByDescendantId(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: FilterableClosureFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`FilterableClosure\`.\\"\\"\\"
+    """The method to use when ordering \`FilterableClosure\`."""
     orderBy: [FilterableClosuresOrderBy!] = [PRIMARY_KEY_ASC]
   ): FilterableClosuresConnection!
   float4: Float
   float8: Float
 
-  \\"\\"\\"Reads a single \`Forward\` that is related to this \`Filterable\`.\\"\\"\\"
+  """Reads a single \`Forward\` that is related to this \`Filterable\`."""
   forwardByForwardId: Forward
   forwardColumn: Forward
   forwardCompound1: Int
   forwardCompound2: Int
 
-  \\"\\"\\"Reads a single \`ForwardCompound\` that is related to this \`Filterable\`.\\"\\"\\"
+  """Reads a single \`ForwardCompound\` that is related to this \`Filterable\`."""
   forwardCompoundByForwardCompound1AndForwardCompound2: ForwardCompound
   forwardId: Int
   hstore: KeyValueHash
@@ -2665,13 +2665,13 @@ type Filterable implements Node {
   money: Float
   name: String
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
   numeric: BigFloat
 
-  \\"\\"\\"Reads a single \`Parent\` that is related to this \`Filterable\`.\\"\\"\\"
+  """Reads a single \`Parent\` that is related to this \`Filterable\`."""
   parentByParentId: Parent
   parentId: Int
   text: String
@@ -2691,78 +2691,78 @@ type FilterableClosure implements Node {
   depth: Int!
   descendantId: Int!
 
-  \\"\\"\\"
+  """
   Reads a single \`Filterable\` that is related to this \`FilterableClosure\`.
-  \\"\\"\\"
+  """
   filterableByAncestorId: Filterable
 
-  \\"\\"\\"
+  """
   Reads a single \`Filterable\` that is related to this \`FilterableClosure\`.
-  \\"\\"\\"
+  """
   filterableByDescendantId: Filterable
   id: Int!
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`FilterableClosure\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input FilterableClosureFilter {
-  \\"\\"\\"Filter by the object’s \`ancestorId\` field.\\"\\"\\"
+  """Filter by the object’s \`ancestorId\` field."""
   ancestorId: IntFilter
 
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [FilterableClosureFilter!]
 
-  \\"\\"\\"Filter by the object’s \`depth\` field.\\"\\"\\"
+  """Filter by the object’s \`depth\` field."""
   depth: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`descendantId\` field.\\"\\"\\"
+  """Filter by the object’s \`descendantId\` field."""
   descendantId: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: FilterableClosureFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [FilterableClosureFilter!]
 }
 
-\\"\\"\\"A connection to a list of \`FilterableClosure\` values.\\"\\"\\"
+"""A connection to a list of \`FilterableClosure\` values."""
 type FilterableClosuresConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`FilterableClosure\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [FilterableClosuresEdge!]!
 
-  \\"\\"\\"A list of \`FilterableClosure\` objects.\\"\\"\\"
+  """A list of \`FilterableClosure\` objects."""
   nodes: [FilterableClosure]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"
+  """
   The count of *all* \`FilterableClosure\` you could get from the connection.
-  \\"\\"\\"
+  """
   totalCount: Int!
 }
 
-\\"\\"\\"A \`FilterableClosure\` edge in the connection.\\"\\"\\"
+"""A \`FilterableClosure\` edge in the connection."""
 type FilterableClosuresEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`FilterableClosure\` at the end of the edge.\\"\\"\\"
+  """The \`FilterableClosure\` at the end of the edge."""
   node: FilterableClosure
 }
 
-\\"\\"\\"Methods to use when ordering \`FilterableClosure\`.\\"\\"\\"
+"""Methods to use when ordering \`FilterableClosure\`."""
 enum FilterableClosuresOrderBy {
   ANCESTOR_ID_ASC
   ANCESTOR_ID_DESC
@@ -2777,187 +2777,187 @@ enum FilterableClosuresOrderBy {
   PRIMARY_KEY_DESC
 }
 
-\\"\\"\\"A connection to a list of \`Int\` values.\\"\\"\\"
+"""A connection to a list of \`Int\` values."""
 type FilterableComputedSetofIntConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`Int\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [FilterableComputedSetofIntEdge!]!
 
-  \\"\\"\\"A list of \`Int\` objects.\\"\\"\\"
+  """A list of \`Int\` objects."""
   nodes: [Int]!
 
-  \\"\\"\\"The count of *all* \`Int\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`Int\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`Int\` edge in the connection.\\"\\"\\"
+"""A \`Int\` edge in the connection."""
 type FilterableComputedSetofIntEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`Int\` at the end of the edge.\\"\\"\\"
+  """The \`Int\` at the end of the edge."""
   node: Int
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`Filterable\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input FilterableFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [FilterableFilter!]
 
-  \\"\\"\\"Filter by the object’s \`backwardCompound1\` field.\\"\\"\\"
+  """Filter by the object’s \`backwardCompound1\` field."""
   backwardCompound1: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`backwardCompound2\` field.\\"\\"\\"
+  """Filter by the object’s \`backwardCompound2\` field."""
   backwardCompound2: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`bit4\` field.\\"\\"\\"
+  """Filter by the object’s \`bit4\` field."""
   bit4: BitStringFilter
 
-  \\"\\"\\"Filter by the object’s \`bool\` field.\\"\\"\\"
+  """Filter by the object’s \`bool\` field."""
   bool: BooleanFilter
 
-  \\"\\"\\"Filter by the object’s \`bpchar4\` field.\\"\\"\\"
+  """Filter by the object’s \`bpchar4\` field."""
   bpchar4: StringFilter
 
-  \\"\\"\\"Filter by the object’s \`char4\` field.\\"\\"\\"
+  """Filter by the object’s \`char4\` field."""
   char4: StringFilter
 
-  \\"\\"\\"Filter by the object’s \`cidr\` field.\\"\\"\\"
+  """Filter by the object’s \`cidr\` field."""
   cidr: CidrAddressFilter
 
-  \\"\\"\\"Filter by the object’s \`citext\` field.\\"\\"\\"
+  """Filter by the object’s \`citext\` field."""
   citext: StringFilter
 
-  \\"\\"\\"Filter by the object’s \`compositeColumn\` field.\\"\\"\\"
+  """Filter by the object’s \`compositeColumn\` field."""
   compositeColumn: CompositeFilter
 
-  \\"\\"\\"Filter by the object’s \`computed\` field.\\"\\"\\"
+  """Filter by the object’s \`computed\` field."""
   computed: StringFilter
 
-  \\"\\"\\"Filter by the object’s \`computedIntArray\` field.\\"\\"\\"
+  """Filter by the object’s \`computedIntArray\` field."""
   computedIntArray: IntListFilter
 
-  \\"\\"\\"Filter by the object’s \`computedTaggedFilterable\` field.\\"\\"\\"
+  """Filter by the object’s \`computedTaggedFilterable\` field."""
   computedTaggedFilterable: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`date\` field.\\"\\"\\"
+  """Filter by the object’s \`date\` field."""
   date: DateFilter
 
-  \\"\\"\\"Filter by the object’s \`float4\` field.\\"\\"\\"
+  """Filter by the object’s \`float4\` field."""
   float4: FloatFilter
 
-  \\"\\"\\"Filter by the object’s \`float8\` field.\\"\\"\\"
+  """Filter by the object’s \`float8\` field."""
   float8: FloatFilter
 
-  \\"\\"\\"Filter by the object’s \`forwardCompound1\` field.\\"\\"\\"
+  """Filter by the object’s \`forwardCompound1\` field."""
   forwardCompound1: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`forwardCompound2\` field.\\"\\"\\"
+  """Filter by the object’s \`forwardCompound2\` field."""
   forwardCompound2: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`forwardId\` field.\\"\\"\\"
+  """Filter by the object’s \`forwardId\` field."""
   forwardId: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`hstore\` field.\\"\\"\\"
+  """Filter by the object’s \`hstore\` field."""
   hstore: KeyValueHashFilter
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`inet\` field.\\"\\"\\"
+  """Filter by the object’s \`inet\` field."""
   inet: InternetAddressFilter
 
-  \\"\\"\\"Filter by the object’s \`int2\` field.\\"\\"\\"
+  """Filter by the object’s \`int2\` field."""
   int2: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`int4\` field.\\"\\"\\"
+  """Filter by the object’s \`int4\` field."""
   int4: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`int8\` field.\\"\\"\\"
+  """Filter by the object’s \`int8\` field."""
   int8: BigIntFilter
 
-  \\"\\"\\"Filter by the object’s \`interval\` field.\\"\\"\\"
+  """Filter by the object’s \`interval\` field."""
   interval: IntervalFilter
 
-  \\"\\"\\"Filter by the object’s \`jsonb\` field.\\"\\"\\"
+  """Filter by the object’s \`jsonb\` field."""
   jsonb: JSONFilter
 
-  \\"\\"\\"Filter by the object’s \`macaddr\` field.\\"\\"\\"
+  """Filter by the object’s \`macaddr\` field."""
   macaddr: MacAddressFilter
 
-  \\"\\"\\"Filter by the object’s \`money\` field.\\"\\"\\"
+  """Filter by the object’s \`money\` field."""
   money: FloatFilter
 
-  \\"\\"\\"Filter by the object’s \`name\` field.\\"\\"\\"
+  """Filter by the object’s \`name\` field."""
   name: StringFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: FilterableFilter
 
-  \\"\\"\\"Filter by the object’s \`numeric\` field.\\"\\"\\"
+  """Filter by the object’s \`numeric\` field."""
   numeric: BigFloatFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [FilterableFilter!]
 
-  \\"\\"\\"Filter by the object’s \`parentId\` field.\\"\\"\\"
+  """Filter by the object’s \`parentId\` field."""
   parentId: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`text\` field.\\"\\"\\"
+  """Filter by the object’s \`text\` field."""
   text: StringFilter
 
-  \\"\\"\\"Filter by the object’s \`time\` field.\\"\\"\\"
+  """Filter by the object’s \`time\` field."""
   time: TimeFilter
 
-  \\"\\"\\"Filter by the object’s \`timestamp\` field.\\"\\"\\"
+  """Filter by the object’s \`timestamp\` field."""
   timestamp: DatetimeFilter
 
-  \\"\\"\\"Filter by the object’s \`timestamptz\` field.\\"\\"\\"
+  """Filter by the object’s \`timestamptz\` field."""
   timestamptz: DatetimeFilter
 
-  \\"\\"\\"Filter by the object’s \`timetz\` field.\\"\\"\\"
+  """Filter by the object’s \`timetz\` field."""
   timetz: TimeFilter
 
-  \\"\\"\\"Filter by the object’s \`uuid\` field.\\"\\"\\"
+  """Filter by the object’s \`uuid\` field."""
   uuid: UUIDFilter
 
-  \\"\\"\\"Filter by the object’s \`varbit\` field.\\"\\"\\"
+  """Filter by the object’s \`varbit\` field."""
   varbit: BitStringFilter
 
-  \\"\\"\\"Filter by the object’s \`varchar\` field.\\"\\"\\"
+  """Filter by the object’s \`varchar\` field."""
   varchar: StringFilter
 }
 
-\\"\\"\\"A connection to a list of \`Filterable\` values.\\"\\"\\"
+"""A connection to a list of \`Filterable\` values."""
 type FilterablesConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`Filterable\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [FilterablesEdge!]!
 
-  \\"\\"\\"A list of \`Filterable\` objects.\\"\\"\\"
+  """A list of \`Filterable\` objects."""
   nodes: [Filterable]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`Filterable\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`Filterable\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`Filterable\` edge in the connection.\\"\\"\\"
+"""A \`Filterable\` edge in the connection."""
 type FilterablesEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`Filterable\` at the end of the edge.\\"\\"\\"
+  """The \`Filterable\` at the end of the edge."""
   node: Filterable
 }
 
-\\"\\"\\"Methods to use when ordering \`Filterable\`.\\"\\"\\"
+"""Methods to use when ordering \`Filterable\`."""
 enum FilterablesOrderBy {
   BACKWARD_COMPOUND_1_ASC
   BACKWARD_COMPOUND_1_DESC
@@ -3046,188 +3046,188 @@ enum FilterablesOrderBy {
   XML_DESC
 }
 
-\\"\\"\\"
+"""
 A filter to be used against Float fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input FloatFilter {
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: Float
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: Float
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: Float
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: Float
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [Float!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: Float
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: Float
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: Float
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: Float
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [Float!]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against Float List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input FloatListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: Float
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: Float
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: Float
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: Float
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: Float
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: Float
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [Float]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [Float]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [Float]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [Float]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [Float]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [Float]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [Float]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [Float]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [Float]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [Float]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [Float]
 }
 
 type Forward implements Node {
-  \\"\\"\\"Reads a single \`Filterable\` that is related to this \`Forward\`.\\"\\"\\"
+  """Reads a single \`Filterable\` that is related to this \`Forward\`."""
   filterableByForwardId: Filterable
   id: Int!
   name: String!
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
 type ForwardCompound implements Node {
-  \\"\\"\\"Reads a single \`Filterable\` that is related to this \`ForwardCompound\`.\\"\\"\\"
+  """Reads a single \`Filterable\` that is related to this \`ForwardCompound\`."""
   filterableByForwardCompound1AndForwardCompound2: Filterable
   forwardCompound1: Int!
   forwardCompound2: Int!
   name: String
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`ForwardCompound\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input ForwardCompoundFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [ForwardCompoundFilter!]
 
-  \\"\\"\\"Filter by the object’s \`forwardCompound1\` field.\\"\\"\\"
+  """Filter by the object’s \`forwardCompound1\` field."""
   forwardCompound1: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`forwardCompound2\` field.\\"\\"\\"
+  """Filter by the object’s \`forwardCompound2\` field."""
   forwardCompound2: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`name\` field.\\"\\"\\"
+  """Filter by the object’s \`name\` field."""
   name: StringFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: ForwardCompoundFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [ForwardCompoundFilter!]
 }
 
-\\"\\"\\"A connection to a list of \`ForwardCompound\` values.\\"\\"\\"
+"""A connection to a list of \`ForwardCompound\` values."""
 type ForwardCompoundsConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`ForwardCompound\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [ForwardCompoundsEdge!]!
 
-  \\"\\"\\"A list of \`ForwardCompound\` objects.\\"\\"\\"
+  """A list of \`ForwardCompound\` objects."""
   nodes: [ForwardCompound]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"
+  """
   The count of *all* \`ForwardCompound\` you could get from the connection.
-  \\"\\"\\"
+  """
   totalCount: Int!
 }
 
-\\"\\"\\"A \`ForwardCompound\` edge in the connection.\\"\\"\\"
+"""A \`ForwardCompound\` edge in the connection."""
 type ForwardCompoundsEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`ForwardCompound\` at the end of the edge.\\"\\"\\"
+  """The \`ForwardCompound\` at the end of the edge."""
   node: ForwardCompound
 }
 
-\\"\\"\\"Methods to use when ordering \`ForwardCompound\`.\\"\\"\\"
+"""Methods to use when ordering \`ForwardCompound\`."""
 enum ForwardCompoundsOrderBy {
   FORWARD_COMPOUND_1_ASC
   FORWARD_COMPOUND_1_DESC
@@ -3240,53 +3240,53 @@ enum ForwardCompoundsOrderBy {
   PRIMARY_KEY_DESC
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`Forward\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input ForwardFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [ForwardFilter!]
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`name\` field.\\"\\"\\"
+  """Filter by the object’s \`name\` field."""
   name: StringFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: ForwardFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [ForwardFilter!]
 }
 
-\\"\\"\\"A connection to a list of \`Forward\` values.\\"\\"\\"
+"""A connection to a list of \`Forward\` values."""
 type ForwardsConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`Forward\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [ForwardsEdge!]!
 
-  \\"\\"\\"A list of \`Forward\` objects.\\"\\"\\"
+  """A list of \`Forward\` objects."""
   nodes: [Forward]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`Forward\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`Forward\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`Forward\` edge in the connection.\\"\\"\\"
+"""A \`Forward\` edge in the connection."""
 type ForwardsEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`Forward\` at the end of the edge.\\"\\"\\"
+  """The \`Forward\` at the end of the edge."""
   node: Forward
 }
 
-\\"\\"\\"Methods to use when ordering \`Forward\`.\\"\\"\\"
+"""Methods to use when ordering \`Forward\`."""
 enum ForwardsOrderBy {
   ID_ASC
   ID_DESC
@@ -3300,40 +3300,40 @@ enum ForwardsOrderBy {
 type FullyOmitted implements Node {
   id: Int!
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
   text: String
 }
 
-\\"\\"\\"A connection to a list of \`FullyOmitted\` values.\\"\\"\\"
+"""A connection to a list of \`FullyOmitted\` values."""
 type FullyOmittedsConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`FullyOmitted\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [FullyOmittedsEdge!]!
 
-  \\"\\"\\"A list of \`FullyOmitted\` objects.\\"\\"\\"
+  """A list of \`FullyOmitted\` objects."""
   nodes: [FullyOmitted]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`FullyOmitted\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`FullyOmitted\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`FullyOmitted\` edge in the connection.\\"\\"\\"
+"""A \`FullyOmitted\` edge in the connection."""
 type FullyOmittedsEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`FullyOmitted\` at the end of the edge.\\"\\"\\"
+  """The \`FullyOmitted\` at the end of the edge."""
   node: FullyOmitted
 }
 
-\\"\\"\\"Methods to use when ordering \`FullyOmitted\`.\\"\\"\\"
+"""Methods to use when ordering \`FullyOmitted\`."""
 enum FullyOmittedsOrderBy {
   ID_ASC
   ID_DESC
@@ -3344,746 +3344,746 @@ enum FullyOmittedsOrderBy {
   TEXT_DESC
 }
 
-\\"\\"\\"A connection to a list of \`FuncReturnsTableMultiColRecord\` values.\\"\\"\\"
+"""A connection to a list of \`FuncReturnsTableMultiColRecord\` values."""
 type FuncReturnsTableMultiColConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`FuncReturnsTableMultiColRecord\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [FuncReturnsTableMultiColEdge!]!
 
-  \\"\\"\\"A list of \`FuncReturnsTableMultiColRecord\` objects.\\"\\"\\"
+  """A list of \`FuncReturnsTableMultiColRecord\` objects."""
   nodes: [FuncReturnsTableMultiColRecord]!
 
-  \\"\\"\\"
+  """
   The count of *all* \`FuncReturnsTableMultiColRecord\` you could get from the connection.
-  \\"\\"\\"
+  """
   totalCount: Int!
 }
 
-\\"\\"\\"A \`FuncReturnsTableMultiColRecord\` edge in the connection.\\"\\"\\"
+"""A \`FuncReturnsTableMultiColRecord\` edge in the connection."""
 type FuncReturnsTableMultiColEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`FuncReturnsTableMultiColRecord\` at the end of the edge.\\"\\"\\"
+  """The \`FuncReturnsTableMultiColRecord\` at the end of the edge."""
   node: FuncReturnsTableMultiColRecord
 }
 
-\\"\\"\\"The return type of our \`funcReturnsTableMultiCol\` query.\\"\\"\\"
+"""The return type of our \`funcReturnsTableMultiCol\` query."""
 type FuncReturnsTableMultiColRecord {
   col1: Int
   col2: String
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`FuncReturnsTableMultiColRecord\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input FuncReturnsTableMultiColRecordFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [FuncReturnsTableMultiColRecordFilter!]
 
-  \\"\\"\\"Filter by the object’s \`col1\` field.\\"\\"\\"
+  """Filter by the object’s \`col1\` field."""
   col1: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`col2\` field.\\"\\"\\"
+  """Filter by the object’s \`col2\` field."""
   col2: StringFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: FuncReturnsTableMultiColRecordFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [FuncReturnsTableMultiColRecordFilter!]
 }
 
-\\"\\"\\"A connection to a list of \`Int\` values.\\"\\"\\"
+"""A connection to a list of \`Int\` values."""
 type FuncReturnsTableOneColConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`Int\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [FuncReturnsTableOneColEdge!]!
 
-  \\"\\"\\"A list of \`Int\` objects.\\"\\"\\"
+  """A list of \`Int\` objects."""
   nodes: [Int]!
 
-  \\"\\"\\"The count of *all* \`Int\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`Int\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`Int\` edge in the connection.\\"\\"\\"
+"""A \`Int\` edge in the connection."""
 type FuncReturnsTableOneColEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`Int\` at the end of the edge.\\"\\"\\"
+  """The \`Int\` at the end of the edge."""
   node: Int
 }
 
-\\"\\"\\"
+"""
 A connection to a list of \`FuncTaggedFilterableReturnsTableMultiColRecord\` values.
-\\"\\"\\"
+"""
 type FuncTaggedFilterableReturnsTableMultiColConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`FuncTaggedFilterableReturnsTableMultiColRecord\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [FuncTaggedFilterableReturnsTableMultiColEdge!]!
 
-  \\"\\"\\"A list of \`FuncTaggedFilterableReturnsTableMultiColRecord\` objects.\\"\\"\\"
+  """A list of \`FuncTaggedFilterableReturnsTableMultiColRecord\` objects."""
   nodes: [FuncTaggedFilterableReturnsTableMultiColRecord]!
 
-  \\"\\"\\"
+  """
   The count of *all* \`FuncTaggedFilterableReturnsTableMultiColRecord\` you could get from the connection.
-  \\"\\"\\"
+  """
   totalCount: Int!
 }
 
-\\"\\"\\"
+"""
 A \`FuncTaggedFilterableReturnsTableMultiColRecord\` edge in the connection.
-\\"\\"\\"
+"""
 type FuncTaggedFilterableReturnsTableMultiColEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"
+  """
   The \`FuncTaggedFilterableReturnsTableMultiColRecord\` at the end of the edge.
-  \\"\\"\\"
+  """
   node: FuncTaggedFilterableReturnsTableMultiColRecord
 }
 
-\\"\\"\\"
+"""
 The return type of our \`funcTaggedFilterableReturnsTableMultiCol\` query.
-\\"\\"\\"
+"""
 type FuncTaggedFilterableReturnsTableMultiColRecord {
   col1: Int
   col2: String
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`FuncTaggedFilterableReturnsTableMultiColRecord\`
 object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input FuncTaggedFilterableReturnsTableMultiColRecordFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [FuncTaggedFilterableReturnsTableMultiColRecordFilter!]
 
-  \\"\\"\\"Filter by the object’s \`col1\` field.\\"\\"\\"
+  """Filter by the object’s \`col1\` field."""
   col1: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`col2\` field.\\"\\"\\"
+  """Filter by the object’s \`col2\` field."""
   col2: StringFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: FuncTaggedFilterableReturnsTableMultiColRecordFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [FuncTaggedFilterableReturnsTableMultiColRecordFilter!]
 }
 
 scalar Int4Domain
 
-\\"\\"\\"
+"""
 A filter to be used against Int4Domain fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input Int4DomainFilter {
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: Int4Domain
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: Int4Domain
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: Int4Domain
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: Int4Domain
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [Int4Domain!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: Int4Domain
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: Int4Domain
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: Int4Domain
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: Int4Domain
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [Int4Domain!]
 }
 
-\\"\\"\\"An IPv4 or IPv6 host address, and optionally its subnet.\\"\\"\\"
+"""An IPv4 or IPv6 host address, and optionally its subnet."""
 scalar InternetAddress
 
-\\"\\"\\"
+"""
 A filter to be used against InternetAddress fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input InternetAddressFilter {
-  \\"\\"\\"Contained by the specified internet address.\\"\\"\\"
+  """Contained by the specified internet address."""
   containedBy: InternetAddress
 
-  \\"\\"\\"Contained by or equal to the specified internet address.\\"\\"\\"
+  """Contained by or equal to the specified internet address."""
   containedByOrEqualTo: InternetAddress
 
-  \\"\\"\\"Contains the specified internet address.\\"\\"\\"
+  """Contains the specified internet address."""
   contains: InternetAddress
 
-  \\"\\"\\"Contains or contained by the specified internet address.\\"\\"\\"
+  """Contains or contained by the specified internet address."""
   containsOrContainedBy: InternetAddress
 
-  \\"\\"\\"Contains or equal to the specified internet address.\\"\\"\\"
+  """Contains or equal to the specified internet address."""
   containsOrEqualTo: InternetAddress
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: InternetAddress
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: InternetAddress
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: InternetAddress
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: InternetAddress
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [InternetAddress!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: InternetAddress
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: InternetAddress
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: InternetAddress
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: InternetAddress
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [InternetAddress!]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against InternetAddress List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input InternetAddressListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: InternetAddress
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: InternetAddress
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: InternetAddress
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: InternetAddress
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: InternetAddress
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: InternetAddress
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [InternetAddress]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [InternetAddress]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [InternetAddress]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [InternetAddress]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [InternetAddress]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [InternetAddress]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [InternetAddress]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [InternetAddress]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [InternetAddress]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [InternetAddress]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [InternetAddress]
 }
 
-\\"\\"\\"
+"""
 An interval of time that has passed where the smallest distinct unit is a second.
-\\"\\"\\"
+"""
 type Interval {
-  \\"\\"\\"A quantity of days.\\"\\"\\"
+  """A quantity of days."""
   days: Int
 
-  \\"\\"\\"A quantity of hours.\\"\\"\\"
+  """A quantity of hours."""
   hours: Int
 
-  \\"\\"\\"A quantity of minutes.\\"\\"\\"
+  """A quantity of minutes."""
   minutes: Int
 
-  \\"\\"\\"A quantity of months.\\"\\"\\"
+  """A quantity of months."""
   months: Int
 
-  \\"\\"\\"
+  """
   A quantity of seconds. This is the only non-integer field, as all the other
   fields will dump their overflow into a smaller unit of time. Intervals don’t
   have a smaller unit than seconds.
-  \\"\\"\\"
+  """
   seconds: Float
 
-  \\"\\"\\"A quantity of years.\\"\\"\\"
+  """A quantity of years."""
   years: Int
 }
 
-\\"\\"\\"
+"""
 A filter to be used against Interval fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input IntervalFilter {
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: IntervalInput
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: IntervalInput
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: IntervalInput
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: IntervalInput
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [IntervalInput!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: IntervalInput
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: IntervalInput
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: IntervalInput
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: IntervalInput
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [IntervalInput!]
 }
 
-\\"\\"\\"
+"""
 An interval of time that has passed where the smallest distinct unit is a second.
-\\"\\"\\"
+"""
 input IntervalInput {
-  \\"\\"\\"A quantity of days.\\"\\"\\"
+  """A quantity of days."""
   days: Int
 
-  \\"\\"\\"A quantity of hours.\\"\\"\\"
+  """A quantity of hours."""
   hours: Int
 
-  \\"\\"\\"A quantity of minutes.\\"\\"\\"
+  """A quantity of minutes."""
   minutes: Int
 
-  \\"\\"\\"A quantity of months.\\"\\"\\"
+  """A quantity of months."""
   months: Int
 
-  \\"\\"\\"
+  """
   A quantity of seconds. This is the only non-integer field, as all the other
   fields will dump their overflow into a smaller unit of time. Intervals don’t
   have a smaller unit than seconds.
-  \\"\\"\\"
+  """
   seconds: Float
 
-  \\"\\"\\"A quantity of years.\\"\\"\\"
+  """A quantity of years."""
   years: Int
 }
 
-\\"\\"\\"
+"""
 A filter to be used against Interval List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input IntervalListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: IntervalInput
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: IntervalInput
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: IntervalInput
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: IntervalInput
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: IntervalInput
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: IntervalInput
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [IntervalInput]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [IntervalInput]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [IntervalInput]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [IntervalInput]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [IntervalInput]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [IntervalInput]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [IntervalInput]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [IntervalInput]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [IntervalInput]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [IntervalInput]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [IntervalInput]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against Int fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input IntFilter {
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: Int
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: Int
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: Int
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: Int
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [Int!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: Int
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: Int
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: Int
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: Int
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [Int!]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against Int List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input IntListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: Int
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: Int
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: Int
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: Int
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: Int
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: Int
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [Int]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [Int]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [Int]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [Int]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [Int]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [Int]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [Int]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [Int]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [Int]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [Int]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [Int]
 }
 
-\\"\\"\\"A range of \`Int\`.\\"\\"\\"
+"""A range of \`Int\`."""
 type IntRange {
-  \\"\\"\\"The ending bound of our range.\\"\\"\\"
+  """The ending bound of our range."""
   end: IntRangeBound
 
-  \\"\\"\\"The starting bound of our range.\\"\\"\\"
+  """The starting bound of our range."""
   start: IntRangeBound
 }
 
-\\"\\"\\"
+"""
 The value at one end of a range. A range can either include this value, or not.
-\\"\\"\\"
+"""
 type IntRangeBound {
-  \\"\\"\\"Whether or not the value of this bound is included in the range.\\"\\"\\"
+  """Whether or not the value of this bound is included in the range."""
   inclusive: Boolean!
 
-  \\"\\"\\"The value at one end of our range.\\"\\"\\"
+  """The value at one end of our range."""
   value: Int!
 }
 
-\\"\\"\\"
+"""
 The value at one end of a range. A range can either include this value, or not.
-\\"\\"\\"
+"""
 input IntRangeBoundInput {
-  \\"\\"\\"Whether or not the value of this bound is included in the range.\\"\\"\\"
+  """Whether or not the value of this bound is included in the range."""
   inclusive: Boolean!
 
-  \\"\\"\\"The value at one end of our range.\\"\\"\\"
+  """The value at one end of our range."""
   value: Int!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against IntRange fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input IntRangeFilter {
-  \\"\\"\\"Adjacent to the specified range.\\"\\"\\"
+  """Adjacent to the specified range."""
   adjacentTo: IntRangeInput
 
-  \\"\\"\\"Contained by the specified range.\\"\\"\\"
+  """Contained by the specified range."""
   containedBy: IntRangeInput
 
-  \\"\\"\\"Contains the specified range.\\"\\"\\"
+  """Contains the specified range."""
   contains: IntRangeInput
 
-  \\"\\"\\"Contains the specified value.\\"\\"\\"
+  """Contains the specified value."""
   containsElement: Int
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: IntRangeInput
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: IntRangeInput
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: IntRangeInput
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: IntRangeInput
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [IntRangeInput!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: IntRangeInput
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: IntRangeInput
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: IntRangeInput
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: IntRangeInput
 
-  \\"\\"\\"Does not extend left of the specified range.\\"\\"\\"
+  """Does not extend left of the specified range."""
   notExtendsLeftOf: IntRangeInput
 
-  \\"\\"\\"Does not extend right of the specified range.\\"\\"\\"
+  """Does not extend right of the specified range."""
   notExtendsRightOf: IntRangeInput
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [IntRangeInput!]
 
-  \\"\\"\\"Overlaps the specified range.\\"\\"\\"
+  """Overlaps the specified range."""
   overlaps: IntRangeInput
 
-  \\"\\"\\"Strictly left of the specified range.\\"\\"\\"
+  """Strictly left of the specified range."""
   strictlyLeftOf: IntRangeInput
 
-  \\"\\"\\"Strictly right of the specified range.\\"\\"\\"
+  """Strictly right of the specified range."""
   strictlyRightOf: IntRangeInput
 }
 
-\\"\\"\\"A range of \`Int\`.\\"\\"\\"
+"""A range of \`Int\`."""
 input IntRangeInput {
-  \\"\\"\\"The ending bound of our range.\\"\\"\\"
+  """The ending bound of our range."""
   end: IntRangeBoundInput
 
-  \\"\\"\\"The starting bound of our range.\\"\\"\\"
+  """The starting bound of our range."""
   start: IntRangeBoundInput
 }
 
-\\"\\"\\"
+"""
 A filter to be used against IntRange List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input IntRangeListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: IntRangeInput
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: IntRangeInput
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: IntRangeInput
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: IntRangeInput
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: IntRangeInput
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: IntRangeInput
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [IntRangeInput]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [IntRangeInput]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [IntRangeInput]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [IntRangeInput]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [IntRangeInput]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [IntRangeInput]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [IntRangeInput]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [IntRangeInput]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [IntRangeInput]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [IntRangeInput]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [IntRangeInput]
 }
 
-\\"\\"\\"
+"""
 A JavaScript object encoded in the JSON format as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf).
-\\"\\"\\"
+"""
 scalar JSON
 
 type JsonbTest implements Node {
@@ -4091,62 +4091,62 @@ type JsonbTest implements Node {
   jsonbWithArray: JSON
   jsonbWithObject: JSON
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`JsonbTest\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input JsonbTestFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [JsonbTestFilter!]
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`jsonbWithArray\` field.\\"\\"\\"
+  """Filter by the object’s \`jsonbWithArray\` field."""
   jsonbWithArray: JSONFilter
 
-  \\"\\"\\"Filter by the object’s \`jsonbWithObject\` field.\\"\\"\\"
+  """Filter by the object’s \`jsonbWithObject\` field."""
   jsonbWithObject: JSONFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: JsonbTestFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [JsonbTestFilter!]
 }
 
-\\"\\"\\"A connection to a list of \`JsonbTest\` values.\\"\\"\\"
+"""A connection to a list of \`JsonbTest\` values."""
 type JsonbTestsConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`JsonbTest\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [JsonbTestsEdge!]!
 
-  \\"\\"\\"A list of \`JsonbTest\` objects.\\"\\"\\"
+  """A list of \`JsonbTest\` objects."""
   nodes: [JsonbTest]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`JsonbTest\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`JsonbTest\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`JsonbTest\` edge in the connection.\\"\\"\\"
+"""A \`JsonbTest\` edge in the connection."""
 type JsonbTestsEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`JsonbTest\` at the end of the edge.\\"\\"\\"
+  """The \`JsonbTest\` at the end of the edge."""
   node: JsonbTest
 }
 
-\\"\\"\\"Methods to use when ordering \`JsonbTest\`.\\"\\"\\"
+"""Methods to use when ordering \`JsonbTest\`."""
 enum JsonbTestsOrderBy {
   ID_ASC
   ID_DESC
@@ -4159,188 +4159,188 @@ enum JsonbTestsOrderBy {
   PRIMARY_KEY_DESC
 }
 
-\\"\\"\\"
+"""
 A filter to be used against JSON fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input JSONFilter {
-  \\"\\"\\"Contained by the specified JSON.\\"\\"\\"
+  """Contained by the specified JSON."""
   containedBy: JSON
 
-  \\"\\"\\"Contains the specified JSON.\\"\\"\\"
+  """Contains the specified JSON."""
   contains: JSON
 
-  \\"\\"\\"Contains all of the specified keys.\\"\\"\\"
+  """Contains all of the specified keys."""
   containsAllKeys: [String!]
 
-  \\"\\"\\"Contains any of the specified keys.\\"\\"\\"
+  """Contains any of the specified keys."""
   containsAnyKeys: [String!]
 
-  \\"\\"\\"Contains the specified key.\\"\\"\\"
+  """Contains the specified key."""
   containsKey: String
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: JSON
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: JSON
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: JSON
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: JSON
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [JSON!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: JSON
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: JSON
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: JSON
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: JSON
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [JSON!]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against JSON List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input JSONListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: JSON
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: JSON
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: JSON
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: JSON
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: JSON
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: JSON
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [JSON]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [JSON]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [JSON]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [JSON]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [JSON]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [JSON]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [JSON]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [JSON]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [JSON]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [JSON]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [JSON]
 }
 
 type Junction implements Node {
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 
-  \\"\\"\\"Reads a single \`SideA\` that is related to this \`Junction\`.\\"\\"\\"
+  """Reads a single \`SideA\` that is related to this \`Junction\`."""
   sideABySideAId: SideA
   sideAId: Int!
 
-  \\"\\"\\"Reads a single \`SideB\` that is related to this \`Junction\`.\\"\\"\\"
+  """Reads a single \`SideB\` that is related to this \`Junction\`."""
   sideBBySideBId: SideB
   sideBId: Int!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`Junction\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input JunctionFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [JunctionFilter!]
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: JunctionFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [JunctionFilter!]
 
-  \\"\\"\\"Filter by the object’s \`sideAId\` field.\\"\\"\\"
+  """Filter by the object’s \`sideAId\` field."""
   sideAId: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`sideBId\` field.\\"\\"\\"
+  """Filter by the object’s \`sideBId\` field."""
   sideBId: IntFilter
 }
 
-\\"\\"\\"A connection to a list of \`Junction\` values.\\"\\"\\"
+"""A connection to a list of \`Junction\` values."""
 type JunctionsConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`Junction\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [JunctionsEdge!]!
 
-  \\"\\"\\"A list of \`Junction\` objects.\\"\\"\\"
+  """A list of \`Junction\` objects."""
   nodes: [Junction]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`Junction\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`Junction\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`Junction\` edge in the connection.\\"\\"\\"
+"""A \`Junction\` edge in the connection."""
 type JunctionsEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`Junction\` at the end of the edge.\\"\\"\\"
+  """The \`Junction\` at the end of the edge."""
   node: Junction
 }
 
-\\"\\"\\"Methods to use when ordering \`Junction\`.\\"\\"\\"
+"""Methods to use when ordering \`Junction\`."""
 enum JunctionsOrderBy {
   NATURAL
   PRIMARY_KEY_ASC
@@ -4351,224 +4351,224 @@ enum JunctionsOrderBy {
   SIDE_B_ID_DESC
 }
 
-\\"\\"\\"
+"""
 A set of key/value pairs, keys are strings, values may be a string or null. Exposed as a JSON object.
-\\"\\"\\"
+"""
 scalar KeyValueHash
 
-\\"\\"\\"
+"""
 A filter to be used against KeyValueHash fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input KeyValueHashFilter {
-  \\"\\"\\"Contained by the specified KeyValueHash.\\"\\"\\"
+  """Contained by the specified KeyValueHash."""
   containedBy: KeyValueHash
 
-  \\"\\"\\"Contains the specified KeyValueHash.\\"\\"\\"
+  """Contains the specified KeyValueHash."""
   contains: KeyValueHash
 
-  \\"\\"\\"Contains all of the specified keys.\\"\\"\\"
+  """Contains all of the specified keys."""
   containsAllKeys: [String!]
 
-  \\"\\"\\"Contains any of the specified keys.\\"\\"\\"
+  """Contains any of the specified keys."""
   containsAnyKeys: [String!]
 
-  \\"\\"\\"Contains the specified key.\\"\\"\\"
+  """Contains the specified key."""
   containsKey: String
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: KeyValueHash
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: KeyValueHash
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [KeyValueHash!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: KeyValueHash
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: KeyValueHash
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [KeyValueHash!]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against KeyValueHash List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input KeyValueHashListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: KeyValueHash
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: KeyValueHash
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: KeyValueHash
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: KeyValueHash
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: KeyValueHash
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: KeyValueHash
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [KeyValueHash]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [KeyValueHash]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [KeyValueHash]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [KeyValueHash]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [KeyValueHash]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [KeyValueHash]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [KeyValueHash]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [KeyValueHash]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [KeyValueHash]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [KeyValueHash]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [KeyValueHash]
 }
 
-\\"\\"\\"A 6-byte MAC address.\\"\\"\\"
+"""A 6-byte MAC address."""
 scalar MacAddress
 
-\\"\\"\\"
+"""
 A filter to be used against MacAddress fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input MacAddressFilter {
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: MacAddress
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: MacAddress
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: MacAddress
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: MacAddress
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [MacAddress!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: MacAddress
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: MacAddress
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: MacAddress
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: MacAddress
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [MacAddress!]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against MacAddress List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input MacAddressListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: MacAddress
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: MacAddress
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: MacAddress
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: MacAddress
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: MacAddress
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: MacAddress
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [MacAddress]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [MacAddress]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [MacAddress]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [MacAddress]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [MacAddress]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [MacAddress]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [MacAddress]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [MacAddress]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [MacAddress]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [MacAddress]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [MacAddress]
 }
 
@@ -4578,219 +4578,219 @@ enum Mood {
   SAD
 }
 
-\\"\\"\\"
+"""
 A filter to be used against Mood fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input MoodFilter {
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: Mood
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: Mood
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: Mood
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: Mood
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [Mood!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: Mood
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: Mood
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: Mood
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: Mood
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [Mood!]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against Mood List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input MoodListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: Mood
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: Mood
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: Mood
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: Mood
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: Mood
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: Mood
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [Mood]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [Mood]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [Mood]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [Mood]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [Mood]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [Mood]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [Mood]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [Mood]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [Mood]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [Mood]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [Mood]
 }
 
-\\"\\"\\"An object with a globally unique \`ID\`.\\"\\"\\"
+"""An object with a globally unique \`ID\`."""
 interface Node {
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
-\\"\\"\\"Information about pagination in a connection.\\"\\"\\"
+"""Information about pagination in a connection."""
 type PageInfo {
-  \\"\\"\\"When paginating forwards, the cursor to continue.\\"\\"\\"
+  """When paginating forwards, the cursor to continue."""
   endCursor: Cursor
 
-  \\"\\"\\"When paginating forwards, are there more items?\\"\\"\\"
+  """When paginating forwards, are there more items?"""
   hasNextPage: Boolean!
 
-  \\"\\"\\"When paginating backwards, are there more items?\\"\\"\\"
+  """When paginating backwards, are there more items?"""
   hasPreviousPage: Boolean!
 
-  \\"\\"\\"When paginating backwards, the cursor to continue.\\"\\"\\"
+  """When paginating backwards, the cursor to continue."""
   startCursor: Cursor
 }
 
 type Parent implements Node {
-  \\"\\"\\"Reads and enables pagination through a set of \`Filterable\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Filterable\`."""
   filterablesByParentId(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: FilterableFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`Filterable\`.\\"\\"\\"
+    """The method to use when ordering \`Filterable\`."""
     orderBy: [FilterablesOrderBy!] = [PRIMARY_KEY_ASC]
   ): FilterablesConnection!
   id: Int!
   name: String!
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`Parent\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input ParentFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [ParentFilter!]
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`name\` field.\\"\\"\\"
+  """Filter by the object’s \`name\` field."""
   name: StringFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: ParentFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [ParentFilter!]
 }
 
-\\"\\"\\"A connection to a list of \`Parent\` values.\\"\\"\\"
+"""A connection to a list of \`Parent\` values."""
 type ParentsConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`Parent\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [ParentsEdge!]!
 
-  \\"\\"\\"A list of \`Parent\` objects.\\"\\"\\"
+  """A list of \`Parent\` objects."""
   nodes: [Parent]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`Parent\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`Parent\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`Parent\` edge in the connection.\\"\\"\\"
+"""A \`Parent\` edge in the connection."""
 type ParentsEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`Parent\` at the end of the edge.\\"\\"\\"
+  """The \`Parent\` at the end of the edge."""
   node: Parent
 }
 
-\\"\\"\\"Methods to use when ordering \`Parent\`.\\"\\"\\"
+"""Methods to use when ordering \`Parent\`."""
 enum ParentsOrderBy {
   ID_ASC
   ID_DESC
@@ -4805,704 +4805,704 @@ type Protected implements Node {
   id: Int!
   name: String
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
   otherId: Int
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`Protected\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input ProtectedFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [ProtectedFilter!]
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`name\` field.\\"\\"\\"
+  """Filter by the object’s \`name\` field."""
   name: StringFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: ProtectedFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [ProtectedFilter!]
 
-  \\"\\"\\"Filter by the object’s \`otherId\` field.\\"\\"\\"
+  """Filter by the object’s \`otherId\` field."""
   otherId: IntFilter
 }
 
-\\"\\"\\"A connection to a list of \`Protected\` values.\\"\\"\\"
+"""A connection to a list of \`Protected\` values."""
 type ProtectedsConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`Protected\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [ProtectedsEdge!]!
 
-  \\"\\"\\"A list of \`Protected\` objects.\\"\\"\\"
+  """A list of \`Protected\` objects."""
   nodes: [Protected]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`Protected\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`Protected\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`Protected\` edge in the connection.\\"\\"\\"
+"""A \`Protected\` edge in the connection."""
 type ProtectedsEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`Protected\` at the end of the edge.\\"\\"\\"
+  """The \`Protected\` at the end of the edge."""
   node: Protected
 }
 
-\\"\\"\\"The root query type which gives access points into the data universe.\\"\\"\\"
+"""The root query type which gives access points into the data universe."""
 type Query implements Node {
-  \\"\\"\\"Reads and enables pagination through a set of \`ArrayType\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`ArrayType\`."""
   allArrayTypes(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: ArrayTypeFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`ArrayType\`.\\"\\"\\"
+    """The method to use when ordering \`ArrayType\`."""
     orderBy: [ArrayTypesOrderBy!] = [PRIMARY_KEY_ASC]
   ): ArrayTypesConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`BackwardCompound\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`BackwardCompound\`."""
   allBackwardCompounds(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: BackwardCompoundFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`BackwardCompound\`.\\"\\"\\"
+    """The method to use when ordering \`BackwardCompound\`."""
     orderBy: [BackwardCompoundsOrderBy!] = [PRIMARY_KEY_ASC]
   ): BackwardCompoundsConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Backward\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Backward\`."""
   allBackwards(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: BackwardFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`Backward\`.\\"\\"\\"
+    """The method to use when ordering \`Backward\`."""
     orderBy: [BackwardsOrderBy!] = [PRIMARY_KEY_ASC]
   ): BackwardsConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`ChildNoRelatedFilter\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`ChildNoRelatedFilter\`."""
   allChildNoRelatedFilters(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: ChildNoRelatedFilterFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`ChildNoRelatedFilter\`.\\"\\"\\"
+    """The method to use when ordering \`ChildNoRelatedFilter\`."""
     orderBy: [ChildNoRelatedFiltersOrderBy!] = [PRIMARY_KEY_ASC]
   ): ChildNoRelatedFiltersConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Child\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Child\`."""
   allChildren(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: ChildFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`Child\`.\\"\\"\\"
+    """The method to use when ordering \`Child\`."""
     orderBy: [ChildrenOrderBy!] = [PRIMARY_KEY_ASC]
   ): ChildrenConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`DomainType\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`DomainType\`."""
   allDomainTypes(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: DomainTypeFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`DomainType\`.\\"\\"\\"
+    """The method to use when ordering \`DomainType\`."""
     orderBy: [DomainTypesOrderBy!] = [PRIMARY_KEY_ASC]
   ): DomainTypesConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`EnumArrayType\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`EnumArrayType\`."""
   allEnumArrayTypes(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: EnumArrayTypeFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`EnumArrayType\`.\\"\\"\\"
+    """The method to use when ordering \`EnumArrayType\`."""
     orderBy: [EnumArrayTypesOrderBy!] = [PRIMARY_KEY_ASC]
   ): EnumArrayTypesConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`EnumType\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`EnumType\`."""
   allEnumTypes(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: EnumTypeFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`EnumType\`.\\"\\"\\"
+    """The method to use when ordering \`EnumType\`."""
     orderBy: [EnumTypesOrderBy!] = [PRIMARY_KEY_ASC]
   ): EnumTypesConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Filterable\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Filterable\`."""
   allFilterables(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: FilterableFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`Filterable\`.\\"\\"\\"
+    """The method to use when ordering \`Filterable\`."""
     orderBy: [FilterablesOrderBy!] = [PRIMARY_KEY_ASC]
   ): FilterablesConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`ForwardCompound\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`ForwardCompound\`."""
   allForwardCompounds(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: ForwardCompoundFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`ForwardCompound\`.\\"\\"\\"
+    """The method to use when ordering \`ForwardCompound\`."""
     orderBy: [ForwardCompoundsOrderBy!] = [PRIMARY_KEY_ASC]
   ): ForwardCompoundsConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Forward\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Forward\`."""
   allForwards(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: ForwardFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`Forward\`.\\"\\"\\"
+    """The method to use when ordering \`Forward\`."""
     orderBy: [ForwardsOrderBy!] = [PRIMARY_KEY_ASC]
   ): ForwardsConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`FullyOmitted\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`FullyOmitted\`."""
   allFullyOmitteds(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`FullyOmitted\`.\\"\\"\\"
+    """The method to use when ordering \`FullyOmitted\`."""
     orderBy: [FullyOmittedsOrderBy!] = [PRIMARY_KEY_ASC]
   ): FullyOmittedsConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`JsonbTest\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`JsonbTest\`."""
   allJsonbTests(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: JsonbTestFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`JsonbTest\`.\\"\\"\\"
+    """The method to use when ordering \`JsonbTest\`."""
     orderBy: [JsonbTestsOrderBy!] = [PRIMARY_KEY_ASC]
   ): JsonbTestsConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Junction\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Junction\`."""
   allJunctions(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: JunctionFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`Junction\`.\\"\\"\\"
+    """The method to use when ordering \`Junction\`."""
     orderBy: [JunctionsOrderBy!] = [PRIMARY_KEY_ASC]
   ): JunctionsConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Parent\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Parent\`."""
   allParents(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: ParentFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`Parent\`.\\"\\"\\"
+    """The method to use when ordering \`Parent\`."""
     orderBy: [ParentsOrderBy!] = [PRIMARY_KEY_ASC]
   ): ParentsConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`RangeArrayType\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`RangeArrayType\`."""
   allRangeArrayTypes(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: RangeArrayTypeFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`RangeArrayType\`.\\"\\"\\"
+    """The method to use when ordering \`RangeArrayType\`."""
     orderBy: [RangeArrayTypesOrderBy!] = [PRIMARY_KEY_ASC]
   ): RangeArrayTypesConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`RangeType\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`RangeType\`."""
   allRangeTypes(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: RangeTypeFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`RangeType\`.\\"\\"\\"
+    """The method to use when ordering \`RangeType\`."""
     orderBy: [RangeTypesOrderBy!] = [PRIMARY_KEY_ASC]
   ): RangeTypesConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`SideA\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`SideA\`."""
   allSideAs(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: SideAFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`SideA\`.\\"\\"\\"
+    """The method to use when ordering \`SideA\`."""
     orderBy: [SideAsOrderBy!] = [PRIMARY_KEY_ASC]
   ): SideAsConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`SideB\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`SideB\`."""
   allSideBs(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: SideBFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`SideB\`.\\"\\"\\"
+    """The method to use when ordering \`SideB\`."""
     orderBy: [SideBsOrderBy!] = [PRIMARY_KEY_ASC]
   ): SideBsConnection
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Unfilterable\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Unfilterable\`."""
   allUnfilterables(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`Unfilterable\`.\\"\\"\\"
+    """The method to use when ordering \`Unfilterable\`."""
     orderBy: [UnfilterablesOrderBy!] = [PRIMARY_KEY_ASC]
   ): UnfilterablesConnection
 
-  \\"\\"\\"Reads a single \`ArrayType\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`ArrayType\` using its globally unique \`ID\`."""
   arrayType(
-    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`ArrayType\`.\\"\\"\\"
+    """The globally unique \`ID\` to be used in selecting a single \`ArrayType\`."""
     nodeId: ID!
   ): ArrayType
   arrayTypeById(id: Int!): ArrayType
 
-  \\"\\"\\"Reads a single \`Backward\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`Backward\` using its globally unique \`ID\`."""
   backward(
-    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`Backward\`.\\"\\"\\"
+    """The globally unique \`ID\` to be used in selecting a single \`Backward\`."""
     nodeId: ID!
   ): Backward
   backwardByFilterableId(filterableId: Int!): Backward
   backwardById(id: Int!): Backward
 
-  \\"\\"\\"Reads a single \`BackwardCompound\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`BackwardCompound\` using its globally unique \`ID\`."""
   backwardCompound(
-    \\"\\"\\"
+    """
     The globally unique \`ID\` to be used in selecting a single \`BackwardCompound\`.
-    \\"\\"\\"
+    """
     nodeId: ID!
   ): BackwardCompound
   backwardCompoundByBackwardCompound1AndBackwardCompound2(backwardCompound1: Int!, backwardCompound2: Int!): BackwardCompound
 
-  \\"\\"\\"Reads a single \`Child\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`Child\` using its globally unique \`ID\`."""
   child(
-    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`Child\`.\\"\\"\\"
+    """The globally unique \`ID\` to be used in selecting a single \`Child\`."""
     nodeId: ID!
   ): Child
   childById(id: Int!): Child
 
-  \\"\\"\\"Reads a single \`ChildNoRelatedFilter\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`ChildNoRelatedFilter\` using its globally unique \`ID\`."""
   childNoRelatedFilter(
-    \\"\\"\\"
+    """
     The globally unique \`ID\` to be used in selecting a single \`ChildNoRelatedFilter\`.
-    \\"\\"\\"
+    """
     nodeId: ID!
   ): ChildNoRelatedFilter
   childNoRelatedFilterById(id: Int!): ChildNoRelatedFilter
 
-  \\"\\"\\"Reads a single \`DomainType\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`DomainType\` using its globally unique \`ID\`."""
   domainType(
-    \\"\\"\\"
+    """
     The globally unique \`ID\` to be used in selecting a single \`DomainType\`.
-    \\"\\"\\"
+    """
     nodeId: ID!
   ): DomainType
   domainTypeById(id: Int!): DomainType
 
-  \\"\\"\\"Reads a single \`EnumArrayType\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`EnumArrayType\` using its globally unique \`ID\`."""
   enumArrayType(
-    \\"\\"\\"
+    """
     The globally unique \`ID\` to be used in selecting a single \`EnumArrayType\`.
-    \\"\\"\\"
+    """
     nodeId: ID!
   ): EnumArrayType
   enumArrayTypeById(id: Int!): EnumArrayType
 
-  \\"\\"\\"Reads a single \`EnumType\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`EnumType\` using its globally unique \`ID\`."""
   enumType(
-    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`EnumType\`.\\"\\"\\"
+    """The globally unique \`ID\` to be used in selecting a single \`EnumType\`."""
     nodeId: ID!
   ): EnumType
   enumTypeById(id: Int!): EnumType
 
-  \\"\\"\\"Reads a single \`Filterable\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`Filterable\` using its globally unique \`ID\`."""
   filterable(
-    \\"\\"\\"
+    """
     The globally unique \`ID\` to be used in selecting a single \`Filterable\`.
-    \\"\\"\\"
+    """
     nodeId: ID!
   ): Filterable
   filterableByBackwardCompound1AndBackwardCompound2(backwardCompound1: Int!, backwardCompound2: Int!): Filterable
@@ -5510,247 +5510,247 @@ type Query implements Node {
   filterableByForwardId(forwardId: Int!): Filterable
   filterableById(id: Int!): Filterable
 
-  \\"\\"\\"Reads a single \`FilterableClosure\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`FilterableClosure\` using its globally unique \`ID\`."""
   filterableClosure(
-    \\"\\"\\"
+    """
     The globally unique \`ID\` to be used in selecting a single \`FilterableClosure\`.
-    \\"\\"\\"
+    """
     nodeId: ID!
   ): FilterableClosure
   filterableClosureById(id: Int!): FilterableClosure
 
-  \\"\\"\\"Reads a single \`Forward\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`Forward\` using its globally unique \`ID\`."""
   forward(
-    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`Forward\`.\\"\\"\\"
+    """The globally unique \`ID\` to be used in selecting a single \`Forward\`."""
     nodeId: ID!
   ): Forward
   forwardById(id: Int!): Forward
 
-  \\"\\"\\"Reads a single \`ForwardCompound\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`ForwardCompound\` using its globally unique \`ID\`."""
   forwardCompound(
-    \\"\\"\\"
+    """
     The globally unique \`ID\` to be used in selecting a single \`ForwardCompound\`.
-    \\"\\"\\"
+    """
     nodeId: ID!
   ): ForwardCompound
   forwardCompoundByForwardCompound1AndForwardCompound2(forwardCompound1: Int!, forwardCompound2: Int!): ForwardCompound
 
-  \\"\\"\\"Reads a single \`FullyOmitted\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`FullyOmitted\` using its globally unique \`ID\`."""
   fullyOmitted(
-    \\"\\"\\"
+    """
     The globally unique \`ID\` to be used in selecting a single \`FullyOmitted\`.
-    \\"\\"\\"
+    """
     nodeId: ID!
   ): FullyOmitted
   fullyOmittedById(id: Int!): FullyOmitted
   funcReturnsTableMultiCol(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: FuncReturnsTableMultiColRecordFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
     i: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
   ): FuncReturnsTableMultiColConnection!
   funcReturnsTableOneCol(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: IntFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
     i: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
   ): FuncReturnsTableOneColConnection!
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Filterable\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Filterable\`."""
   funcTaggedFilterableReturnsSetofFilterable(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: FilterableFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
   ): FilterablesConnection!
   funcTaggedFilterableReturnsTableMultiCol(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: FuncTaggedFilterableReturnsTableMultiColRecordFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
   ): FuncTaggedFilterableReturnsTableMultiColConnection!
 
-  \\"\\"\\"Reads a single \`JsonbTest\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`JsonbTest\` using its globally unique \`ID\`."""
   jsonbTest(
-    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`JsonbTest\`.\\"\\"\\"
+    """The globally unique \`ID\` to be used in selecting a single \`JsonbTest\`."""
     nodeId: ID!
   ): JsonbTest
   jsonbTestById(id: Int!): JsonbTest
 
-  \\"\\"\\"Reads a single \`Junction\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`Junction\` using its globally unique \`ID\`."""
   junction(
-    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`Junction\`.\\"\\"\\"
+    """The globally unique \`ID\` to be used in selecting a single \`Junction\`."""
     nodeId: ID!
   ): Junction
   junctionBySideAIdAndSideBId(sideAId: Int!, sideBId: Int!): Junction
 
-  \\"\\"\\"Fetches an object given its globally unique \`ID\`.\\"\\"\\"
+  """Fetches an object given its globally unique \`ID\`."""
   node(
-    \\"\\"\\"The globally unique \`ID\`.\\"\\"\\"
+    """The globally unique \`ID\`."""
     nodeId: ID!
   ): Node
 
-  \\"\\"\\"
+  """
   The root query type must be a \`Node\` to work well with Relay 1 mutations. This just resolves to \`query\`.
-  \\"\\"\\"
+  """
   nodeId: ID!
 
-  \\"\\"\\"Reads a single \`Parent\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`Parent\` using its globally unique \`ID\`."""
   parent(
-    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`Parent\`.\\"\\"\\"
+    """The globally unique \`ID\` to be used in selecting a single \`Parent\`."""
     nodeId: ID!
   ): Parent
   parentById(id: Int!): Parent
 
-  \\"\\"\\"Reads a single \`Protected\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`Protected\` using its globally unique \`ID\`."""
   protected(
-    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`Protected\`.\\"\\"\\"
+    """The globally unique \`ID\` to be used in selecting a single \`Protected\`."""
     nodeId: ID!
   ): Protected
   protectedById(id: Int!): Protected
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Protected\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Protected\`."""
   protectedsByOtherId(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: ProtectedFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
     otherId: Int
   ): ProtectedsConnection!
 
-  \\"\\"\\"
+  """
   Exposes the root query type nested one level down. This is helpful for Relay 1
   which can only query top level fields if they are in a particular form.
-  \\"\\"\\"
+  """
   query: Query!
 
-  \\"\\"\\"Reads a single \`RangeArrayType\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`RangeArrayType\` using its globally unique \`ID\`."""
   rangeArrayType(
-    \\"\\"\\"
+    """
     The globally unique \`ID\` to be used in selecting a single \`RangeArrayType\`.
-    \\"\\"\\"
+    """
     nodeId: ID!
   ): RangeArrayType
   rangeArrayTypeById(id: Int!): RangeArrayType
 
-  \\"\\"\\"Reads a single \`RangeType\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`RangeType\` using its globally unique \`ID\`."""
   rangeType(
-    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`RangeType\`.\\"\\"\\"
+    """The globally unique \`ID\` to be used in selecting a single \`RangeType\`."""
     nodeId: ID!
   ): RangeType
   rangeTypeById(id: Int!): RangeType
 
-  \\"\\"\\"Reads a single \`SideA\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`SideA\` using its globally unique \`ID\`."""
   sideA(
-    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`SideA\`.\\"\\"\\"
+    """The globally unique \`ID\` to be used in selecting a single \`SideA\`."""
     nodeId: ID!
   ): SideA
   sideAByAId(aId: Int!): SideA
 
-  \\"\\"\\"Reads a single \`SideB\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`SideB\` using its globally unique \`ID\`."""
   sideB(
-    \\"\\"\\"The globally unique \`ID\` to be used in selecting a single \`SideB\`.\\"\\"\\"
+    """The globally unique \`ID\` to be used in selecting a single \`SideB\`."""
     nodeId: ID!
   ): SideB
   sideBByBId(bId: Int!): SideB
 
-  \\"\\"\\"Reads a single \`Unfilterable\` using its globally unique \`ID\`.\\"\\"\\"
+  """Reads a single \`Unfilterable\` using its globally unique \`ID\`."""
   unfilterable(
-    \\"\\"\\"
+    """
     The globally unique \`ID\` to be used in selecting a single \`Unfilterable\`.
-    \\"\\"\\"
+    """
     nodeId: ID!
   ): Unfilterable
   unfilterableById(id: Int!): Unfilterable
@@ -5762,77 +5762,77 @@ type RangeArrayType implements Node {
   int4RangeArray: [IntRange]
   int8RangeArray: [BigIntRange]
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
   numericRangeArray: [BigFloatRange]
   timestampRangeArray: [DatetimeRange]
   timestamptzRangeArray: [DatetimeRange]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`RangeArrayType\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input RangeArrayTypeFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [RangeArrayTypeFilter!]
 
-  \\"\\"\\"Filter by the object’s \`dateRangeArray\` field.\\"\\"\\"
+  """Filter by the object’s \`dateRangeArray\` field."""
   dateRangeArray: DateRangeListFilter
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`int4RangeArray\` field.\\"\\"\\"
+  """Filter by the object’s \`int4RangeArray\` field."""
   int4RangeArray: IntRangeListFilter
 
-  \\"\\"\\"Filter by the object’s \`int8RangeArray\` field.\\"\\"\\"
+  """Filter by the object’s \`int8RangeArray\` field."""
   int8RangeArray: BigIntRangeListFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: RangeArrayTypeFilter
 
-  \\"\\"\\"Filter by the object’s \`numericRangeArray\` field.\\"\\"\\"
+  """Filter by the object’s \`numericRangeArray\` field."""
   numericRangeArray: BigFloatRangeListFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [RangeArrayTypeFilter!]
 
-  \\"\\"\\"Filter by the object’s \`timestampRangeArray\` field.\\"\\"\\"
+  """Filter by the object’s \`timestampRangeArray\` field."""
   timestampRangeArray: DatetimeRangeListFilter
 
-  \\"\\"\\"Filter by the object’s \`timestamptzRangeArray\` field.\\"\\"\\"
+  """Filter by the object’s \`timestamptzRangeArray\` field."""
   timestamptzRangeArray: DatetimeRangeListFilter
 }
 
-\\"\\"\\"A connection to a list of \`RangeArrayType\` values.\\"\\"\\"
+"""A connection to a list of \`RangeArrayType\` values."""
 type RangeArrayTypesConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`RangeArrayType\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [RangeArrayTypesEdge!]!
 
-  \\"\\"\\"A list of \`RangeArrayType\` objects.\\"\\"\\"
+  """A list of \`RangeArrayType\` objects."""
   nodes: [RangeArrayType]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`RangeArrayType\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`RangeArrayType\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`RangeArrayType\` edge in the connection.\\"\\"\\"
+"""A \`RangeArrayType\` edge in the connection."""
 type RangeArrayTypesEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`RangeArrayType\` at the end of the edge.\\"\\"\\"
+  """The \`RangeArrayType\` at the end of the edge."""
   node: RangeArrayType
 }
 
-\\"\\"\\"Methods to use when ordering \`RangeArrayType\`.\\"\\"\\"
+"""Methods to use when ordering \`RangeArrayType\`."""
 enum RangeArrayTypesOrderBy {
   DATE_RANGE_ARRAY_ASC
   DATE_RANGE_ARRAY_DESC
@@ -5859,77 +5859,77 @@ type RangeType implements Node {
   int4Range: IntRange
   int8Range: BigIntRange
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
   numericRange: BigFloatRange
   timestampRange: DatetimeRange
   timestamptzRange: DatetimeRange
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`RangeType\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input RangeTypeFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [RangeTypeFilter!]
 
-  \\"\\"\\"Filter by the object’s \`dateRange\` field.\\"\\"\\"
+  """Filter by the object’s \`dateRange\` field."""
   dateRange: DateRangeFilter
 
-  \\"\\"\\"Filter by the object’s \`id\` field.\\"\\"\\"
+  """Filter by the object’s \`id\` field."""
   id: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`int4Range\` field.\\"\\"\\"
+  """Filter by the object’s \`int4Range\` field."""
   int4Range: IntRangeFilter
 
-  \\"\\"\\"Filter by the object’s \`int8Range\` field.\\"\\"\\"
+  """Filter by the object’s \`int8Range\` field."""
   int8Range: BigIntRangeFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: RangeTypeFilter
 
-  \\"\\"\\"Filter by the object’s \`numericRange\` field.\\"\\"\\"
+  """Filter by the object’s \`numericRange\` field."""
   numericRange: BigFloatRangeFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [RangeTypeFilter!]
 
-  \\"\\"\\"Filter by the object’s \`timestampRange\` field.\\"\\"\\"
+  """Filter by the object’s \`timestampRange\` field."""
   timestampRange: DatetimeRangeFilter
 
-  \\"\\"\\"Filter by the object’s \`timestamptzRange\` field.\\"\\"\\"
+  """Filter by the object’s \`timestamptzRange\` field."""
   timestamptzRange: DatetimeRangeFilter
 }
 
-\\"\\"\\"A connection to a list of \`RangeType\` values.\\"\\"\\"
+"""A connection to a list of \`RangeType\` values."""
 type RangeTypesConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`RangeType\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [RangeTypesEdge!]!
 
-  \\"\\"\\"A list of \`RangeType\` objects.\\"\\"\\"
+  """A list of \`RangeType\` objects."""
   nodes: [RangeType]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`RangeType\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`RangeType\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`RangeType\` edge in the connection.\\"\\"\\"
+"""A \`RangeType\` edge in the connection."""
 type RangeTypesEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`RangeType\` at the end of the edge.\\"\\"\\"
+  """The \`RangeType\` at the end of the edge."""
   node: RangeType
 }
 
-\\"\\"\\"Methods to use when ordering \`RangeType\`.\\"\\"\\"
+"""Methods to use when ordering \`RangeType\`."""
 enum RangeTypesOrderBy {
   DATE_RANGE_ASC
   DATE_RANGE_DESC
@@ -5953,89 +5953,89 @@ enum RangeTypesOrderBy {
 type SideA implements Node {
   aId: Int!
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Junction\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Junction\`."""
   junctionsBySideAId(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: JunctionFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`Junction\`.\\"\\"\\"
+    """The method to use when ordering \`Junction\`."""
     orderBy: [JunctionsOrderBy!] = [PRIMARY_KEY_ASC]
   ): JunctionsConnection!
   name: String!
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`SideA\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input SideAFilter {
-  \\"\\"\\"Filter by the object’s \`aId\` field.\\"\\"\\"
+  """Filter by the object’s \`aId\` field."""
   aId: IntFilter
 
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [SideAFilter!]
 
-  \\"\\"\\"Filter by the object’s \`name\` field.\\"\\"\\"
+  """Filter by the object’s \`name\` field."""
   name: StringFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: SideAFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [SideAFilter!]
 }
 
-\\"\\"\\"A connection to a list of \`SideA\` values.\\"\\"\\"
+"""A connection to a list of \`SideA\` values."""
 type SideAsConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`SideA\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [SideAsEdge!]!
 
-  \\"\\"\\"A list of \`SideA\` objects.\\"\\"\\"
+  """A list of \`SideA\` objects."""
   nodes: [SideA]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`SideA\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`SideA\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`SideA\` edge in the connection.\\"\\"\\"
+"""A \`SideA\` edge in the connection."""
 type SideAsEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`SideA\` at the end of the edge.\\"\\"\\"
+  """The \`SideA\` at the end of the edge."""
   node: SideA
 }
 
-\\"\\"\\"Methods to use when ordering \`SideA\`.\\"\\"\\"
+"""Methods to use when ordering \`SideA\`."""
 enum SideAsOrderBy {
   A_ID_ASC
   A_ID_DESC
@@ -6049,89 +6049,89 @@ enum SideAsOrderBy {
 type SideB implements Node {
   bId: Int!
 
-  \\"\\"\\"Reads and enables pagination through a set of \`Junction\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`Junction\`."""
   junctionsBySideBId(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: JunctionFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`Junction\`.\\"\\"\\"
+    """The method to use when ordering \`Junction\`."""
     orderBy: [JunctionsOrderBy!] = [PRIMARY_KEY_ASC]
   ): JunctionsConnection!
   name: String!
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
 }
 
-\\"\\"\\"
+"""
 A filter to be used against \`SideB\` object types. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input SideBFilter {
-  \\"\\"\\"Checks for all expressions in this list.\\"\\"\\"
+  """Checks for all expressions in this list."""
   and: [SideBFilter!]
 
-  \\"\\"\\"Filter by the object’s \`bId\` field.\\"\\"\\"
+  """Filter by the object’s \`bId\` field."""
   bId: IntFilter
 
-  \\"\\"\\"Filter by the object’s \`name\` field.\\"\\"\\"
+  """Filter by the object’s \`name\` field."""
   name: StringFilter
 
-  \\"\\"\\"Negates the expression.\\"\\"\\"
+  """Negates the expression."""
   not: SideBFilter
 
-  \\"\\"\\"Checks for any expressions in this list.\\"\\"\\"
+  """Checks for any expressions in this list."""
   or: [SideBFilter!]
 }
 
-\\"\\"\\"A connection to a list of \`SideB\` values.\\"\\"\\"
+"""A connection to a list of \`SideB\` values."""
 type SideBsConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`SideB\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [SideBsEdge!]!
 
-  \\"\\"\\"A list of \`SideB\` objects.\\"\\"\\"
+  """A list of \`SideB\` objects."""
   nodes: [SideB]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`SideB\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`SideB\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`SideB\` edge in the connection.\\"\\"\\"
+"""A \`SideB\` edge in the connection."""
 type SideBsEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`SideB\` at the end of the edge.\\"\\"\\"
+  """The \`SideB\` at the end of the edge."""
   node: SideB
 }
 
-\\"\\"\\"Methods to use when ordering \`SideB\`.\\"\\"\\"
+"""Methods to use when ordering \`SideB\`."""
 enum SideBsOrderBy {
   B_ID_ASC
   B_ID_DESC
@@ -6142,382 +6142,382 @@ enum SideBsOrderBy {
   PRIMARY_KEY_DESC
 }
 
-\\"\\"\\"
+"""
 A filter to be used against String fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input StringFilter {
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: String
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value (case-insensitive).
-  \\"\\"\\"
+  """
   distinctFromInsensitive: String
 
-  \\"\\"\\"Ends with the specified string (case-sensitive).\\"\\"\\"
+  """Ends with the specified string (case-sensitive)."""
   endsWith: String
 
-  \\"\\"\\"Ends with the specified string (case-insensitive).\\"\\"\\"
+  """Ends with the specified string (case-insensitive)."""
   endsWithInsensitive: String
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: String
 
-  \\"\\"\\"Equal to the specified value (case-insensitive).\\"\\"\\"
+  """Equal to the specified value (case-insensitive)."""
   equalToInsensitive: String
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: String
 
-  \\"\\"\\"Greater than the specified value (case-insensitive).\\"\\"\\"
+  """Greater than the specified value (case-insensitive)."""
   greaterThanInsensitive: String
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: String
 
-  \\"\\"\\"Greater than or equal to the specified value (case-insensitive).\\"\\"\\"
+  """Greater than or equal to the specified value (case-insensitive)."""
   greaterThanOrEqualToInsensitive: String
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [String!]
 
-  \\"\\"\\"Included in the specified list (case-insensitive).\\"\\"\\"
-  inInsensitive: [String!]
-
-  \\"\\"\\"Contains the specified string (case-sensitive).\\"\\"\\"
+  """Contains the specified string (case-sensitive)."""
   includes: String
 
-  \\"\\"\\"Contains the specified string (case-insensitive).\\"\\"\\"
+  """Contains the specified string (case-insensitive)."""
   includesInsensitive: String
 
-  \\"\\"\\"
+  """Included in the specified list (case-insensitive)."""
+  inInsensitive: [String!]
+
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: String
 
-  \\"\\"\\"Less than the specified value (case-insensitive).\\"\\"\\"
+  """Less than the specified value (case-insensitive)."""
   lessThanInsensitive: String
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: String
 
-  \\"\\"\\"Less than or equal to the specified value (case-insensitive).\\"\\"\\"
+  """Less than or equal to the specified value (case-insensitive)."""
   lessThanOrEqualToInsensitive: String
 
-  \\"\\"\\"
+  """
   Matches the specified pattern (case-sensitive). An underscore (_) matches any
   single character; a percent sign (%) matches any sequence of zero or more characters.
-  \\"\\"\\"
+  """
   like: String
 
-  \\"\\"\\"
+  """
   Matches the specified pattern (case-insensitive). An underscore (_) matches
   any single character; a percent sign (%) matches any sequence of zero or more characters.
-  \\"\\"\\"
+  """
   likeInsensitive: String
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: String
 
-  \\"\\"\\"
+  """
   Equal to the specified value, treating null like an ordinary value (case-insensitive).
-  \\"\\"\\"
+  """
   notDistinctFromInsensitive: String
 
-  \\"\\"\\"Does not end with the specified string (case-sensitive).\\"\\"\\"
+  """Does not end with the specified string (case-sensitive)."""
   notEndsWith: String
 
-  \\"\\"\\"Does not end with the specified string (case-insensitive).\\"\\"\\"
+  """Does not end with the specified string (case-insensitive)."""
   notEndsWithInsensitive: String
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: String
 
-  \\"\\"\\"Not equal to the specified value (case-insensitive).\\"\\"\\"
+  """Not equal to the specified value (case-insensitive)."""
   notEqualToInsensitive: String
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [String!]
 
-  \\"\\"\\"Not included in the specified list (case-insensitive).\\"\\"\\"
-  notInInsensitive: [String!]
-
-  \\"\\"\\"Does not contain the specified string (case-sensitive).\\"\\"\\"
+  """Does not contain the specified string (case-sensitive)."""
   notIncludes: String
 
-  \\"\\"\\"Does not contain the specified string (case-insensitive).\\"\\"\\"
+  """Does not contain the specified string (case-insensitive)."""
   notIncludesInsensitive: String
 
-  \\"\\"\\"
+  """Not included in the specified list (case-insensitive)."""
+  notInInsensitive: [String!]
+
+  """
   Does not match the specified pattern (case-sensitive). An underscore (_)
   matches any single character; a percent sign (%) matches any sequence of zero
   or more characters.
-  \\"\\"\\"
+  """
   notLike: String
 
-  \\"\\"\\"
+  """
   Does not match the specified pattern (case-insensitive). An underscore (_)
   matches any single character; a percent sign (%) matches any sequence of zero
   or more characters.
-  \\"\\"\\"
+  """
   notLikeInsensitive: String
 
-  \\"\\"\\"Does not start with the specified string (case-sensitive).\\"\\"\\"
+  """Does not start with the specified string (case-sensitive)."""
   notStartsWith: String
 
-  \\"\\"\\"Does not start with the specified string (case-insensitive).\\"\\"\\"
+  """Does not start with the specified string (case-insensitive)."""
   notStartsWithInsensitive: String
 
-  \\"\\"\\"Starts with the specified string (case-sensitive).\\"\\"\\"
+  """Starts with the specified string (case-sensitive)."""
   startsWith: String
 
-  \\"\\"\\"Starts with the specified string (case-insensitive).\\"\\"\\"
+  """Starts with the specified string (case-insensitive)."""
   startsWithInsensitive: String
 }
 
-\\"\\"\\"
+"""
 A filter to be used against String List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input StringListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: String
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: String
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: String
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: String
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: String
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: String
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [String]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [String]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [String]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [String]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [String]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [String]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [String]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [String]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [String]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [String]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [String]
 }
 
-\\"\\"\\"
+"""
 The exact time of day, does not include the date. May or may not have a timezone offset.
-\\"\\"\\"
+"""
 scalar Time
 
-\\"\\"\\"
+"""
 A filter to be used against Time fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input TimeFilter {
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: Time
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: Time
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: Time
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: Time
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [Time!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: Time
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: Time
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: Time
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: Time
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [Time!]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against Time List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input TimeListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: Time
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: Time
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: Time
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: Time
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: Time
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: Time
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [Time]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [Time]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [Time]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [Time]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [Time]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [Time]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [Time]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [Time]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [Time]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [Time]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [Time]
 }
 
 type Unfilterable implements Node {
-  \\"\\"\\"Reads and enables pagination through a set of \`ChildNoRelatedFilter\`.\\"\\"\\"
+  """Reads and enables pagination through a set of \`ChildNoRelatedFilter\`."""
   childNoRelatedFiltersByUnfilterableId(
-    \\"\\"\\"Read all values in the set after (below) this cursor.\\"\\"\\"
+    """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    \\"\\"\\"Read all values in the set before (above) this cursor.\\"\\"\\"
+    """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    \\"\\"\\"
+    """
     A filter to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
+    """
     filter: ChildNoRelatedFilterFilter
 
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
+    """Only read the first \`n\` values of the set."""
     first: Int
 
-    \\"\\"\\"Only read the last \`n\` values of the set.\\"\\"\\"
+    """Only read the last \`n\` values of the set."""
     last: Int
 
-    \\"\\"\\"
+    """
     Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
     based pagination. May not be used with \`last\`.
-    \\"\\"\\"
+    """
     offset: Int
 
-    \\"\\"\\"The method to use when ordering \`ChildNoRelatedFilter\`.\\"\\"\\"
+    """The method to use when ordering \`ChildNoRelatedFilter\`."""
     orderBy: [ChildNoRelatedFiltersOrderBy!] = [PRIMARY_KEY_ASC]
   ): ChildNoRelatedFiltersConnection!
   id: Int!
 
-  \\"\\"\\"
+  """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  \\"\\"\\"
+  """
   nodeId: ID!
   text: String
 }
 
-\\"\\"\\"A connection to a list of \`Unfilterable\` values.\\"\\"\\"
+"""A connection to a list of \`Unfilterable\` values."""
 type UnfilterablesConnection {
-  \\"\\"\\"
+  """
   A list of edges which contains the \`Unfilterable\` and cursor to aid in pagination.
-  \\"\\"\\"
+  """
   edges: [UnfilterablesEdge!]!
 
-  \\"\\"\\"A list of \`Unfilterable\` objects.\\"\\"\\"
+  """A list of \`Unfilterable\` objects."""
   nodes: [Unfilterable]!
 
-  \\"\\"\\"Information to aid in pagination.\\"\\"\\"
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  \\"\\"\\"The count of *all* \`Unfilterable\` you could get from the connection.\\"\\"\\"
+  """The count of *all* \`Unfilterable\` you could get from the connection."""
   totalCount: Int!
 }
 
-\\"\\"\\"A \`Unfilterable\` edge in the connection.\\"\\"\\"
+"""A \`Unfilterable\` edge in the connection."""
 type UnfilterablesEdge {
-  \\"\\"\\"A cursor for use in pagination.\\"\\"\\"
+  """A cursor for use in pagination."""
   cursor: Cursor
 
-  \\"\\"\\"The \`Unfilterable\` at the end of the edge.\\"\\"\\"
+  """The \`Unfilterable\` at the end of the edge."""
   node: Unfilterable
 }
 
-\\"\\"\\"Methods to use when ordering \`Unfilterable\`.\\"\\"\\"
+"""Methods to use when ordering \`Unfilterable\`."""
 enum UnfilterablesOrderBy {
   ID_ASC
   ID_DESC
@@ -6528,114 +6528,114 @@ enum UnfilterablesOrderBy {
   TEXT_DESC
 }
 
-\\"\\"\\"
+"""
 A universally unique identifier as defined by [RFC 4122](https://tools.ietf.org/html/rfc4122).
-\\"\\"\\"
+"""
 scalar UUID
 
-\\"\\"\\"
+"""
 A filter to be used against UUID fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input UUIDFilter {
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: UUID
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: UUID
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: UUID
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: UUID
 
-  \\"\\"\\"Included in the specified list.\\"\\"\\"
+  """Included in the specified list."""
   in: [UUID!]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: UUID
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: UUID
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: UUID
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: UUID
 
-  \\"\\"\\"Not included in the specified list.\\"\\"\\"
+  """Not included in the specified list."""
   notIn: [UUID!]
 }
 
-\\"\\"\\"
+"""
 A filter to be used against UUID List fields. All fields are combined with a logical ‘and.’
-\\"\\"\\"
+"""
 input UUIDListFilter {
-  \\"\\"\\"Any array item is equal to the specified value.\\"\\"\\"
+  """Any array item is equal to the specified value."""
   anyEqualTo: UUID
 
-  \\"\\"\\"Any array item is greater than the specified value.\\"\\"\\"
+  """Any array item is greater than the specified value."""
   anyGreaterThan: UUID
 
-  \\"\\"\\"Any array item is greater than or equal to the specified value.\\"\\"\\"
+  """Any array item is greater than or equal to the specified value."""
   anyGreaterThanOrEqualTo: UUID
 
-  \\"\\"\\"Any array item is less than the specified value.\\"\\"\\"
+  """Any array item is less than the specified value."""
   anyLessThan: UUID
 
-  \\"\\"\\"Any array item is less than or equal to the specified value.\\"\\"\\"
+  """Any array item is less than or equal to the specified value."""
   anyLessThanOrEqualTo: UUID
 
-  \\"\\"\\"Any array item is not equal to the specified value.\\"\\"\\"
+  """Any array item is not equal to the specified value."""
   anyNotEqualTo: UUID
 
-  \\"\\"\\"Contained by the specified list of values.\\"\\"\\"
+  """Contained by the specified list of values."""
   containedBy: [UUID]
 
-  \\"\\"\\"Contains the specified list of values.\\"\\"\\"
+  """Contains the specified list of values."""
   contains: [UUID]
 
-  \\"\\"\\"
+  """
   Not equal to the specified value, treating null like an ordinary value.
-  \\"\\"\\"
+  """
   distinctFrom: [UUID]
 
-  \\"\\"\\"Equal to the specified value.\\"\\"\\"
+  """Equal to the specified value."""
   equalTo: [UUID]
 
-  \\"\\"\\"Greater than the specified value.\\"\\"\\"
+  """Greater than the specified value."""
   greaterThan: [UUID]
 
-  \\"\\"\\"Greater than or equal to the specified value.\\"\\"\\"
+  """Greater than or equal to the specified value."""
   greaterThanOrEqualTo: [UUID]
 
-  \\"\\"\\"
+  """
   Is null (if \`true\` is specified) or is not null (if \`false\` is specified).
-  \\"\\"\\"
+  """
   isNull: Boolean
 
-  \\"\\"\\"Less than the specified value.\\"\\"\\"
+  """Less than the specified value."""
   lessThan: [UUID]
 
-  \\"\\"\\"Less than or equal to the specified value.\\"\\"\\"
+  """Less than or equal to the specified value."""
   lessThanOrEqualTo: [UUID]
 
-  \\"\\"\\"Equal to the specified value, treating null like an ordinary value.\\"\\"\\"
+  """Equal to the specified value, treating null like an ordinary value."""
   notDistinctFrom: [UUID]
 
-  \\"\\"\\"Not equal to the specified value.\\"\\"\\"
+  """Not equal to the specified value."""
   notEqualTo: [UUID]
 
-  \\"\\"\\"Overlaps the specified list of values.\\"\\"\\"
+  """Overlaps the specified list of values."""
   overlaps: [UUID]
 }
-"
+
 `;

--- a/__tests__/integration/schema/core.ts
+++ b/__tests__/integration/schema/core.ts
@@ -1,6 +1,7 @@
 import * as pg from "pg";
+import { lexicographicSortSchema } from "graphql";
 import { createPostGraphileSchema } from "postgraphile-core";
-import { printSchemaOrdered, withPgClient } from "../../helpers";
+import { withPgClient } from "../../helpers";
 
 export const test = (
   schemas: string[],
@@ -16,5 +17,5 @@ export const test = (
       }
     }
     const schema = await createPostGraphileSchema(client, schemas, options);
-    expect(printSchemaOrdered(schema)).toMatchSnapshot();
+    expect(lexicographicSortSchema(schema)).toMatchSnapshot();
   });

--- a/jest.config.js
+++ b/jest.config.js
@@ -5,4 +5,5 @@ module.exports = {
   },
   testRegex: "(/__tests__/.*\\.(test|spec))\\.[tj]sx?$",
   moduleFileExtensions: ["ts", "js", "json"],
+  snapshotSerializers: ["jest-serializer-graphql-schema"],
 };

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "eslint-plugin-jest": "24.3.3",
     "graphql": "14.7.0",
     "jest": "26.6.3",
+    "jest-serializer-graphql-schema": "^4.10.0",
     "pg": "8.5.1",
     "postgraphile-core": "4.5.0",
     "prettier": "2.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2692,6 +2692,13 @@ jest-runtime@^26.6.3:
     strip-bom "^4.0.0"
     yargs "^15.4.1"
 
+jest-serializer-graphql-schema@^4.10.0:
+  version "4.10.0"
+  resolved "https://registry.yarnpkg.com/jest-serializer-graphql-schema/-/jest-serializer-graphql-schema-4.10.0.tgz#debff8b58e8adc00e581eadf885e9a2e4619ab66"
+  integrity sha512-qBeF42OWaqTHYwSfnlfvmFB63VBy8PCmx1w1Mslgbv6fWleHSjAakIvIXJpiHcsKNWSLJArQ4wUYXko8qZzgSg==
+  dependencies:
+    tslib "^2.0.1"
+
 jest-serializer@^26.6.2:
   version "26.6.2"
   resolved "https://registry.yarnpkg.com/jest-serializer/-/jest-serializer-26.6.2.tgz#d139aafd46957d3a448f3a6cdabe2919ba0742d1"
@@ -4285,7 +4292,7 @@ tslib@^1.8.1:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
-tslib@^2.3.0:
+tslib@^2.0.1, tslib@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.0.tgz#803b8cdab3e12ba581a4ca41c8839bbb0dacb09e"
   integrity sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==


### PR DESCRIPTION
This Jest serializer basically nicely prints the GraphQL schemas, broadly this means all the `\\"\\"\\"` become simply `"""` so it's much easier to read, and you can also simply copy/paste the GraphQL schema out into a different file if you want to e.g. validate it with other tooling.

Built on #177.