### PR TITLE
Custom filter name via connectionFilterName

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,18 @@ To allow `null` and `{}` in inputs, use the `connectionFilterAllowNullInput` and
 
 When using PostGraphile as a library, the following plugin options can be passed via `graphileBuildOptions`:
 
+#### connectionFilterName
+
+Specify the name of the filter:
+
+```js
+postgraphile(pgConfig, schema, {
+  graphileBuildOptions: {
+    connectionFilterName: "filter" // default value
+  },
+});
+```
+
 #### connectionFilterAllowedOperators
 
 Restrict filtering to specific operators:

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "dist/index.js",
   "scripts": {
     "build": "tsc",
+    "postinstall": "npm run build",
     "format": "prettier --ignore-path ./.eslintignore",
     "format:all": "yarn format '**/*.{json,md,html,js,jsx,ts,tsx}'",
     "format:fix": "yarn format:all --write",

--- a/src/ConnectionArgFilterPlugin.ts
+++ b/src/ConnectionArgFilterPlugin.ts
@@ -2,18 +2,24 @@ import type { Plugin } from "graphile-build";
 
 const ConnectionArgFilterPlugin: Plugin = (builder) => {
   builder.hook("inflection", (inflection) => {
-    return Object.assign(inflection, {
-      filterType(typeName: string) {
-        return `${typeName}Filter`;
-      },
-      filterFieldType(typeName: string) {
-        return `${typeName}Filter`;
-      },
-      filterFieldListType(typeName: string) {
-        return `${typeName}ListFilter`;
-      },
+    const {
+      connectionFilterName = "filter"
+    } = inflection;
+    const camcelCasedFilterName = inflection.upperCamelCase(connectionFilterName);
+    return {
+      return Object.assign(inflection, {
+        filterType(typeName: string) {
+          return `${typeName}${camcelCasedFilterName}`;
+        },
+        filterFieldType(typeName: string) {
+          return `${typeName}${camcelCasedFilterName}`;
+        },
+        filterFieldListType(typeName: string) {
+          return `${typeName}List${camcelCasedFilterName}`;
+        },
+      });
     });
-  });
+  }
 };
 
 export default ConnectionArgFilterPlugin;

--- a/src/ConnectionArgFilterPlugin.ts
+++ b/src/ConnectionArgFilterPlugin.ts
@@ -17,7 +17,7 @@ const ConnectionArgFilterPlugin: Plugin = (builder) => {
         return `${typeName}List${camcelCasedFilterName}`;
       },
     });
-  }
+  });
 };
 
 export default ConnectionArgFilterPlugin;

--- a/src/ConnectionArgFilterPlugin.ts
+++ b/src/ConnectionArgFilterPlugin.ts
@@ -6,18 +6,16 @@ const ConnectionArgFilterPlugin: Plugin = (builder) => {
       connectionFilterName = "filter"
     } = inflection;
     const camcelCasedFilterName = inflection.upperCamelCase(connectionFilterName);
-    return {
-      return Object.assign(inflection, {
-        filterType(typeName: string) {
-          return `${typeName}${camcelCasedFilterName}`;
-        },
-        filterFieldType(typeName: string) {
-          return `${typeName}${camcelCasedFilterName}`;
-        },
-        filterFieldListType(typeName: string) {
-          return `${typeName}List${camcelCasedFilterName}`;
-        },
-      });
+    return Object.assign(inflection, {
+      filterType(typeName: string) {
+        return `${typeName}${camcelCasedFilterName}`;
+      },
+      filterFieldType(typeName: string) {
+        return `${typeName}${camcelCasedFilterName}`;
+      },
+      filterFieldListType(typeName: string) {
+        return `${typeName}List${camcelCasedFilterName}`;
+      },
     });
   }
 };

--- a/src/ConnectionArgFilterPlugin.ts
+++ b/src/ConnectionArgFilterPlugin.ts
@@ -3,7 +3,7 @@ import type { Plugin } from "graphile-build";
 const ConnectionArgFilterPlugin: Plugin = (builder) => {
   builder.hook("inflection", (inflection) => {
     const {
-      connectionFilterName = "filter"
+      connectionFilterName = "where"
     } = inflection;
     const camcelCasedFilterName = inflection.upperCamelCase(connectionFilterName);
     return Object.assign(inflection, {

--- a/src/PgConnectionArgFilterBackwardRelationsPlugin.ts
+++ b/src/PgConnectionArgFilterBackwardRelationsPlugin.ts
@@ -4,7 +4,7 @@ import { ConnectionFilterResolver } from "./PgConnectionArgFilterPlugin";
 
 const PgConnectionArgFilterBackwardRelationsPlugin: Plugin = (
   builder,
-  { pgSimpleCollections, pgOmitListSuffix, connectionFilterUseListInflectors, connectionFilterName = "filter" }
+  { pgSimpleCollections, pgOmitListSuffix, connectionFilterUseListInflectors, connectionFilterName = "where" }
 ) => {
   const hasConnections = pgSimpleCollections !== "only";
   const simpleInflectorsAreShorter = pgOmitListSuffix === true;

--- a/src/PgConnectionArgFilterBackwardRelationsPlugin.ts
+++ b/src/PgConnectionArgFilterBackwardRelationsPlugin.ts
@@ -4,7 +4,7 @@ import { ConnectionFilterResolver } from "./PgConnectionArgFilterPlugin";
 
 const PgConnectionArgFilterBackwardRelationsPlugin: Plugin = (
   builder,
-  { pgSimpleCollections, pgOmitListSuffix, connectionFilterUseListInflectors, connectionFilterName = "where" }
+  { pgSimpleCollections, pgOmitListSuffix, connectionFilterUseListInflectors, connectionFilterName = "filter" }
 ) => {
   const hasConnections = pgSimpleCollections !== "only";
   const simpleInflectorsAreShorter = pgOmitListSuffix === true;

--- a/src/PgConnectionArgFilterBackwardRelationsPlugin.ts
+++ b/src/PgConnectionArgFilterBackwardRelationsPlugin.ts
@@ -4,7 +4,7 @@ import { ConnectionFilterResolver } from "./PgConnectionArgFilterPlugin";
 
 const PgConnectionArgFilterBackwardRelationsPlugin: Plugin = (
   builder,
-  { pgSimpleCollections, pgOmitListSuffix, connectionFilterUseListInflectors }
+  { pgSimpleCollections, pgOmitListSuffix, connectionFilterUseListInflectors, connectionFilterName = "filter" }
 ) => {
   const hasConnections = pgSimpleCollections !== "only";
   const simpleInflectorsAreShorter = pgOmitListSuffix === true;
@@ -28,7 +28,7 @@ const PgConnectionArgFilterBackwardRelationsPlugin: Plugin = (
         return (this as any).upperCamelCase(
           `${(this as any).tableType(table)}-to-many-${(this as any).tableType(
             foreignTable
-          )}-filter`
+          )}-${connectionFilterName}`
         );
       },
       filterBackwardSingleRelationExistsFieldName(relationFieldName: string) {
@@ -79,7 +79,7 @@ const PgConnectionArgFilterBackwardRelationsPlugin: Plugin = (
       .reduce((memo: BackwardRelationSpec[], foreignConstraint) => {
         if (
           omit(foreignConstraint, "read") ||
-          omit(foreignConstraint, "filter")
+          omit(foreignConstraint, connectionFilterName)
         ) {
           return memo;
         }
@@ -90,7 +90,7 @@ const PgConnectionArgFilterBackwardRelationsPlugin: Plugin = (
             `Could not find the foreign table (constraint: ${foreignConstraint.name})`
           );
         }
-        if (omit(foreignTable, "read") || omit(foreignTable, "filter")) {
+        if (omit(foreignTable, "read") || omit(foreignTable, connectionFilterName)) {
           return memo;
         }
         const attributes = (
@@ -309,7 +309,7 @@ const PgConnectionArgFilterBackwardRelationsPlugin: Plugin = (
               GraphQLInputObjectType,
               {
                 name: filterManyTypeName,
-                description: `A filter to be used against many \`${foreignTableTypeName}\` object types. All fields are combined with a logical ‘and.’`,
+                description: `A ${connectionFilterName} to be used against many \`${foreignTableTypeName}\` object types. All fields are combined with a logical ‘and.’`,
               },
               {
                 foreignTable,
@@ -340,7 +340,7 @@ const PgConnectionArgFilterBackwardRelationsPlugin: Plugin = (
             FilterManyType,
             makeResolveMany(spec),
             spec,
-            `Adding connection filter backward relation field from ${describePgEntity(
+            `Adding connection ${connectionFilterName} backward relation field from ${describePgEntity(
               table
             )} to ${describePgEntity(foreignTable)}`
           );
@@ -353,7 +353,7 @@ const PgConnectionArgFilterBackwardRelationsPlugin: Plugin = (
             GraphQLBoolean,
             resolveExists,
             spec,
-            `Adding connection filter backward relation exists field from ${describePgEntity(
+            `Adding connection ${connectionFilterName} backward relation exists field from ${describePgEntity(
               table
             )} to ${describePgEntity(foreignTable)}`
           );
@@ -373,7 +373,7 @@ const PgConnectionArgFilterBackwardRelationsPlugin: Plugin = (
           ForeignTableFilterType,
           resolveSingle,
           spec,
-          `Adding connection filter backward relation field from ${describePgEntity(
+          `Adding connection ${connectionFilterName} backward relation field from ${describePgEntity(
             table
           )} to ${describePgEntity(foreignTable)}`
         );
@@ -386,7 +386,7 @@ const PgConnectionArgFilterBackwardRelationsPlugin: Plugin = (
           GraphQLBoolean,
           resolveExists,
           spec,
-          `Adding connection filter backward relation exists field from ${describePgEntity(
+          `Adding connection ${connectionFilterName} backward relation exists field from ${describePgEntity(
             table
           )} to ${describePgEntity(foreignTable)}`
         );
@@ -431,7 +431,7 @@ const PgConnectionArgFilterBackwardRelationsPlugin: Plugin = (
       every: fieldWithHooks(
         "every",
         {
-          description: `Every related \`${foreignTableTypeName}\` matches the filter criteria. All fields are combined with a logical ‘and.’`,
+          description: `Every related \`${foreignTableTypeName}\` matches the ${connectionFilterName} criteria. All fields are combined with a logical ‘and.’`,
           type: FilterType,
         },
         {
@@ -441,7 +441,7 @@ const PgConnectionArgFilterBackwardRelationsPlugin: Plugin = (
       some: fieldWithHooks(
         "some",
         {
-          description: `Some related \`${foreignTableTypeName}\` matches the filter criteria. All fields are combined with a logical ‘and.’`,
+          description: `Some related \`${foreignTableTypeName}\` matches the ${connectionFilterName} criteria. All fields are combined with a logical ‘and.’`,
           type: FilterType,
         },
         {
@@ -451,7 +451,7 @@ const PgConnectionArgFilterBackwardRelationsPlugin: Plugin = (
       none: fieldWithHooks(
         "none",
         {
-          description: `No related \`${foreignTableTypeName}\` matches the filter criteria. All fields are combined with a logical ‘and.’`,
+          description: `No related \`${foreignTableTypeName}\` matches the ${connectionFilterName} criteria. All fields are combined with a logical ‘and.’`,
           type: FilterType,
         },
         {

--- a/src/PgConnectionArgFilterColumnsPlugin.ts
+++ b/src/PgConnectionArgFilterColumnsPlugin.ts
@@ -12,7 +12,7 @@ const PgConnectionArgFilterColumnsPlugin: Plugin = (builder) => {
       pgColumnFilter,
       pgOmit: omit,
       inflection,
-      connectionFilterName = "filter",
+      connectionFilterName = "where",
       connectionFilterOperatorsType,
       connectionFilterRegisterResolver,
       connectionFilterResolve,

--- a/src/PgConnectionArgFilterColumnsPlugin.ts
+++ b/src/PgConnectionArgFilterColumnsPlugin.ts
@@ -12,6 +12,7 @@ const PgConnectionArgFilterColumnsPlugin: Plugin = (builder) => {
       pgColumnFilter,
       pgOmit: omit,
       inflection,
+      connectionFilterName = "filter",
       connectionFilterOperatorsType,
       connectionFilterRegisterResolver,
       connectionFilterResolve,
@@ -32,7 +33,7 @@ const PgConnectionArgFilterColumnsPlugin: Plugin = (builder) => {
     )
       .filter((attr) => attr.classId === table.id)
       .filter((attr) => pgColumnFilter(attr, build, context))
-      .filter((attr) => !omit(attr, "filter"))
+      .filter((attr) => !omit(attr, connectionFilterName))
       .reduce((memo: { [fieldName: string]: PgAttribute }, attr) => {
         const fieldName: string = inflection.column(attr);
         memo[fieldName] = attr;

--- a/src/PgConnectionArgFilterCompositeTypeColumnsPlugin.ts
+++ b/src/PgConnectionArgFilterCompositeTypeColumnsPlugin.ts
@@ -16,6 +16,7 @@ const PgConnectionArgFilterCompositeTypeColumnsPlugin: Plugin = (
       pgColumnFilter,
       pgOmit: omit,
       inflection,
+      connectionFilterName = "filter",
       connectionFilterRegisterResolver,
       connectionFilterResolve,
       connectionFilterType,
@@ -36,7 +37,7 @@ const PgConnectionArgFilterCompositeTypeColumnsPlugin: Plugin = (
     )
       .filter((attr) => attr.classId === table.id)
       .filter((attr) => pgColumnFilter(attr, build, context))
-      .filter((attr) => !omit(attr, "filter"))
+      .filter((attr) => !omit(attr, connectionFilterName))
       .filter(
         (attr) =>
           attr.type &&

--- a/src/PgConnectionArgFilterCompositeTypeColumnsPlugin.ts
+++ b/src/PgConnectionArgFilterCompositeTypeColumnsPlugin.ts
@@ -16,7 +16,7 @@ const PgConnectionArgFilterCompositeTypeColumnsPlugin: Plugin = (
       pgColumnFilter,
       pgOmit: omit,
       inflection,
-      connectionFilterName = "filter",
+      connectionFilterName = "where",
       connectionFilterRegisterResolver,
       connectionFilterResolve,
       connectionFilterType,

--- a/src/PgConnectionArgFilterComputedColumnsPlugin.ts
+++ b/src/PgConnectionArgFilterComputedColumnsPlugin.ts
@@ -14,6 +14,7 @@ const PgConnectionArgFilterComputedColumnsPlugin: Plugin = (
       pgOmit: omit,
       pgSql: sql,
       inflection,
+      connectionFilterName = "filter",
       connectionFilterOperatorsType,
       connectionFilterRegisterResolver,
       connectionFilterResolve,
@@ -40,7 +41,7 @@ const PgConnectionArgFilterComputedColumnsPlugin: Plugin = (
 
       // Must not be omitted
       if (omit(proc, "execute")) return memo;
-      if (omit(proc, "filter")) return memo;
+      if (omit(proc, connectionFilterName)) return memo;
 
       // Must be a computed column
       const computedColumnDetails = getComputedColumnDetails(

--- a/src/PgConnectionArgFilterComputedColumnsPlugin.ts
+++ b/src/PgConnectionArgFilterComputedColumnsPlugin.ts
@@ -14,7 +14,7 @@ const PgConnectionArgFilterComputedColumnsPlugin: Plugin = (
       pgOmit: omit,
       pgSql: sql,
       inflection,
-      connectionFilterName = "filter",
+      connectionFilterName = "where",
       connectionFilterOperatorsType,
       connectionFilterRegisterResolver,
       connectionFilterResolve,

--- a/src/PgConnectionArgFilterForwardRelationsPlugin.ts
+++ b/src/PgConnectionArgFilterForwardRelationsPlugin.ts
@@ -23,6 +23,7 @@ const PgConnectionArgFilterForwardRelationsPlugin: Plugin = (builder) => {
       pgOmit: omit,
       pgSql: sql,
       pgIntrospectionResultsByKind: introspectionResultsByKind,
+      connectionFilterName = "filter",
       connectionFilterResolve,
       connectionFilterRegisterResolver,
       connectionFilterTypesByTypeName,
@@ -44,7 +45,7 @@ const PgConnectionArgFilterForwardRelationsPlugin: Plugin = (builder) => {
       .filter((con) => con.type === "f")
       .filter((con) => con.classId === table.id)
       .reduce((memo: ForwardRelationSpec[], constraint) => {
-        if (omit(constraint, "read") || omit(constraint, "filter")) {
+        if (omit(constraint, "read") || omit(constraint, connectionFilterName)) {
           return memo;
         }
         const foreignTable = constraint.foreignClassId
@@ -55,7 +56,7 @@ const PgConnectionArgFilterForwardRelationsPlugin: Plugin = (builder) => {
             `Could not find the foreign table (constraint: ${constraint.name})`
           );
         }
-        if (omit(foreignTable, "read") || omit(foreignTable, "filter")) {
+        if (omit(foreignTable, "read") || omit(foreignTable, connectionFilterName)) {
           return memo;
         }
         const attributes = (
@@ -239,7 +240,7 @@ const PgConnectionArgFilterForwardRelationsPlugin: Plugin = (builder) => {
         ForeignTableFilterType,
         resolve,
         spec,
-        `Adding connection filter forward relation field from ${describePgEntity(
+        `Adding connection ${connectionFilterName} forward relation field from ${describePgEntity(
           table
         )} to ${describePgEntity(foreignTable)}`
       );
@@ -254,7 +255,7 @@ const PgConnectionArgFilterForwardRelationsPlugin: Plugin = (builder) => {
           GraphQLBoolean,
           resolveExists,
           spec,
-          `Adding connection filter forward relation exists field from ${describePgEntity(
+          `Adding connection ${connectionFilterName} forward relation exists field from ${describePgEntity(
             table
           )} to ${describePgEntity(foreignTable)}`
         );

--- a/src/PgConnectionArgFilterForwardRelationsPlugin.ts
+++ b/src/PgConnectionArgFilterForwardRelationsPlugin.ts
@@ -23,7 +23,7 @@ const PgConnectionArgFilterForwardRelationsPlugin: Plugin = (builder) => {
       pgOmit: omit,
       pgSql: sql,
       pgIntrospectionResultsByKind: introspectionResultsByKind,
-      connectionFilterName = "filter",
+      connectionFilterName = "where",
       connectionFilterResolve,
       connectionFilterRegisterResolver,
       connectionFilterTypesByTypeName,

--- a/src/PgConnectionArgFilterPlugin.ts
+++ b/src/PgConnectionArgFilterPlugin.ts
@@ -16,7 +16,7 @@ import { BackwardRelationSpec } from "./PgConnectionArgFilterBackwardRelationsPl
 const PgConnectionArgFilterPlugin: Plugin = (
   builder,
   {
-    connectionFilterName = "filter",
+    connectionFilterName = "where",
     connectionFilterAllowedFieldTypes,
     connectionFilterArrays,
     connectionFilterSetofFunctions,

--- a/src/PgConnectionArgFilterPlugin.ts
+++ b/src/PgConnectionArgFilterPlugin.ts
@@ -16,6 +16,7 @@ import { BackwardRelationSpec } from "./PgConnectionArgFilterBackwardRelationsPl
 const PgConnectionArgFilterPlugin: Plugin = (
   builder,
   {
+    connectionFilterName = "filter",
     connectionFilterAllowedFieldTypes,
     connectionFilterArrays,
     connectionFilterSetofFunctions,
@@ -57,7 +58,7 @@ const PgConnectionArgFilterPlugin: Plugin = (
       if (!shouldAddFilter) return args;
 
       if (!source) return args;
-      if (omit(source, "filter")) return args;
+      if (omit(source, connectionFilterName)) return args;
 
       if (source.kind === "procedure") {
         if (!(source.tags.filterable || connectionFilterSetofFunctions)) {
@@ -104,9 +105,9 @@ const PgConnectionArgFilterPlugin: Plugin = (
       addArgDataGenerator(function connectionFilter(args: any) {
         return {
           pgQuery: (queryBuilder: QueryBuilder) => {
-            if (Object.prototype.hasOwnProperty.call(args, "filter")) {
+            if (Object.prototype.hasOwnProperty.call(args, connectionFilterName)) {
               const sqlFragment = connectionFilterResolve(
-                args.filter,
+                args[connectionFilterName],
                 queryBuilder.getTableAlias(),
                 filterTypeName,
                 queryBuilder,
@@ -124,13 +125,13 @@ const PgConnectionArgFilterPlugin: Plugin = (
       return extend(
         args,
         {
-          filter: {
+          [connectionFilterName as string]: {
             description:
               "A filter to be used in determining which values should be returned by the collection.",
             type: FilterType,
           },
         },
-        `Adding connection filter arg to field '${field.name}' of '${Self.name}'`
+        `Adding connection ${connectionFilterName} arg to field '${field.name}' of '${Self.name}'`
       );
     }
   );
@@ -154,7 +155,7 @@ const PgConnectionArgFilterPlugin: Plugin = (
     const handleNullInput = () => {
       if (!connectionFilterAllowNullInput) {
         throw new Error(
-          "Null literals are forbidden in filter argument input."
+          `Null literals are forbidden in ${connectionFilterName} argument input.`
         );
       }
       return null;
@@ -163,7 +164,7 @@ const PgConnectionArgFilterPlugin: Plugin = (
     const handleEmptyObjectInput = () => {
       if (!connectionFilterAllowEmptyObjectInput) {
         throw new Error(
-          "Empty objects are forbidden in filter argument input."
+          `Empty objects are forbidden in ${connectionFilterName} argument input.`
         );
       }
       return null;
@@ -217,7 +218,7 @@ const PgConnectionArgFilterPlugin: Plugin = (
               parentFieldInfo,
             });
           }
-          throw new Error(`Unable to resolve filter field '${key}'`);
+          throw new Error(`Unable to resolve ${connectionFilterName} field '${key}'`);
         })
         .filter((x) => x != null);
 
@@ -371,7 +372,7 @@ const PgConnectionArgFilterPlugin: Plugin = (
         GraphQLInputObjectType,
         {
           name: operatorsTypeName,
-          description: `A filter to be used against ${namedType.name}${
+          description: `A ${connectionFilterName} to be used against ${namedType.name}${
             isListType ? " List" : ""
           } fields. All fields are combined with a logical ‘and.’`,
         },
@@ -410,7 +411,7 @@ const PgConnectionArgFilterPlugin: Plugin = (
       return newWithHooks(
         GraphQLInputObjectType,
         {
-          description: `A filter to be used against \`${nodeTypeName}\` object types. All fields are combined with a logical ‘and.’`,
+          description: `A ${connectionFilterName} to be used against \`${nodeTypeName}\` object types. All fields are combined with a logical ‘and.’`,
           name: filterTypeName,
         },
         {

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,6 +42,7 @@ const PostGraphileConnectionFilterPlugin: Plugin = (builder, configOptions) => {
   const defaultOptions = {
     //connectionFilterAllowedOperators,
     //connectionFilterAllowedFieldTypes,
+    connectionFilterName: "filter",
     connectionFilterArrays: true,
     connectionFilterComputedColumns: true,
     //connectionFilterOperatorNames,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,6 @@
     "importHelpers": true,
     "experimentalDecorators": true,
     "noImplicitAny": true,
-    "suppressImplicitAnyIndexErrors": true,
     "strictNullChecks": true,
     "noFallthroughCasesInSwitch": true,
     "noUnusedParameters": true,


### PR DESCRIPTION
Where i work we wanted the ability to name the filter "where", so while we migrate from Hasura our queries will not change -- this PR adds this feature via connectionFilterName option