### PR TITLE
Don't need source for relations

### DIFF
--- a/src/PgConnectionArgFilterBackwardRelationsPlugin.ts
+++ b/src/PgConnectionArgFilterBackwardRelationsPlugin.ts
@@ -382,7 +382,7 @@ export const PgConnectionArgFilterBackwardRelationsPlugin: GraphileConfig.Plugin
                         })
                       ),
                     },
-                    `Adding connection filter backward relation field from ${source.name} to ${foreignTable.name}`
+                    `Adding connection filter backward relation ${relationName} field from ${source.name} to ${foreignTable.name}`
                   );
 
                   const existsFieldName =
@@ -448,7 +448,7 @@ export const PgConnectionArgFilterBackwardRelationsPlugin: GraphileConfig.Plugin
                         })
                       ),
                     },
-                    `Adding connection filter backward relation exists field from ${source.name} to ${foreignTable.name}`
+                    `Adding connection filter backward relation ${relationName} exists field from ${source.name} to ${foreignTable.name}`
                   );
                 }
               } else {
@@ -514,7 +514,7 @@ export const PgConnectionArgFilterBackwardRelationsPlugin: GraphileConfig.Plugin
                       })
                     ),
                   },
-                  `Adding connection filter backward relation field from ${source.name} to ${foreignTable.name}`
+                  `Adding connection filter backward relation ${relationName} field from ${source.name} to ${foreignTable.name}`
                 );
 
                 const existsFieldName =
@@ -576,7 +576,7 @@ export const PgConnectionArgFilterBackwardRelationsPlugin: GraphileConfig.Plugin
                         })
                       ),
                     },
-                    `Adding connection filter backward relation exists field from ${source.name} to ${foreignTable.name}`
+                    `Adding connection filter backward relation ${relationName} exists field from ${source.name} to ${foreignTable.name}`
                   )
                 );
               }

--- a/src/PgConnectionArgFilterBackwardRelationsPlugin.ts
+++ b/src/PgConnectionArgFilterBackwardRelationsPlugin.ts
@@ -99,6 +99,7 @@ export const PgConnectionArgFilterBackwardRelationsPlugin: GraphileConfig.Plugin
             sql,
             graphql: { GraphQLBoolean },
             EXPORTABLE,
+            input: { pgRegistry: registry },
           } = build;
           const {
             fieldWithHooks,
@@ -116,21 +117,17 @@ export const PgConnectionArgFilterBackwardRelationsPlugin: GraphileConfig.Plugin
 
           const assertAllowed = makeAssertAllowed(build);
 
-          const source =
+          if (
+            isPgConnectionFilter &&
             pgCodec &&
-            (Object.values(build.input.pgRegistry.pgResources).find(
-              (s) => s.codec === pgCodec && !s.parameters
-            ) as
-              | PgResource<any, PgCodecWithAttributes, any, any, PgRegistry>
-              | undefined);
-          if (isPgConnectionFilter && pgCodec && pgCodec.attributes && source) {
-            const backwardsRelations = Object.entries(
-              source.getRelations() as {
-                [relationName: string]: PgCodecRelation;
-              }
-            ).filter(([relationName, relation]) => {
-              return relation.isReferencee;
-            });
+            pgCodec.attributes &&
+            registry.pgRelations[pgCodec.name]
+          ) {
+            const codec = pgCodec as PgCodecWithAttributes;
+            const relations = registry.pgRelations[codec.name];
+            const backwardsRelations = Object.entries(relations).filter(
+              ([_relationName, relation]) => relation.isReferencee
+            );
 
             for (const [relationName, relation] of backwardsRelations) {
               const foreignTable = relation.remoteResource; // Deliberate shadowing
@@ -317,7 +314,7 @@ export const PgConnectionArgFilterBackwardRelationsPlugin: GraphileConfig.Plugin
                   build.behavior.pgCodecRelationMatches(relation, "connection")
                 ) {
                   const filterManyTypeName = inflection.filterManyType(
-                    source.codec,
+                    codec,
                     foreignTable
                   );
                   const FilterManyType = build.getTypeByName(
@@ -330,8 +327,8 @@ export const PgConnectionArgFilterBackwardRelationsPlugin: GraphileConfig.Plugin
                   }
                   // TODO: revisit using `_` prefixed inflector
                   const fieldName = inflection._manyRelation({
-                    registry: source.registry,
-                    codec: source.codec,
+                    registry,
+                    codec,
                     relationName,
                   });
                   const filterFieldName =
@@ -382,7 +379,7 @@ export const PgConnectionArgFilterBackwardRelationsPlugin: GraphileConfig.Plugin
                         })
                       ),
                     },
-                    `Adding connection filter backward relation ${relationName} field from ${source.name} to ${foreignTable.name}`
+                    `Adding connection filter backward relation ${relationName} field from ${codec.name} to ${foreignTable.name}`
                   );
 
                   const existsFieldName =
@@ -448,13 +445,13 @@ export const PgConnectionArgFilterBackwardRelationsPlugin: GraphileConfig.Plugin
                         })
                       ),
                     },
-                    `Adding connection filter backward relation ${relationName} exists field from ${source.name} to ${foreignTable.name}`
+                    `Adding connection filter backward relation ${relationName} exists field from ${codec.name} to ${foreignTable.name}`
                   );
                 }
               } else {
                 const fieldName = inflection.singleRelationBackwards({
-                  registry: source.registry,
-                  codec: source.codec,
+                  registry,
+                  codec,
                   relationName,
                 });
                 const filterFieldName =
@@ -514,7 +511,7 @@ export const PgConnectionArgFilterBackwardRelationsPlugin: GraphileConfig.Plugin
                       })
                     ),
                   },
-                  `Adding connection filter backward relation ${relationName} field from ${source.name} to ${foreignTable.name}`
+                  `Adding connection filter backward relation ${relationName} field from ${codec.name} to ${foreignTable.name}`
                 );
 
                 const existsFieldName =
@@ -576,7 +573,7 @@ export const PgConnectionArgFilterBackwardRelationsPlugin: GraphileConfig.Plugin
                         })
                       ),
                     },
-                    `Adding connection filter backward relation ${relationName} exists field from ${source.name} to ${foreignTable.name}`
+                    `Adding connection filter backward relation ${relationName} exists field from ${codec.name} to ${foreignTable.name}`
                   )
                 );
               }

--- a/src/PgConnectionArgFilterForwardRelationsPlugin.ts
+++ b/src/PgConnectionArgFilterForwardRelationsPlugin.ts
@@ -116,6 +116,7 @@ export const PgConnectionArgFilterForwardRelationsPlugin: GraphileConfig.Plugin 
             sql,
             options: { pgIgnoreReferentialIntegrity },
             EXPORTABLE,
+            input: { pgRegistry: registry },
           } = build;
           const {
             fieldWithHooks,
@@ -123,31 +124,23 @@ export const PgConnectionArgFilterForwardRelationsPlugin: GraphileConfig.Plugin 
           } = context;
           const assertAllowed = makeAssertAllowed(build);
 
-          const source =
-            pgCodec &&
-            (Object.values(build.input.pgRegistry.pgResources).find(
-              (s) => s.codec === pgCodec && !s.parameters
-            ) as PgResource<any, PgCodecWithAttributes, any, any, any>);
-
-          if (
-            !isPgConnectionFilter ||
-            !pgCodec ||
-            !pgCodec.attributes ||
-            !source
-          ) {
+          if (!isPgConnectionFilter || !pgCodec || !pgCodec.attributes) {
             return fields;
           }
+          const codec = pgCodec as PgCodecWithAttributes;
 
-          const forwardRelations = Object.entries(
-            source.getRelations() as {
-              [relationName: string]: PgCodecRelation;
+          const relations = registry.pgRelations[codec.name];
+          if (!relations) {
+            return fields;
+          }
+          const forwardRelations = Object.entries(relations).filter(
+            ([_relationName, relation]) => {
+              return !relation.isReferencee;
             }
-          ).filter(([_relationName, relation]) => {
-            return !relation.isReferencee;
-          });
+          );
 
           for (const [relationName, relation] of forwardRelations) {
-            const foreignTable = relation.remoteResource; // Deliberate shadowing
+            const foreignTable = relation.remoteResource;
 
             // Used to use 'read' behavior too
             if (!build.behavior.pgCodecRelationMatches(relation, "filterBy")) {
@@ -155,8 +148,8 @@ export const PgConnectionArgFilterForwardRelationsPlugin: GraphileConfig.Plugin 
             }
 
             const fieldName = inflection.singleRelation({
-              registry: source.registry,
-              codec: source.codec,
+              registry,
+              codec,
               relationName,
             });
             const filterFieldName =
@@ -228,8 +221,7 @@ export const PgConnectionArgFilterForwardRelationsPlugin: GraphileConfig.Plugin 
             );
 
             const keyIsNullable = relation.localAttributes.some(
-              (col) =>
-                !(source.codec.attributes[col] as PgCodecAttribute).notNull
+              (col) => !(codec.attributes[col] as PgCodecAttribute).notNull
             );
             if (keyIsNullable || pgIgnoreReferentialIntegrity) {
               const existsFieldName =

--- a/src/PgConnectionArgFilterForwardRelationsPlugin.ts
+++ b/src/PgConnectionArgFilterForwardRelationsPlugin.ts
@@ -134,9 +134,7 @@ export const PgConnectionArgFilterForwardRelationsPlugin: GraphileConfig.Plugin 
             return fields;
           }
           const forwardRelations = Object.entries(relations).filter(
-            ([_relationName, relation]) => {
-              return !relation.isReferencee;
-            }
+            ([_relationName, relation]) => !relation.isReferencee
           );
 
           for (const [relationName, relation] of forwardRelations) {

--- a/src/PgConnectionArgFilterForwardRelationsPlugin.ts
+++ b/src/PgConnectionArgFilterForwardRelationsPlugin.ts
@@ -224,7 +224,7 @@ export const PgConnectionArgFilterForwardRelationsPlugin: GraphileConfig.Plugin 
                   })
                 ),
               },
-              `Adding connection filter forward relation field from ${source.name} to ${foreignTable.name}`
+              `Adding connection filter forward relation ${relationName} field from ${codec.name} to ${foreignTable.name}`
             );
 
             const keyIsNullable = relation.localAttributes.some(
@@ -283,7 +283,7 @@ export const PgConnectionArgFilterForwardRelationsPlugin: GraphileConfig.Plugin 
                     })
                   ),
                 },
-                `Adding connection filter forward relation exists field from ${source.name} to ${foreignTable.name}`
+                `Adding connection filter forward relation ${relationName} exists field from ${codec.name} to ${foreignTable.name}`
               );
             }
           }


### PR DESCRIPTION
A composite type can have `@foreignKey` relations. We can't go reverse to it, but we can go from it elsewhere.